### PR TITLE
fix: processedFiles correctly uses files from both pip plugins

### DIFF
--- a/pkg/ecosystems/orchestrator/orchestrator.go
+++ b/pkg/ecosystems/orchestrator/orchestrator.go
@@ -67,7 +67,7 @@ func resolvePython(ctx context.Context, enhancedLogger *zerolog.Logger, dir stri
 
 	result.Results = append(result.Results, pipResults.Results...)
 	result.Results = append(result.Results, pipenvResults.Results...)
-	result.ProcessedFiles = append(result.ProcessedFiles, pipenvResults.ProcessedFiles...)
+	result.ProcessedFiles = append(result.ProcessedFiles, pipResults.ProcessedFiles...)
 	result.ProcessedFiles = append(result.ProcessedFiles, pipenvResults.ProcessedFiles...)
 
 	return result


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Small fix to properly process processedFiles