### PR TITLE
fix: npm strict-out-of-sync arg

### DIFF
--- a/pkg/depgraph/callback.go
+++ b/pkg/depgraph/callback.go
@@ -161,9 +161,9 @@ func prepareLegacyFlags(cfg configuration.Configuration, logger *log.Logger) { /
 		logger.Println("Init script:", initScript)
 	}
 
-	if cfg.GetBool(FlagNPMStrictOutOfSync) {
-		cmdArgs = append(cmdArgs, "--strict-out-of-sync")
-		logger.Println("NPM strict-out-of-sync: true")
+	if cfg.GetString(FlagNPMStrictOutOfSync) == "false" {
+		cmdArgs = append(cmdArgs, "--strict-out-of-sync=false")
+		logger.Println("NPM strict-out-of-sync: false")
 	}
 
 	if cfg.GetBool(FlagNugetAssetsProjectName) {

--- a/pkg/depgraph/callback_test.go
+++ b/pkg/depgraph/callback_test.go
@@ -153,8 +153,8 @@ func Test_callback(t *testing.T) {
 		},
 		{
 			key:      FlagNPMStrictOutOfSync,
-			value:    true,
-			expected: "--strict-out-of-sync",
+			value:    "false",
+			expected: "--strict-out-of-sync=false",
 		},
 		{
 			key:      FlagNugetAssetsProjectName,

--- a/pkg/depgraph/flags.go
+++ b/pkg/depgraph/flags.go
@@ -50,7 +50,7 @@ func getFlagSet() *pflag.FlagSet {
 	flagSet.String(FlagPythonCommand, "", "Indicate which specific Python commands to use based on the Python version.")
 	flagSet.Bool(FlagPythonSkipUnresolved, false, "Skip Python packages that cannot be found in the environment.")
 	flagSet.String(FlagPythonPackageManager, "", `Add --package-manager=pip to your command if the file name is not "requirements.txt".`)
-	flagSet.Bool(FlagNPMStrictOutOfSync, true, "Prevent testing out-of-sync NPM lockfiles.")
+	flagSet.String(FlagNPMStrictOutOfSync, "true", "Prevent testing out-of-sync NPM lockfiles.")
 	flagSet.Bool(FlagNugetAssetsProjectName, false, "When you are monitoring a .NET project using NuGet PackageReference uses the project name in project.assets.json if found.")
 	flagSet.String(FlagNugetPkgsFolder, "", "Specify a custom path to the packages folder when using NuGet.")
 	flagSet.Int(FlagUnmanagedMaxDepth, 0, "Specify the maximum level of archive extraction for unmanaged scanning.")


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Fix the false scenario of the `strict-out-of-sync` argument on the NPM ecosystems.

