### PR TITLE
feat: add flags for yarn, python

### DIFF
--- a/pkg/depgraph/callback.go
+++ b/pkg/depgraph/callback.go
@@ -160,5 +160,25 @@ func prepareLegacyFlags(cfg configuration.Configuration, logger *log.Logger) { /
 		logger.Println("Init script:", initScript)
 	}
 
+	if cfg.GetBool(FlagYarnWorkspaces) {
+		cmdArgs = append(cmdArgs, "--yarn-workspaces")
+		logger.Println("Yarn Workspaces: true")
+	}
+
+	if pyCmd := cfg.GetString(FlagPythonCommand); pyCmd != "" {
+		cmdArgs = append(cmdArgs, "--command="+pyCmd)
+		logger.Println("Python command:", pyCmd)
+	}
+
+	if cfg.GetBool(FlagPythonSkipUnresolved) {
+		cmdArgs = append(cmdArgs, "--skip-unresolved")
+		logger.Println("Python skip unresolved: true")
+	}
+
+	if pyPkgManager := cfg.GetString(FlagPythonPackageManager); pyPkgManager != "" {
+		cmdArgs = append(cmdArgs, "--package-manager="+pyPkgManager)
+		logger.Println("Python package manager:", pyPkgManager)
+	}
+
 	cfg.Set(configuration.RAW_CMD_ARGS, cmdArgs)
 }

--- a/pkg/depgraph/callback_test.go
+++ b/pkg/depgraph/callback_test.go
@@ -131,6 +131,26 @@ func Test_callback(t *testing.T) {
 			value:    "/somewhere/init.gradle",
 			expected: "--init-script=/somewhere/init.gradle",
 		},
+		{
+			key:      FlagYarnWorkspaces,
+			value:    true,
+			expected: "--yarn-workspaces",
+		},
+		{
+			key:      FlagPythonCommand,
+			value:    "python3",
+			expected: "--command=python3",
+		},
+		{
+			key:      FlagPythonSkipUnresolved,
+			value:    true,
+			expected: "--skip-unresolved",
+		},
+		{
+			key:      FlagPythonPackageManager,
+			value:    "pip",
+			expected: "--package-manager=pip",
+		},
 	}
 
 	for _, tc := range options {

--- a/pkg/depgraph/flags.go
+++ b/pkg/depgraph/flags.go
@@ -18,6 +18,10 @@ const (
 	FlagConfigurationMatching        = "configuration-matching"
 	FlagConfigurationAttributes      = "configuration-attributes"
 	FlagInitScript                   = "init-script"
+	FlagYarnWorkspaces               = "yarn-workspaces"
+	FlagPythonCommand                = "command"
+	FlagPythonSkipUnresolved         = "skip-unresolved"
+	FlagPythonPackageManager         = "package-manager"
 )
 
 func getFlagSet() *pflag.FlagSet {
@@ -38,6 +42,10 @@ func getFlagSet() *pflag.FlagSet {
 	flagSet.String(FlagConfigurationMatching, "", "Resolve dependencies using only configuration(s) that match the specified Java regular expression.")
 	flagSet.String(FlagConfigurationAttributes, "", "Select certain values of configuration attributes to install and resolve dependencies.")
 	flagSet.String(FlagInitScript, "", "Use for projects that contain a Gradle initialization script.")
+	flagSet.Bool(FlagYarnWorkspaces, false, "Detect and scan Yarn Workspaces only when a lockfile is in the root.")
+	flagSet.String(FlagPythonCommand, "", "Indicate which specific Python commands to use based on the Python version.")
+	flagSet.Bool(FlagPythonSkipUnresolved, false, "Skip Python packages that cannot be found in the environment.")
+	flagSet.String(FlagPythonPackageManager, "", `Add --package-manager=pip to your command if the file name is not "requirements.txt".`)
 
 	return flagSet
 }


### PR DESCRIPTION
This adds additional config flags for ecosystems yarn and python:

* `--yarn-workspaces`
* `--command`
* `--skip-unresolved`
* `--package-manager`
 
See `snyk test --help` for details.
