### PR TITLE
feat: return error when there is no root project without `--all-projects`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/golang/mock v1.6.0
 	github.com/rs/zerolog v1.34.0
 	github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62
-	github.com/snyk/error-catalog-golang-public v0.0.0-20260205094614-116c03822905
+	github.com/snyk/error-catalog-golang-public v0.0.0-20260316131845-f02d7f42046b
 	github.com/snyk/go-application-framework v0.0.0-20251201143055-028dabb99a6d
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -168,8 +168,8 @@ github.com/snyk/code-client-go v1.24.3 h1:2TVOADxyNpdFQ79y25ci/RPw3KW28OmLFf9Xv5
 github.com/snyk/code-client-go v1.24.3/go.mod h1:uMlmMToe4uuNhNLs+yxjM3WFbytna+ytDWhpbnNwTSk=
 github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62 h1:kgZNQ5ztI4+n3YKLR5LJbqL8WJmUYgDSbFKREIY79g0=
 github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62/go.mod h1:hTr91da/4ze2nk9q6ZW1BmfM2Z8rLUZSEZ3kK+6WGpc=
-github.com/snyk/error-catalog-golang-public v0.0.0-20260205094614-116c03822905 h1:pUe6iOWHEOFY0t4u4ssXeTqpMmZBu1xq06VBFI9zUik=
-github.com/snyk/error-catalog-golang-public v0.0.0-20260205094614-116c03822905/go.mod h1:Ytttq7Pw4vOCu9NtRQaOeDU2dhBYUyNBe6kX4+nIIQ4=
+github.com/snyk/error-catalog-golang-public v0.0.0-20260316131845-f02d7f42046b h1:DM2SPu7rhsD/TNS7zhv4ZoqLLi2cFOqg1VTBCP6RfSg=
+github.com/snyk/error-catalog-golang-public v0.0.0-20260316131845-f02d7f42046b/go.mod h1:Ytttq7Pw4vOCu9NtRQaOeDU2dhBYUyNBe6kX4+nIIQ4=
 github.com/snyk/go-application-framework v0.0.0-20251201143055-028dabb99a6d h1:hU+haVM8HI7S+7j8di8ChPTUHo+QTfrXflO2Nm8ShmE=
 github.com/snyk/go-application-framework v0.0.0-20251201143055-028dabb99a6d/go.mod h1:HXON5jD2A4GarLrQyUSLBGR7jJy7LfzzHmjdkLe3VCk=
 github.com/snyk/go-httpauth v0.0.0-20231117135515-eb445fea7530 h1:s9PHNkL6ueYRiAKNfd8OVxlUOqU3qY0VDbgCD1f6WQY=

--- a/internal/uv/mock_client.go
+++ b/internal/uv/mock_client.go
@@ -23,7 +23,64 @@ func (m *MockClient) ExportSBOM(inputDir string, _ *scaplugin.Options) (Sbom, er
 		return nil, m.ReturnErr
 	}
 
-	sbom := `{"bomFormat":"CycloneDX","specVersion":"1.5","metadata":{"component":{"name":"mock-project","version":"1.0.0"}}}`
+	sbom := `{
+		"bomFormat": "CycloneDX",
+		"specVersion": "1.5",
+		"version": 1,
+		"serialNumber": "urn:uuid:d9b838b1-8d37-4399-9604-44086160b08b",
+		"metadata": {
+			"timestamp": "2026-03-16T16:19:32.146360000Z",
+			"tools": [
+				{
+					"vendor": "Astral Software Inc.",
+					"name": "uv",
+					"version": "0.10.9"
+				}
+			],
+			"component": {
+				"type": "library",
+				"bom-ref": "mock-project-1@1.0.0",
+				"name": "mock-project",
+				"version": "1.0.0",
+				"properties": [
+					{
+						"name": "uv:package:is_project_root",
+						"value": "true"
+					}
+				]
+			}
+		},
+		"components": [
+			{
+				"type": "library",
+				"bom-ref": "django-2@3.1",
+				"name": "django",
+				"version": "3.1",
+				"purl": "pkg:pypi/django@3.1"
+			},
+			{
+				"type": "library",
+				"bom-ref": "idna-3@3.6",
+				"name": "idna",
+				"version": "3.6",
+				"purl": "pkg:pypi/idna@3.6"
+			}
+		],
+		"dependencies": [
+			{
+				"ref": "mock-project-1@1.0.0",
+				"dependsOn": ["django-2@3.1", "idna-3@3.6"]
+			},
+			{
+				"ref": "django-2@3.1",
+				"dependsOn": []
+			},
+			{
+				"ref": "idna-3@3.6",
+				"dependsOn": []
+			}
+		]
+	}`
 	return Sbom(sbom), nil
 }
 

--- a/internal/uv/uv_plugin.go
+++ b/internal/uv/uv_plugin.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/snyk/dep-graph/go/pkg/depgraph"
 
+	"github.com/snyk/error-catalog-golang-public/opensource/ecosystems"
+
 	"github.com/snyk/cli-extension-dep-graph/internal/conversion"
 	"github.com/snyk/cli-extension-dep-graph/internal/snykclient"
 	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/discovery"
@@ -53,7 +55,7 @@ func (p Plugin) BuildFindingsFromDir(
 	for _, file := range files {
 		lockFilePath := file.RelPath // e.g., "uv.lock" or "project1/uv.lock"
 		lockFileDir := filepath.Dir(lockFilePath)
-		log.Info(ctx, "Building dependency graph", logger.Attr("lockFile", lockFilePath))
+		log.Info(ctx, "Building dependency graph", logger.Attr("lockFile", lockFilePath)) //nolint:goconst // logger key, not worth a constant
 
 		sbom, err := p.client.ExportSBOM(lockFileDir, options)
 		if err != nil {
@@ -67,7 +69,7 @@ func (p Plugin) BuildFindingsFromDir(
 			findings = append(findings, errorFinding)
 			continue
 		}
-		fs, err := p.buildFindings(ctx, sbom, lockFilePath, lockFileDir, log)
+		fs, err := p.buildFindings(ctx, sbom, lockFilePath, lockFileDir, options, log)
 		if err != nil {
 			return nil, err
 		}
@@ -86,11 +88,23 @@ func (p Plugin) buildFindings(
 	sbom Sbom,
 	lockFilePath string,
 	lockFileDir string,
+	options *scaplugin.Options,
 	log logger.Logger,
 ) ([]scaplugin.Finding, error) {
 	parsedSbom, err := parseAndValidateSBOM(sbom)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse and validate sbom for %s: %w", lockFilePath, err)
+	}
+
+	if !options.AllProjects && !options.UvWorkspacePackages && !hasProjectRoot(parsedSbom) {
+		log.Info(ctx, "No root project found in SBOM", logger.Attr("lockFile", lockFilePath))
+		noRootErr := ecosystems.NewUvNoProjectRootError(
+			"Found uv workspace with no root project. To scan all workspace members use the --all-projects flag.",
+		)
+		return []scaplugin.Finding{{
+			LockFile: lockFilePath,
+			Error:    noRootErr,
+		}}, nil
 	}
 
 	metadata := extractMetadata(parsedSbom)

--- a/internal/uv/uv_plugin_test.go
+++ b/internal/uv/uv_plugin_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/snyk/dep-graph/go/pkg/depgraph"
+	"github.com/snyk/error-catalog-golang-public/snyk_errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -22,10 +23,19 @@ import (
 var testLogger = logger.Nop()
 
 const validSBOMJSON = `{
+	"bomFormat": "CycloneDX",
+	"specVersion": "1.5",
+	"version": 1,
 	"metadata": {
+		"tools": [{"vendor": "Astral Software Inc.", "name": "uv", "version": "0.10.9"}],
 		"component": {
+			"type": "library",
+			"bom-ref": "test-package-1@1.0.0",
 			"name": "test-package",
-			"version": "1.0.0"
+			"version": "1.0.0",
+			"properties": [
+				{"name": "uv:package:is_project_root", "value": "true"}
+			]
 		}
 	},
 	"components": []
@@ -493,7 +503,7 @@ func TestBuildFindings_Success(t *testing.T) {
 	snykClient := setupMockSnykClient(t, mockResponseBody)
 	plugin := NewUvPlugin(&MockClient{}, snykClient, "")
 
-	findings, err := plugin.buildFindings(context.Background(), sbom, "uv.lock", ".", testLogger)
+	findings, err := plugin.buildFindings(context.Background(), sbom, "uv.lock", ".", &scaplugin.Options{}, testLogger)
 
 	require.NoError(t, err)
 	require.Len(t, findings, 1)
@@ -503,12 +513,159 @@ func TestBuildFindings_Success(t *testing.T) {
 	assert.Nil(t, findings[0].Error)
 }
 
+func TestBuildFindings_NoProjectRoot_ReturnsErrorFinding(t *testing.T) {
+	sbomJSON := `{
+		"bomFormat": "CycloneDX",
+		"specVersion": "1.5",
+		"version": 1,
+		"metadata": {
+			"tools": [{"vendor": "Astral Software Inc.", "name": "uv", "version": "0.10.9"}],
+			"component": {
+				"type": "library",
+				"bom-ref": "uv-workspace-3",
+				"name": "uv-workspace",
+				"properties": [
+					{"name": "uv:package:is_synthetic_root", "value": "true"}
+				]
+			}
+		},
+		"components": [
+			{
+				"type": "library",
+				"bom-ref": "albatross-1@0.1.0",
+				"name": "albatross",
+				"version": "0.1.0",
+				"properties": [
+					{"name": "uv:workspace:path", "value": "packages/albatross"}
+				]
+			},
+			{
+				"type": "library",
+				"bom-ref": "seeds-2@1.0.0",
+				"name": "seeds",
+				"version": "1.0.0",
+				"properties": [
+					{"name": "uv:workspace:path", "value": "packages/seeds"}
+				]
+			}
+		]
+	}`
+	sbom := Sbom(sbomJSON)
+	snykClient := setupMockSnykClient(t, `{}`)
+	plugin := NewUvPlugin(&MockClient{}, snykClient, "")
+
+	findings, err := plugin.buildFindings(context.Background(), sbom, "uv.lock", ".", &scaplugin.Options{}, testLogger)
+
+	require.NoError(t, err, "should not return an error, but rather an error finding")
+	require.Len(t, findings, 1)
+	require.NotNil(t, findings[0].Error)
+	assert.Contains(t, findings[0].Error.Error(), "No root project found")
+	assert.Nil(t, findings[0].DepGraph)
+	assert.Equal(t, "uv.lock", findings[0].LockFile)
+
+	var catalogErr snyk_errors.Error
+	require.True(t, errors.As(findings[0].Error, &catalogErr), "error should be a catalog error")
+	assert.Equal(t, "SNYK-OS-UV-0001", catalogErr.ErrorCode)
+	assert.Contains(t, catalogErr.Detail, "no root")
+	assert.Contains(t, catalogErr.Detail, "--all-projects")
+}
+
+func TestBuildFindings_NoProjectRoot_AllProjects_Succeeds(t *testing.T) {
+	sbomJSON := `{
+		"bomFormat": "CycloneDX",
+		"specVersion": "1.5",
+		"version": 1,
+		"metadata": {
+			"tools": [{"vendor": "Astral Software Inc.", "name": "uv", "version": "0.10.9"}],
+			"component": {
+				"type": "library",
+				"bom-ref": "uv-workspace-3",
+				"name": "uv-workspace",
+				"properties": [
+					{"name": "uv:package:is_synthetic_root", "value": "true"}
+				]
+			}
+		},
+		"components": [
+			{
+				"type": "library",
+				"bom-ref": "albatross-1@0.1.0",
+				"name": "albatross",
+				"version": "0.1.0",
+				"properties": [
+					{"name": "uv:workspace:path", "value": "packages/albatross"}
+				]
+			}
+		]
+	}`
+	sbom := Sbom(sbomJSON)
+	mockResponseBody := singleDepGraphResponse("albatross", "0.1.0")
+	snykClient := setupMockSnykClient(t, mockResponseBody)
+	plugin := NewUvPlugin(&MockClient{}, snykClient, "")
+
+	findings, err := plugin.buildFindings(context.Background(), sbom, "uv.lock", ".", &scaplugin.Options{AllProjects: true}, testLogger)
+
+	require.NoError(t, err)
+	require.Len(t, findings, 1)
+	assert.NotNil(t, findings[0].DepGraph)
+	assert.Nil(t, findings[0].Error)
+}
+
+func TestBuildFindings_NoProjectRoot_UvWorkspacePackages_Succeeds(t *testing.T) {
+	sbomJSON := `{
+		"bomFormat": "CycloneDX",
+		"specVersion": "1.5",
+		"version": 1,
+		"metadata": {
+			"tools": [{"vendor": "Astral Software Inc.", "name": "uv", "version": "0.10.9"}],
+			"component": {
+				"type": "library",
+				"bom-ref": "uv-workspace-3",
+				"name": "uv-workspace",
+				"properties": [
+					{"name": "uv:package:is_synthetic_root", "value": "true"}
+				]
+			}
+		},
+		"components": [
+			{
+				"type": "library",
+				"bom-ref": "albatross-1@0.1.0",
+				"name": "albatross",
+				"version": "0.1.0",
+				"properties": [
+					{"name": "uv:workspace:path", "value": "packages/albatross"}
+				]
+			}
+		]
+	}`
+	sbom := Sbom(sbomJSON)
+	mockResponseBody := singleDepGraphResponse("albatross", "0.1.0")
+	snykClient := setupMockSnykClient(t, mockResponseBody)
+	plugin := NewUvPlugin(&MockClient{}, snykClient, "")
+
+	findings, err := plugin.buildFindings(
+		context.Background(),
+		sbom,
+		"uv.lock",
+		".",
+		&scaplugin.Options{UvWorkspacePackages: true},
+		testLogger,
+	)
+
+	require.NoError(t, err)
+	require.Len(t, findings, 1)
+	assert.NotNil(t, findings[0].DepGraph)
+	assert.Nil(t, findings[0].Error)
+	assert.Equal(t, filepath.Join("packages", "albatross", "pyproject.toml"), findings[0].ManifestFile)
+}
+
 func TestBuildFindings_InvalidSBOM(t *testing.T) {
 	sbom := Sbom(`{"invalid": "json"}`)
 	snykClient := setupMockSnykClient(t, `{}`)
 	plugin := NewUvPlugin(&MockClient{}, snykClient, "")
 
-	findings, err := plugin.buildFindings(context.Background(), sbom, "uv.lock", ".", testLogger)
+	findings, err := plugin.buildFindings(context.Background(), sbom, "uv.lock", ".", &scaplugin.Options{}, testLogger)
 
 	assert.Error(t, err)
 	assert.Nil(t, findings)
@@ -524,7 +681,7 @@ func TestBuildFindings_MissingRootComponent(t *testing.T) {
 	snykClient := setupMockSnykClient(t, `{}`)
 	plugin := NewUvPlugin(&MockClient{}, snykClient, "")
 
-	findings, err := plugin.buildFindings(context.Background(), sbom, "uv.lock", ".", testLogger)
+	findings, err := plugin.buildFindings(context.Background(), sbom, "uv.lock", ".", &scaplugin.Options{}, testLogger)
 
 	assert.Error(t, err)
 	assert.Nil(t, findings)
@@ -537,7 +694,7 @@ func TestBuildFindings_ConversionError(t *testing.T) {
 	snykClient := setupMockSnykClientMultiResponse(t, []mocks.MockResponse{mockResponse})
 	plugin := NewUvPlugin(&MockClient{}, snykClient, "")
 
-	findings, err := plugin.buildFindings(context.Background(), sbom, "uv.lock", ".", testLogger)
+	findings, err := plugin.buildFindings(context.Background(), sbom, "uv.lock", ".", &scaplugin.Options{}, testLogger)
 
 	assert.Error(t, err)
 	assert.Nil(t, findings)
@@ -550,7 +707,7 @@ func TestBuildFindings_MultipleDepGraphs(t *testing.T) {
 	snykClient := setupMockSnykClient(t, mockResponseBody)
 	plugin := NewUvPlugin(&MockClient{}, snykClient, "")
 
-	findings, err := plugin.buildFindings(context.Background(), sbom, "uv.lock", ".", testLogger)
+	findings, err := plugin.buildFindings(context.Background(), sbom, "uv.lock", ".", &scaplugin.Options{}, testLogger)
 
 	require.NoError(t, err)
 	require.Len(t, findings, 2)
@@ -560,14 +717,25 @@ func TestBuildFindings_MultipleDepGraphs(t *testing.T) {
 
 func TestBuildFindings_WorkspacePackage(t *testing.T) {
 	sbomJSON := `{
+		"bomFormat": "CycloneDX",
+		"specVersion": "1.5",
+		"version": 1,
 		"metadata": {
+			"tools": [{"vendor": "Astral Software Inc.", "name": "uv", "version": "0.10.9"}],
 			"component": {
+				"type": "library",
+				"bom-ref": "workspace-root-1@1.0.0",
 				"name": "workspace-root",
-				"version": "1.0.0"
+				"version": "1.0.0",
+				"properties": [
+					{"name": "uv:package:is_project_root", "value": "true"}
+				]
 			}
 		},
 		"components": [
 			{
+				"type": "library",
+				"bom-ref": "workspace-package-2@3.1.0",
 				"name": "workspace-package",
 				"version": "3.1.0",
 				"properties": [
@@ -584,7 +752,7 @@ func TestBuildFindings_WorkspacePackage(t *testing.T) {
 	snykClient := setupMockSnykClient(t, mockResponseBody)
 	plugin := NewUvPlugin(&MockClient{}, snykClient, "")
 
-	findings, err := plugin.buildFindings(context.Background(), sbom, "uv.lock", ".", testLogger)
+	findings, err := plugin.buildFindings(context.Background(), sbom, "uv.lock", ".", &scaplugin.Options{}, testLogger)
 
 	require.NoError(t, err)
 	require.Len(t, findings, 1)
@@ -598,7 +766,7 @@ func TestBuildFindings_PathConstruction_RootDir(t *testing.T) {
 	snykClient := setupMockSnykClient(t, mockResponseBody)
 	plugin := NewUvPlugin(&MockClient{}, snykClient, "")
 
-	findings, err := plugin.buildFindings(context.Background(), sbom, "uv.lock", ".", testLogger)
+	findings, err := plugin.buildFindings(context.Background(), sbom, "uv.lock", ".", &scaplugin.Options{}, testLogger)
 
 	require.NoError(t, err)
 	require.Len(t, findings, 1)
@@ -612,7 +780,7 @@ func TestBuildFindings_PathConstruction_NestedDir(t *testing.T) {
 	snykClient := setupMockSnykClient(t, mockResponseBody)
 	plugin := NewUvPlugin(&MockClient{}, snykClient, "")
 
-	findings, err := plugin.buildFindings(context.Background(), sbom, "project1/uv.lock", "project1", testLogger)
+	findings, err := plugin.buildFindings(context.Background(), sbom, "project1/uv.lock", "project1", &scaplugin.Options{}, testLogger)
 
 	require.NoError(t, err)
 	require.Len(t, findings, 1)
@@ -622,14 +790,25 @@ func TestBuildFindings_PathConstruction_NestedDir(t *testing.T) {
 
 func TestBuildFindings_PathConstruction_NestedWorkspacePackage(t *testing.T) {
 	sbomJSON := `{
+		"bomFormat": "CycloneDX",
+		"specVersion": "1.5",
+		"version": 1,
 		"metadata": {
+			"tools": [{"vendor": "Astral Software Inc.", "name": "uv", "version": "0.10.9"}],
 			"component": {
+				"type": "library",
+				"bom-ref": "workspace-root-1@1.0.0",
 				"name": "workspace-root",
-				"version": "1.0.0"
+				"version": "1.0.0",
+				"properties": [
+					{"name": "uv:package:is_project_root", "value": "true"}
+				]
 			}
 		},
 		"components": [
 			{
+				"type": "library",
+				"bom-ref": "workspace-package-2@3.1.0",
 				"name": "workspace-package",
 				"version": "3.1.0",
 				"properties": [
@@ -646,7 +825,7 @@ func TestBuildFindings_PathConstruction_NestedWorkspacePackage(t *testing.T) {
 	snykClient := setupMockSnykClient(t, mockResponseBody)
 	plugin := NewUvPlugin(&MockClient{}, snykClient, "")
 
-	findings, err := plugin.buildFindings(context.Background(), sbom, "workspace/uv.lock", "workspace", testLogger)
+	findings, err := plugin.buildFindings(context.Background(), sbom, "workspace/uv.lock", "workspace", &scaplugin.Options{}, testLogger)
 
 	require.NoError(t, err)
 	require.Len(t, findings, 1)

--- a/internal/uv/uvclient.go
+++ b/internal/uv/uvclient.go
@@ -18,6 +18,7 @@ const (
 	RequirementsTxtFileName = "requirements.txt"
 	PyprojectTomlFileName   = "pyproject.toml"
 	UvWorkspacePathProperty = "uv:workspace:path"
+	UvIsProjectRootProperty = "uv:package:is_project_root"
 )
 
 type Client interface {
@@ -87,10 +88,7 @@ func (c client) ExportSBOM(inputDir string, opts *scaplugin.Options) (Sbom, erro
 // Minimal representation of a CycloneDX SBOM.
 type cycloneDXSBOM struct {
 	Metadata struct {
-		Component *struct {
-			Name    string `json:"name"`
-			Version string `json:"version"`
-		} `json:"component"`
+		Component *cycloneDXComponent `json:"component"`
 	} `json:"metadata"`
 	Components []cycloneDXComponent `json:"components"`
 }
@@ -156,6 +154,33 @@ func extractWorkspacePackages(sbom *cycloneDXSBOM) []WorkspacePackage {
 	}
 
 	return workspacePackages
+}
+
+// hasProjectRoot checks whether any component (including the root metadata component) in the SBOM
+// has the property indicating it is a project root. In a virtual uv workspace there is no root
+// project, so this returns false.
+func hasProjectRoot(sbom *cycloneDXSBOM) bool {
+	if componentIsProjectRoot(sbom.Metadata.Component) {
+		return true
+	}
+	for i := range sbom.Components {
+		if componentIsProjectRoot(&sbom.Components[i]) {
+			return true
+		}
+	}
+	return false
+}
+
+func componentIsProjectRoot(component *cycloneDXComponent) bool {
+	if component == nil {
+		return false
+	}
+	for _, prop := range component.Properties {
+		if prop.Name == UvIsProjectRootProperty && prop.Value == "true" {
+			return true
+		}
+	}
+	return false
 }
 
 // Matches uv's error message when the lockfile is out of date.

--- a/internal/uv/uvclient_test.go
+++ b/internal/uv/uvclient_test.go
@@ -444,6 +444,222 @@ func TestExtractMetadata_InvalidJSON(t *testing.T) {
 	}
 }
 
+func TestHasProjectRoot(t *testing.T) {
+	tests := []struct {
+		name     string
+		sbom     string
+		expected bool
+	}{
+		{
+			name: "root component has is_project_root property (single project)",
+			sbom: `{
+				"bomFormat": "CycloneDX",
+				"specVersion": "1.5",
+				"version": 1,
+				"metadata": {
+					"tools": [{"vendor": "Astral Software Inc.", "name": "uv", "version": "0.10.9"}],
+					"component": {
+						"type": "library",
+						"bom-ref": "seeds-1@1.0.0",
+						"name": "seeds",
+						"version": "1.0.0",
+						"properties": [
+							{"name": "uv:package:is_project_root", "value": "true"}
+						]
+					}
+				},
+				"components": [
+					{
+						"type": "library",
+						"bom-ref": "django-2@3.1",
+						"name": "django",
+						"version": "3.1",
+						"purl": "pkg:pypi/django@3.1"
+					}
+				]
+			}`,
+			expected: true,
+		},
+		{
+			name: "non-root component has is_project_root property (workspace member)",
+			sbom: `{
+				"bomFormat": "CycloneDX",
+				"specVersion": "1.5",
+				"version": 1,
+				"metadata": {
+					"tools": [{"vendor": "Astral Software Inc.", "name": "uv", "version": "0.10.9"}],
+					"component": {
+						"type": "library",
+						"bom-ref": "uv-workspace-3",
+						"name": "uv-workspace",
+						"properties": [
+							{"name": "uv:package:is_synthetic_root", "value": "true"}
+						]
+					}
+				},
+				"components": [
+					{
+						"type": "library",
+						"bom-ref": "albatross-1@0.1.0",
+						"name": "albatross",
+						"version": "0.1.0",
+						"properties": [
+							{"name": "uv:package:is_project_root", "value": "true"},
+							{"name": "uv:workspace:path", "value": "packages/albatross"}
+						]
+					}
+				]
+			}`,
+			expected: true,
+		},
+		{
+			name: "no component has is_project_root property (virtual workspace)",
+			sbom: `{
+				"bomFormat": "CycloneDX",
+				"specVersion": "1.5",
+				"version": 1,
+				"metadata": {
+					"tools": [{"vendor": "Astral Software Inc.", "name": "uv", "version": "0.10.9"}],
+					"component": {
+						"type": "library",
+						"bom-ref": "uv-workspace-3",
+						"name": "uv-workspace",
+						"properties": [
+							{"name": "uv:package:is_synthetic_root", "value": "true"}
+						]
+					}
+				},
+				"components": [
+					{
+						"type": "library",
+						"bom-ref": "albatross-1@0.1.0",
+						"name": "albatross",
+						"version": "0.1.0",
+						"properties": [
+							{"name": "uv:workspace:path", "value": "packages/albatross"}
+						]
+					}
+				]
+			}`,
+			expected: false,
+		},
+		{
+			name: "is_project_root property with value false",
+			sbom: `{
+				"bomFormat": "CycloneDX",
+				"specVersion": "1.5",
+				"version": 1,
+				"metadata": {
+					"tools": [{"vendor": "Astral Software Inc.", "name": "uv", "version": "0.10.9"}],
+					"component": {
+						"type": "library",
+						"bom-ref": "seeds-1@1.0.0",
+						"name": "seeds",
+						"version": "1.0.0",
+						"properties": [
+							{"name": "uv:package:is_project_root", "value": "false"}
+						]
+					}
+				},
+				"components": []
+			}`,
+			expected: false,
+		},
+		{
+			name: "no properties at all",
+			sbom: `{
+				"bomFormat": "CycloneDX",
+				"specVersion": "1.5",
+				"version": 1,
+				"metadata": {
+					"tools": [{"vendor": "Astral Software Inc.", "name": "uv", "version": "0.10.9"}],
+					"component": {
+						"type": "library",
+						"bom-ref": "seeds-1@1.0.0",
+						"name": "seeds",
+						"version": "1.0.0"
+					}
+				},
+				"components": []
+			}`,
+			expected: false,
+		},
+		{
+			name: "empty components list with root having is_project_root",
+			sbom: `{
+				"bomFormat": "CycloneDX",
+				"specVersion": "1.5",
+				"version": 1,
+				"metadata": {
+					"tools": [{"vendor": "Astral Software Inc.", "name": "uv", "version": "0.10.9"}],
+					"component": {
+						"type": "library",
+						"bom-ref": "seeds-1@1.0.0",
+						"name": "seeds",
+						"version": "1.0.0",
+						"properties": [
+							{"name": "uv:package:is_project_root", "value": "true"}
+						]
+					}
+				}
+			}`,
+			expected: true,
+		},
+		{
+			name: "multiple components, one has is_project_root",
+			sbom: `{
+				"bomFormat": "CycloneDX",
+				"specVersion": "1.5",
+				"version": 1,
+				"metadata": {
+					"tools": [{"vendor": "Astral Software Inc.", "name": "uv", "version": "0.10.9"}],
+					"component": {
+						"type": "library",
+						"bom-ref": "uv-workspace-4",
+						"name": "uv-workspace",
+						"properties": [
+							{"name": "uv:package:is_synthetic_root", "value": "true"}
+						]
+					}
+				},
+				"components": [
+					{
+						"type": "library",
+						"bom-ref": "albatross-1@0.1.0",
+						"name": "albatross",
+						"version": "0.1.0",
+						"properties": [
+							{"name": "uv:workspace:path", "value": "packages/albatross"}
+						]
+					},
+					{
+						"type": "library",
+						"bom-ref": "seeds-2@1.0.0",
+						"name": "seeds",
+						"version": "1.0.0",
+						"properties": [
+							{"name": "uv:package:is_project_root", "value": "true"},
+							{"name": "uv:workspace:path", "value": "packages/seeds"}
+						]
+					}
+				]
+			}`,
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sbom, err := parseAndValidateSBOM([]byte(tt.sbom))
+			require.NoError(t, err)
+			require.NotNil(t, sbom)
+
+			result := hasProjectRoot(sbom)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
 func TestExtractWorkspacePackages(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
Currently we have a bug where, when testing or monitoring a uv virtual workspace (i.e. a workspace with no root package, only workspace packages), all workspace packages will be included in the results. This is wrong, as a virtual workspace has no root and hence no dependencies. This PR adds an error in this scenario, informing the user that they can instead use `--all-projects` if they would like to intentionally include workspace packages in the results.

I also updated some fixtures in other tests to include the `is_project_root` property, and add some other missing data which ensures that they are as realistic as possible.