### PR TITLE
fix: nuget assets-project-name

### DIFF
--- a/pkg/depgraph/flags.go
+++ b/pkg/depgraph/flags.go
@@ -51,7 +51,7 @@ func getFlagSet() *pflag.FlagSet {
 	flagSet.Bool(FlagPythonSkipUnresolved, false, "Skip Python packages that cannot be found in the environment.")
 	flagSet.String(FlagPythonPackageManager, "", `Add --package-manager=pip to your command if the file name is not "requirements.txt".`)
 	flagSet.Bool(FlagNPMStrictOutOfSync, true, "Prevent testing out-of-sync NPM lockfiles.")
-	flagSet.String(FlagNugetAssetsProjectName, "", "When you are monitoring a .NET project using NuGet PackageReference uses the project name in project.assets.json if found.")
+	flagSet.Bool(FlagNugetAssetsProjectName, false, "When you are monitoring a .NET project using NuGet PackageReference uses the project name in project.assets.json if found.")
 	flagSet.String(FlagNugetPkgsFolder, "", "Specify a custom path to the packages folder when using NuGet.")
 	flagSet.Int(FlagUnmanagedMaxDepth, 0, "Specify the maximum level of archive extraction for unmanaged scanning.")
 


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

A tiny type fix for the `assets-project-name` argument for NuGet.