### PR TITLE
feat: unmanaged scanning --max-depth arg

### DIFF
--- a/pkg/depgraph/callback.go
+++ b/pkg/depgraph/callback.go
@@ -3,6 +3,7 @@ package depgraph
 import (
 	"bytes"
 	"log"
+	"strconv"
 	"strings"
 
 	"github.com/snyk/go-application-framework/pkg/configuration"
@@ -193,6 +194,10 @@ func prepareLegacyFlags(cfg configuration.Configuration, logger *log.Logger) { /
 	if pyPkgManager := cfg.GetString(FlagPythonPackageManager); pyPkgManager != "" {
 		cmdArgs = append(cmdArgs, "--package-manager="+pyPkgManager)
 		logger.Println("Python package manager:", pyPkgManager)
+	}
+
+	if maxDepth := cfg.GetInt(FlagUnmanagedMaxDepth); maxDepth != 0 {
+		cmdArgs = append(cmdArgs, "--max-depth="+strconv.Itoa(maxDepth))
 	}
 
 	cfg.Set(configuration.RAW_CMD_ARGS, cmdArgs)

--- a/pkg/depgraph/callback_test.go
+++ b/pkg/depgraph/callback_test.go
@@ -166,6 +166,11 @@ func Test_callback(t *testing.T) {
 			value:    "../packages",
 			expected: "--packages-folder=../packages",
 		},
+		{
+			key:      FlagUnmanagedMaxDepth,
+			value:    "42",
+			expected: "--max-depth=42",
+		},
 	}
 
 	for _, tc := range options {

--- a/pkg/depgraph/flags.go
+++ b/pkg/depgraph/flags.go
@@ -25,6 +25,7 @@ const (
 	FlagNPMStrictOutOfSync           = "strict-out-of-sync"
 	FlagNugetAssetsProjectName       = "assets-project-name"
 	FlagNugetPkgsFolder              = "packages-folder"
+	FlagUnmanagedMaxDepth            = "max-depth"
 )
 
 func getFlagSet() *pflag.FlagSet {
@@ -52,6 +53,7 @@ func getFlagSet() *pflag.FlagSet {
 	flagSet.Bool(FlagNPMStrictOutOfSync, true, "Prevent testing out-of-sync NPM lockfiles.")
 	flagSet.String(FlagNugetAssetsProjectName, "", "When you are monitoring a .NET project using NuGet PackageReference uses the project name in project.assets.json if found.")
 	flagSet.String(FlagNugetPkgsFolder, "", "Specify a custom path to the packages folder when using NuGet.")
+	flagSet.Int(FlagUnmanagedMaxDepth, 0, "Specify the maximum level of archive extraction for unmanaged scanning.")
 
 	return flagSet
 }


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Add support for the `--max-depth` argument used for unmanaged scanning.

See `snyk test --help` for details.
