### PR TITLE
feat: link-732 add support for npm and nuget

### DIFF
--- a/pkg/depgraph/callback.go
+++ b/pkg/depgraph/callback.go
@@ -160,6 +160,21 @@ func prepareLegacyFlags(cfg configuration.Configuration, logger *log.Logger) { /
 		logger.Println("Init script:", initScript)
 	}
 
+	if cfg.GetBool(FlagNPMStrictOutOfSync) {
+		cmdArgs = append(cmdArgs, "--strict-out-of-sync")
+		logger.Println("NPM strict-out-of-sync: true")
+	}
+
+	if cfg.GetBool(FlagNugetAssetsProjectName) {
+		cmdArgs = append(cmdArgs, "--assets-project-name")
+		logger.Println("NuGet assets-project-name: true")
+	}
+
+	if file := cfg.GetString(FlagNugetPkgsFolder); file != "" {
+		cmdArgs = append(cmdArgs, "--packages-folder="+file)
+		logger.Println("NuGet packages-folder: ", file)
+	}
+
 	if cfg.GetBool(FlagYarnWorkspaces) {
 		cmdArgs = append(cmdArgs, "--yarn-workspaces")
 		logger.Println("Yarn Workspaces: true")

--- a/pkg/depgraph/callback_test.go
+++ b/pkg/depgraph/callback_test.go
@@ -151,6 +151,21 @@ func Test_callback(t *testing.T) {
 			value:    "pip",
 			expected: "--package-manager=pip",
 		},
+		{
+			key:      FlagNPMStrictOutOfSync,
+			value:    true,
+			expected: "--strict-out-of-sync",
+		},
+		{
+			key:      FlagNugetAssetsProjectName,
+			value:    true,
+			expected: "--assets-project-name",
+		},
+		{
+			key:      FlagNugetPkgsFolder,
+			value:    "../packages",
+			expected: "--packages-folder=../packages",
+		},
 	}
 
 	for _, tc := range options {

--- a/pkg/depgraph/flags.go
+++ b/pkg/depgraph/flags.go
@@ -22,6 +22,9 @@ const (
 	FlagPythonCommand                = "command"
 	FlagPythonSkipUnresolved         = "skip-unresolved"
 	FlagPythonPackageManager         = "package-manager"
+	FlagNPMStrictOutOfSync           = "strict-out-of-sync"
+	FlagNugetAssetsProjectName       = "assets-project-name"
+	FlagNugetPkgsFolder              = "packages-folder"
 )
 
 func getFlagSet() *pflag.FlagSet {
@@ -46,6 +49,9 @@ func getFlagSet() *pflag.FlagSet {
 	flagSet.String(FlagPythonCommand, "", "Indicate which specific Python commands to use based on the Python version.")
 	flagSet.Bool(FlagPythonSkipUnresolved, false, "Skip Python packages that cannot be found in the environment.")
 	flagSet.String(FlagPythonPackageManager, "", `Add --package-manager=pip to your command if the file name is not "requirements.txt".`)
+	flagSet.Bool(FlagNPMStrictOutOfSync, true, "Prevent testing out-of-sync NPM lockfiles.")
+	flagSet.String(FlagNugetAssetsProjectName, "", "When you are monitoring a .NET project using NuGet PackageReference uses the project name in project.assets.json if found.")
+	flagSet.String(FlagNugetPkgsFolder, "", "Specify a custom path to the packages folder when using NuGet.")
 
 	return flagSet
 }


### PR DESCRIPTION
### What this does

Propagate [npm and nuget specific args][(https://docs.snyk.io/snyk-cli/commands/test#options-for-nuget-projects](https://docs.snyk.io/snyk-cli/commands/test#options-for-nuget-projects)) to this cli extension. 
This will make the npm+nuget specific args available on the snyk sbom command as well.
