### PR TITLE
fix: improved pip error handling

### DIFF
--- a/pkg/ecosystems/python/pip/extract_test.go
+++ b/pkg/ecosystems/python/pip/extract_test.go
@@ -1,0 +1,74 @@
+package pip
+
+import (
+	"testing"
+)
+
+func TestExtractFailedPackageName(t *testing.T) {
+	tests := map[string]struct {
+		stderr   string
+		expected string
+	}{
+		"metadata_generation_failed_simple": {
+			stderr: `error: metadata-generation-failed
+
+× Encountered error while generating package metadata.
+╰─> gensim
+
+note: This is an issue with the package mentioned above, not pip.`,
+			expected: "gensim",
+		},
+		"metadata_generation_failed_with_lines_of_output": {
+			stderr: `error: subprocess-exited-with-error
+  
+  × Preparing metadata (pyproject.toml) did not run successfully.
+  │ exit code: 1
+  ╰─> [10 lines of output]
+      + meson setup /tmp/pip-install-18e5wn4x/pandas_363f78496e4d425bbbcaca33978fbd75
+      Build type: native build
+      
+      ../meson.build:5:13: ERROR: Command failed with status 1.
+      [end of output]
+  
+  note: This error originates from a subprocess, and is likely not a problem with pip.
+error: metadata-generation-failed
+
+× Encountered error while generating package metadata.
+╰─> pandas
+
+note: This is an issue with the package mentioned above, not pip.`,
+			expected: "pandas",
+		},
+		"failed_to_build_wheel": {
+			stderr:   `ERROR: Failed to build 'gensim' when getting requirements to build wheel`,
+			expected: "gensim",
+		},
+		"failed_building_wheel_for": {
+			stderr:   `ERROR: Failed building wheel for numpy`,
+			expected: "numpy",
+		},
+		"could_not_build_wheels": {
+			stderr:   `ERROR: Could not build wheels for scipy which is required`,
+			expected: "scipy",
+		},
+		"no_match": {
+			stderr:   `Some random error message`,
+			expected: "",
+		},
+		"lines_of_output_only": {
+			stderr: `╰─> [34 lines of output]
+      Some error details
+      [end of output]`,
+			expected: "",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			result := extractFailedPackageName(tt.stderr)
+			if result != tt.expected {
+				t.Errorf("extractFailedPackageName() = %q, want %q", result, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/ecosystems/python/pip/report.go
+++ b/pkg/ecosystems/python/pip/report.go
@@ -292,7 +292,9 @@ func classifyPipError(ctx context.Context, log logger.Logger, err error) error {
 func extractFailedPackageName(stderr string) string {
 	// Pattern: "╰─> package" (appears in metadata-generation-failed errors)
 	// This pattern is checked first as it's the most specific and cleanest
-	if idx := strings.Index(stderr, "╰─> "); idx != -1 {
+	// Use LastIndex to get the last occurrence, as the pattern may appear multiple times
+	// (e.g., "╰─> [10 lines of output]" followed by "╰─> pandas")
+	if idx := strings.LastIndex(stderr, "╰─> "); idx != -1 {
 		start := idx + len("╰─> ")
 		// Find the end of the package name (whitespace or newline)
 		end := strings.IndexAny(stderr[start:], " \n\r\t")
@@ -303,7 +305,8 @@ func extractFailedPackageName(stderr string) string {
 		} else {
 			pkgName = strings.TrimSpace(stderr[start : start+end])
 		}
-		if pkgName != "" {
+		// Filter out patterns like "[10 lines of output]"
+		if pkgName != "" && !strings.HasPrefix(pkgName, "[") {
 			return pkgName
 		}
 	}
@@ -319,17 +322,23 @@ func extractFailedPackageName(stderr string) string {
 	// Pattern: "Failed building wheel for package"
 	if idx := strings.Index(stderr, "Failed building wheel for "); idx != -1 {
 		start := idx + len("Failed building wheel for ")
-		if end := strings.IndexAny(stderr[start:], " \n,"); end != -1 {
-			return stderr[start : start+end]
+		end := strings.IndexAny(stderr[start:], " \n,")
+		if end == -1 {
+			// Package name goes to end of string
+			return strings.TrimSpace(stderr[start:])
 		}
+		return stderr[start : start+end]
 	}
 
 	// Pattern: "Could not build wheels for package"
 	if idx := strings.Index(stderr, "Could not build wheels for "); idx != -1 {
 		start := idx + len("Could not build wheels for ")
-		if end := strings.IndexAny(stderr[start:], " \n,"); end != -1 {
-			return stderr[start : start+end]
+		end := strings.IndexAny(stderr[start:], " \n,")
+		if end == -1 {
+			// Package name goes to end of string
+			return strings.TrimSpace(stderr[start:])
 		}
+		return stderr[start : start+end]
 	}
 
 	return ""


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [ ] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Improve error passing to handle cases such as:
```
× Preparing metadata (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [10 lines of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> pandas
```
