### PR TITLE
fix: wrap ExitError of legacy CLI

### DIFF
--- a/pkg/depgraph/errors_test.go
+++ b/pkg/depgraph/errors_test.go
@@ -36,3 +36,12 @@ func Test_extractLegacyCLIError_InputSameAsOutput(t *testing.T) {
 	assert.NotNil(t, outputError)
 	assert.Equal(t, inputError.Error(), outputError.Error())
 }
+
+func Test_extractLegacyCLIError_RetainExitError(t *testing.T) {
+	inputError := &exec.ExitError{}
+	data := workflow.NewData(workflow.NewTypeIdentifier(WorkflowID, "something"), "application/json", []byte{})
+
+	outputError := extractLegacyCLIError(inputError, []workflow.Data{data})
+
+	assert.ErrorIs(t, outputError, inputError)
+}


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

This retains the original ExitError from the legacy CLI invocation.
