### PR TITLE
fix: wrap original exit error from legacy workflow

### DIFF
--- a/pkg/depgraph/errors.go
+++ b/pkg/depgraph/errors.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 
 	clierrors "github.com/snyk/error-catalog-golang-public/cli"
+	"github.com/snyk/error-catalog-golang-public/snyk_errors"
 	"github.com/snyk/go-application-framework/pkg/workflow"
 )
 
@@ -50,5 +51,5 @@ func extractLegacyCLIError(input error, data []workflow.Data) error {
 		}
 	}
 
-	return clierrors.NewGeneralSCAFailureError(output.Error())
+	return clierrors.NewGeneralSCAFailureError(output.Error(), snyk_errors.WithCause(output))
 }

--- a/pkg/depgraph/errors_test.go
+++ b/pkg/depgraph/errors_test.go
@@ -37,3 +37,12 @@ func Test_extractLegacyCLIError_InputSameAsOutput(t *testing.T) {
 	assert.ErrorAs(t, outputError, &snykErr)
 	assert.Equal(t, inputError.Error(), snykErr.Detail)
 }
+
+func Test_extractLegacyCLIError_RetainExitError(t *testing.T) {
+	inputError := &exec.ExitError{}
+	data := workflow.NewData(workflow.NewTypeIdentifier(WorkflowID, "something"), "application/json", []byte{})
+
+	outputError := extractLegacyCLIError(inputError, []workflow.Data{data})
+
+	assert.ErrorIs(t, outputError, inputError)
+}


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

In [7307561](https://github.com/snyk/cli-extension-dep-graph/commit/73075611087eb2abfd45a6c531de2ee7f82f6ea4) I introduced a regression that would not forward the original ExitError, thus failing to pass on the underlying exit code of the legacy workflow. I also re-introduced the test for this.
