### PR TITLE
chore: transfer ownership to unify

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -5,4 +5,4 @@ metadata:
 spec:
   type: snyk-cli-plugin
   lifecycle: "-"
-  owner: link
+  owner: unify


### PR DESCRIPTION
### What this does

Update catalog-info.yaml to point to Team Link as owners.
