### PR TITLE
feat: support force-single-graph flag to prevent dep-graph splitting

### DIFF
--- a/internal/conversion/sbom.go
+++ b/internal/conversion/sbom.go
@@ -19,8 +19,9 @@ func SbomToDepGraphs(
 	snykClient *snykclient.SnykClient,
 	log logger.Logger,
 	remoteRepoURL string,
+	forceSingleGraph bool,
 ) ([]*depgraph.DepGraph, error) {
-	scans, warnings, err := snykClient.SBOMConvert(ctx, log, sbom, remoteRepoURL)
+	scans, warnings, err := snykClient.SBOMConvert(ctx, log, sbom, remoteRepoURL, forceSingleGraph)
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert SBOM: %w", err)
 	}

--- a/internal/conversion/sbom_test.go
+++ b/internal/conversion/sbom_test.go
@@ -30,7 +30,7 @@ func TestSbomToDepGraphs_Success(t *testing.T) {
 	mockService, snykClient := setupMockSnykClient(t, mockResponseBody, http.StatusOK)
 	defer mockService.Close()
 
-	depGraphs, err := SbomToDepGraphs(context.Background(), sbom, metadata, snykClient, logger, "")
+	depGraphs, err := SbomToDepGraphs(context.Background(), sbom, metadata, snykClient, logger, "", false)
 
 	require.NoError(t, err)
 	require.Len(t, depGraphs, 1)
@@ -53,7 +53,7 @@ func TestSbomToDepGraphs_EmptyScans_CreatesEmptyDepGraph(t *testing.T) {
 	mockService, snykClient := setupMockSnykClient(t, mockResponseBody, http.StatusOK)
 	defer mockService.Close()
 
-	depGraphs, err := SbomToDepGraphs(context.Background(), sbom, metadata, snykClient, logger, "")
+	depGraphs, err := SbomToDepGraphs(context.Background(), sbom, metadata, snykClient, logger, "", false)
 
 	require.NoError(t, err)
 	require.Len(t, depGraphs, 1)
@@ -76,7 +76,7 @@ func TestSbomToDepGraphs_MultipleDepGraphs(t *testing.T) {
 	mockService, snykClient := setupMockSnykClient(t, mockResponseBody, http.StatusOK)
 	defer mockService.Close()
 
-	depGraphs, err := SbomToDepGraphs(context.Background(), sbom, metadata, snykClient, logger, "")
+	depGraphs, err := SbomToDepGraphs(context.Background(), sbom, metadata, snykClient, logger, "", false)
 
 	require.NoError(t, err)
 	require.Len(t, depGraphs, 2)
@@ -96,7 +96,7 @@ func TestSbomToDepGraphs_ConversionError(t *testing.T) {
 	mockService, snykClient := setupMockSnykClient(t, `{"error": "invalid"}`, http.StatusBadRequest)
 	defer mockService.Close()
 
-	depGraphs, err := SbomToDepGraphs(context.Background(), sbom, metadata, snykClient, logger, "")
+	depGraphs, err := SbomToDepGraphs(context.Background(), sbom, metadata, snykClient, logger, "", false)
 
 	assert.Error(t, err)
 	assert.Nil(t, depGraphs)
@@ -116,7 +116,7 @@ func TestSbomToDepGraphs_EmptyDepGraphCreationError_EmptyName(t *testing.T) {
 	mockService, snykClient := setupMockSnykClient(t, mockResponseBody, http.StatusOK)
 	defer mockService.Close()
 
-	depGraphs, err := SbomToDepGraphs(context.Background(), sbom, metadata, snykClient, logger, "")
+	depGraphs, err := SbomToDepGraphs(context.Background(), sbom, metadata, snykClient, logger, "", false)
 
 	assert.Error(t, err)
 	assert.Nil(t, depGraphs)

--- a/internal/snykclient/sbomconvert.go
+++ b/internal/snykclient/sbomconvert.go
@@ -25,8 +25,9 @@ func (t *SnykClient) SBOMConvert(
 	log logger.Logger,
 	sbom io.Reader,
 	remoteRepoURL string,
+	forceSingleGraph bool,
 ) ([]*ScanResult, []*ConversionWarning, error) {
-	u, err := buildSBOMConvertAPIURL(t.apiBaseURL, sbomConvertAPIVersion, t.orgID, remoteRepoURL)
+	u, err := buildSBOMConvertAPIURL(t.apiBaseURL, sbomConvertAPIVersion, t.orgID, remoteRepoURL, forceSingleGraph)
 	if err != nil {
 		log.Error(ctx, "Failed to build SBOM convert API URL", logger.Err(err))
 		return nil, nil, NewSCAError(err)
@@ -90,7 +91,7 @@ func (t *SnykClient) SBOMConvert(
 	return convertResp.ScanResults, convertResp.ConversionWarning, nil
 }
 
-func buildSBOMConvertAPIURL(apiBaseURL, apiVersion, orgID, remoteRepoURL string) (*url.URL, error) {
+func buildSBOMConvertAPIURL(apiBaseURL, apiVersion, orgID, remoteRepoURL string, forceSingleGraph bool) (*url.URL, error) {
 	u, err := url.Parse(apiBaseURL)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse API base URL: %w", err)
@@ -101,6 +102,9 @@ func buildSBOMConvertAPIURL(apiBaseURL, apiVersion, orgID, remoteRepoURL string)
 	query := url.Values{
 		"version":         []string{apiVersion},
 		"remote_repo_url": []string{remoteRepoURL},
+	}
+	if forceSingleGraph {
+		query.Set("force_single_graph", "true")
 	}
 	u.RawQuery = query.Encode()
 

--- a/internal/snykclient/sbomconvert_test.go
+++ b/internal/snykclient/sbomconvert_test.go
@@ -39,7 +39,9 @@ func Test_SBOMConvert(t *testing.T) {
 		context.Background(),
 		logger,
 		bytes.NewBuffer([]byte(sbomContent)),
-		"github.com/snyk/cli-extension-dep-graph")
+		"github.com/snyk/cli-extension-dep-graph",
+		false,
+	)
 
 	assert.NoError(t, err)
 	assert.Equal(t, 2, len(depsResp))
@@ -50,6 +52,52 @@ func Test_SBOMConvert(t *testing.T) {
 	assert.Equal(t, "warning", warnResp[0].Type)
 	assert.Equal(t, "pkg:maven/org.example/artifact@1.0.0", warnResp[0].BOMRef)
 	assert.Equal(t, "This is a warning", warnResp[0].Msg)
+}
+
+func Test_SBOMConvert_ForceSingleGraph_True(t *testing.T) {
+	response := mocks.NewMockResponse(
+		"application/json; charset=utf-8",
+		[]byte(`{"scanResults":[],"warnings":[]}`),
+		http.StatusOK,
+	)
+
+	mockHTTPClient := mocks.NewMockSBOMService(response, func(r *http.Request) {
+		assert.Contains(t, r.RequestURI, "force_single_graph=true")
+	})
+
+	client := snykclient.NewSnykClient(mockHTTPClient.Client(), mockHTTPClient.URL, "org1")
+	_, _, err := client.SBOMConvert(
+		context.Background(),
+		logger,
+		bytes.NewBufferString(`{"foo":"bar"}`),
+		"github.com/snyk/cli-extension-dep-graph",
+		true,
+	)
+
+	assert.NoError(t, err)
+}
+
+func Test_SBOMConvert_ForceSingleGraph_False(t *testing.T) {
+	response := mocks.NewMockResponse(
+		"application/json; charset=utf-8",
+		[]byte(`{"scanResults":[],"warnings":[]}`),
+		http.StatusOK,
+	)
+
+	mockHTTPClient := mocks.NewMockSBOMService(response, func(r *http.Request) {
+		assert.NotContains(t, r.RequestURI, "force_single_graph")
+	})
+
+	client := snykclient.NewSnykClient(mockHTTPClient.Client(), mockHTTPClient.URL, "org1")
+	_, _, err := client.SBOMConvert(
+		context.Background(),
+		logger,
+		bytes.NewBufferString(`{"foo":"bar"}`),
+		"github.com/snyk/cli-extension-dep-graph",
+		false,
+	)
+
+	assert.NoError(t, err)
 }
 
 func Test_SBOMConvert_InvalidJSONReturned(t *testing.T) {
@@ -66,7 +114,9 @@ func Test_SBOMConvert_InvalidJSONReturned(t *testing.T) {
 		context.Background(),
 		logger,
 		strings.NewReader(`{"foo":"bar"}`),
-		"github.com/snyk/cli-extension-dep-graph")
+		"github.com/snyk/cli-extension-dep-graph",
+		false,
+	)
 
 	assert.ErrorContains(t, err, "unexpected EOF")
 }
@@ -111,7 +161,9 @@ func Test_SBOMConvert_ServerErrors(t *testing.T) {
 				context.Background(),
 				logger,
 				bytes.NewBufferString(sbomContent),
-				"github.com/snyk/cli-extension-dep-graph")
+				"github.com/snyk/cli-extension-dep-graph",
+				false,
+			)
 
 			assert.ErrorContainsf(
 				t,

--- a/internal/uv/uv_plugin.go
+++ b/internal/uv/uv_plugin.go
@@ -117,6 +117,7 @@ func (p Plugin) buildFindings(
 		p.snykClient,
 		log,
 		p.remoteRepoURL,
+		options.ForceSingleGraph,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert sbom to dep-graphs for %s: %w", lockFilePath, err)

--- a/pkg/depgraph/flags.go
+++ b/pkg/depgraph/flags.go
@@ -40,6 +40,7 @@ const (
 	FlagDotnetRuntimeResolution       = "dotnet-runtime-resolution"
 	FlagDotnetTargetFramework         = "dotnet-target-framework"
 	FlagUvWorkspacePackages           = "internal-uv-workspace-packages"
+	FlagForceSingleGraph              = "force-single-graph"
 )
 
 func getFlagSet() *pflag.FlagSet {
@@ -80,6 +81,7 @@ func getFlagSet() *pflag.FlagSet {
 		"Optional. You may use this option if your solution contains multiple <TargetFramework> directives. "+
 			"If you do not specify the option --dotnet-target-framework, all supported Target Frameworks will be scanned.")
 	flagSet.Bool(FlagUvWorkspacePackages, false, "Include all uv workspace packages in the dependency graph output")
+	flagSet.Bool(FlagForceSingleGraph, false, "Prevent splitting the dependency graph within an ecosystem.")
 
 	return flagSet
 }

--- a/pkg/depgraph/sbom_resolution.go
+++ b/pkg/depgraph/sbom_resolution.go
@@ -81,6 +81,7 @@ func handleSBOMResolutionDI(
 	allowOutOfSync := !strictOutOfSync
 	exclude := parseExcludeFlag(config.GetString(FlagExclude))
 	failFast := config.GetBool(FlagFailFast)
+	forceSingleGraph := config.GetBool(FlagForceSingleGraph)
 	pluginOptions := scaplugin.Options{
 		AllProjects:         allProjects,
 		UvWorkspacePackages: uvWorkspacePackages,
@@ -89,6 +90,7 @@ func handleSBOMResolutionDI(
 		Exclude:             exclude,
 		FailFast:            failFast,
 		AllowOutOfSync:      allowOutOfSync,
+		ForceSingleGraph:    forceSingleGraph,
 	}
 
 	// Generate Findings

--- a/pkg/scaplugin/interface.go
+++ b/pkg/scaplugin/interface.go
@@ -16,6 +16,7 @@ type Options struct {
 	Exclude             []string
 	FailFast            bool
 	AllowOutOfSync      bool
+	ForceSingleGraph    bool
 }
 
 type Metadata struct {


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Adds a `force-single-graph` flag that, when set, passes `force_single_graph=true` as a query parameter to the sbom-test `/sboms/convert` endpoint. This prevents the backend from splitting the dep-graph within an ecosystem, producing one graph per ecosystem instead of multiple.