### PR TITLE
fix: don't add target directory with file flag

### DIFF
--- a/pkg/depgraph/callback.go
+++ b/pkg/depgraph/callback.go
@@ -86,14 +86,14 @@ func prepareLegacyFlags(cfg configuration.Configuration, logger *log.Logger) { /
 		logger.Println("Detection depth:", detectionDepth)
 	}
 
-	if targetDir := cfg.GetString(configuration.INPUT_DIRECTORY); targetDir != "" {
-		cmdArgs = append(cmdArgs, targetDir)
-		logger.Println("Target directory:", targetDir)
-	}
-
 	if file := cfg.GetString(FlagFile); file != "" {
 		cmdArgs = append(cmdArgs, "--file="+file)
 		logger.Println("File:", file)
+	} else {
+		if targetDir := cfg.GetString(configuration.INPUT_DIRECTORY); targetDir != "" {
+			cmdArgs = append(cmdArgs, targetDir)
+			logger.Println("Target directory:", targetDir)
+		}
 	}
 
 	if cfg.GetBool("unmanaged") {

--- a/pkg/depgraph/callback_test.go
+++ b/pkg/depgraph/callback_test.go
@@ -186,6 +186,16 @@ func Test_callback(t *testing.T) {
 		})
 	}
 
+	t.Run("should not include target directory if file flag provided", func(t *testing.T) {
+		config.Set(FlagFile, "path/to/target/file.js")
+		config.Set("targetDirectory", "path/to/target")
+
+		testCmdArgs := invokeWithConfigAndGetTestCmdArgs(t, engineMock, config, invocationContextMock)
+
+		assert.Contains(t, testCmdArgs, "--file=path/to/target/file.js")
+		assert.NotContains(t, testCmdArgs, "path/to/target")
+	})
+
 	t.Run("should return a depGraphList", func(t *testing.T) {
 		// setup
 		dataIdentifier := workflow.NewTypeIdentifier(WorkflowID, "depgraph")


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [ ] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

This change resolves an issue where the target directory was being passed to the `test --print-graph --json` command when the `--file` flag was being used.