### PR TITLE
feat: ensure that dotnet runtime resolution is disabled for sbom

### DIFF
--- a/pkg/depgraph/legacy_resolution.go
+++ b/pkg/depgraph/legacy_resolution.go
@@ -234,9 +234,10 @@ func prepareLegacyFlags(argument string, cfg configuration.Configuration, logger
 		logger.Print("Include provenance: true")
 	}
 
-	if cfg.GetBool(FlagDotnetRuntimeResolution) {
-		cmdArgs = append(cmdArgs, "--dotnet-runtime-resolution")
-		logger.Print("Dotnet runtime resolution: true")
+	if cfg.IsSet(FlagDotnetRuntimeResolution) {
+		dotnetRuntimeResolution := cfg.GetBool(FlagDotnetRuntimeResolution)
+		cmdArgs = append(cmdArgs, fmt.Sprintf("--dotnet-runtime-resolution=%t", dotnetRuntimeResolution))
+		logger.Print("Dotnet runtime resolution: ", dotnetRuntimeResolution)
 	}
 
 	if tf := cfg.GetString(FlagDotnetTargetFramework); tf != "" {

--- a/pkg/depgraph/legacy_resolution_test.go
+++ b/pkg/depgraph/legacy_resolution_test.go
@@ -186,7 +186,12 @@ func Test_LegacyResolution(t *testing.T) {
 		{
 			key:      FlagDotnetRuntimeResolution,
 			value:    true,
-			expected: "--dotnet-runtime-resolution",
+			expected: "--dotnet-runtime-resolution=true",
+		},
+		{
+			key:      FlagDotnetRuntimeResolution,
+			value:    false,
+			expected: "--dotnet-runtime-resolution=false",
 		},
 		{
 			key:      FlagDotnetTargetFramework,


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Handles the configuration value for `--dotnet-runtime-resolution` more gracefully for a boolean. This supports users being able to set the config option to _false_ whereas before presence alone was enough for this to be explicitly set true. Being able to explicitly set to false was impossible.

To handle backwards compatibility, we will need to set this to `false` to ensure that SBOM generation still works, because otherwise `--dotnet-runtime-resolution` may return >1 dep graph which SBOM doesn't handle.

Handling in SBOM for this particular scenario (likely by prompting for one of the target frameworks) will be implemented later.