### PR TITLE
feat: maven args support [LINK-692]

### DIFF
--- a/pkg/depgraph/callback.go
+++ b/pkg/depgraph/callback.go
@@ -115,5 +115,20 @@ func prepareLegacyFlags(cfg configuration.Configuration, logger *log.Logger) { /
 		logger.Println("Prune repeated sub-dependencies: true")
 	}
 
+	if cfg.GetBool("maven-aggregate-project") {
+		cmdArgs = append(cmdArgs, "--maven-aggregate-project")
+		logger.Println("Ensure all modules are resolvable by the Maven reactor: true")
+	}
+
+	if cfg.GetBool("scan-unmanaged") {
+		cmdArgs = append(cmdArgs, "--scan-unmanaged")
+		logger.Println("Specify an individual JAR, WAR, or AAR file: true")
+	}
+
+	if cfg.GetBool("scan-all-unmanaged") {
+		cmdArgs = append(cmdArgs, "--scan-all-unmanaged")
+		logger.Println("Auto-detect Maven, JAR, WAR, and AAR files recursively from the current folder: true")
+	}
+
 	cfg.Set(configuration.RAW_CMD_ARGS, cmdArgs)
 }

--- a/pkg/depgraph/callback_test.go
+++ b/pkg/depgraph/callback_test.go
@@ -263,6 +263,69 @@ func Test_callback(t *testing.T) {
 		assert.Contains(t, commandArgs, "--unmanaged")
 	})
 
+	t.Run("should support 'prune-repeated-subdependencies' flag", func(t *testing.T) {
+		// setup
+		config.Set("prune-repeated-subdependencies", true)
+
+		dataIdentifier := workflow.NewTypeIdentifier(WorkflowID, "depgraph")
+		data := workflow.NewData(dataIdentifier, "application/json", []byte(payload))
+
+		// engine mocks
+		id := workflow.NewWorkflowIdentifier("legacycli")
+		engineMock.EXPECT().InvokeWithConfig(id, config).Return([]workflow.Data{data}, nil).Times(1)
+
+		// execute
+		_, err := callback(invocationContextMock, []workflow.Data{})
+
+		// assert
+		assert.Nil(t, err)
+
+		commandArgs := config.Get(configuration.RAW_CMD_ARGS)
+		assert.Contains(t, commandArgs, "--prune-repeated-subdependencies")
+	})
+
+	t.Run("should support 'scan-unmanaged' flag", func(t *testing.T) {
+		// setup
+		config.Set("scan-unmanaged", true)
+
+		dataIdentifier := workflow.NewTypeIdentifier(WorkflowID, "depgraph")
+		data := workflow.NewData(dataIdentifier, "application/json", []byte(payload))
+
+		// engine mocks
+		id := workflow.NewWorkflowIdentifier("legacycli")
+		engineMock.EXPECT().InvokeWithConfig(id, config).Return([]workflow.Data{data}, nil).Times(1)
+
+		// execute
+		_, err := callback(invocationContextMock, []workflow.Data{})
+
+		// assert
+		assert.Nil(t, err)
+
+		commandArgs := config.Get(configuration.RAW_CMD_ARGS)
+		assert.Contains(t, commandArgs, "--scan-unmanaged")
+	})
+
+	t.Run("should support 'scan-all-unmanaged' flag", func(t *testing.T) {
+		// setup
+		config.Set("scan-all-unmanaged", true)
+
+		dataIdentifier := workflow.NewTypeIdentifier(WorkflowID, "depgraph")
+		data := workflow.NewData(dataIdentifier, "application/json", []byte(payload))
+
+		// engine mocks
+		id := workflow.NewWorkflowIdentifier("legacycli")
+		engineMock.EXPECT().InvokeWithConfig(id, config).Return([]workflow.Data{data}, nil).Times(1)
+
+		// execute
+		_, err := callback(invocationContextMock, []workflow.Data{})
+
+		// assert
+		assert.Nil(t, err)
+
+		commandArgs := config.Get(configuration.RAW_CMD_ARGS)
+		assert.Contains(t, commandArgs, "--scan-all-unmanaged")
+	})
+
 	t.Run("should error if no dependency graphs found", func(t *testing.T) {
 		dataIdentifier := workflow.NewTypeIdentifier(WorkflowID, "depgraph")
 		data := workflow.NewData(dataIdentifier, "application/json", []byte{})


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Propagate [the maven specific args](https://docs.snyk.io/snyk-cli/commands/test#options-for-maven-projects) to this cli extension. This will make the maven specific args available on the `snyk sbom` command as well.
