### PR TITLE
feat: add --maven-skip-wrapper flag

### DIFF
--- a/pkg/depgraph/flags.go
+++ b/pkg/depgraph/flags.go
@@ -15,6 +15,7 @@ const (
 	FlagDetectionDepth                = "detection-depth"
 	FlagPruneRepeatedSubdependencies  = "prune-repeated-subdependencies"
 	FlagMavenAggregateProject         = "maven-aggregate-project"
+	FlagMavenSkipWrapper              = "maven-skip-wrapper" //nolint:gosec // Not a credential, this is a CLI flag name
 	FlagScanUnmanaged                 = "scan-unmanaged"
 	FlagScanAllUnmanaged              = "scan-all-unmanaged"
 	FlagSubProject                    = "sub-project"
@@ -51,6 +52,7 @@ func getFlagSet() *pflag.FlagSet {
 	flagSet.String(FlagDetectionDepth, "", "Detection depth")
 	flagSet.BoolP(FlagPruneRepeatedSubdependencies, "p", false, "Prune repeated sub-dependencies")
 	flagSet.Bool(FlagMavenAggregateProject, false, "Ensure all modules are resolvable by the Maven reactor.")
+	flagSet.Bool(FlagMavenSkipWrapper, false, "Use system Maven instead of the Maven wrapper.")
 	flagSet.Bool(FlagScanUnmanaged, false, "Specify an individual JAR, WAR, or AAR file.")
 	flagSet.Bool(FlagScanAllUnmanaged, false, "Auto-detect Maven, JAR, WAR, and AAR files recursively from the current folder.")
 	flagSet.String(FlagSubProject, "", "Name of Gradle sub-project to test.")

--- a/pkg/depgraph/legacy_resolution.go
+++ b/pkg/depgraph/legacy_resolution.go
@@ -141,6 +141,11 @@ func prepareLegacyFlags(argument string, cfg configuration.Configuration, logger
 		logger.Print("Ensure all modules are resolvable by the Maven reactor: true")
 	}
 
+	if cfg.GetBool(FlagMavenSkipWrapper) {
+		cmdArgs = append(cmdArgs, "--maven-skip-wrapper")
+		logger.Print("Use system Maven instead of the Maven wrapper: true")
+	}
+
 	if cfg.GetBool(FlagScanUnmanaged) {
 		cmdArgs = append(cmdArgs, "--scan-unmanaged")
 		logger.Print("Specify an individual JAR, WAR, or AAR file: true")


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does
Adds support for the --maven-skip-wrapper flag in the CLI, propagating it to snyk-mvn-plugin v4.6.0 which implements the underlying behaviour.

When a Maven project includes a wrapper script (mvnw / mvnw.cmd), the plugin normally prefers it over a globally installed mvn. This flag forces the plugin to use the global mvn binary instead — useful in CI environments where the wrapper is present but a system-managed Maven installation is required.

[GitBooks PR](https://app.gitbook.com/o/-M4tdxG8qotLgGZnLpFR/s/-MdwVZ6HOZriajCf5nXH/~/changes/10343/developer-tools/snyk-cli/commands/sbom)
[CLI PR](https://github.com/snyk/cli/pull/6653)
