### PR TITLE
chore: update codeowners [PRODSEC-10215]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 * @snyk/unify @snyk/codesec_unify @snyk/open-source_composition-analysis 
 
 /pkg/ecosystems/ @snyk/open-source_composition-analysis 
-/pkg/depgraph @snyk/unify @snyk/codesec_unify 
-/pkg/sca_plugin @snyk/unify @snyk/codesec_unify 
+/pkg/depgraph @snyk/unify @snyk/codesec_unify @snyk/open-source_unify 
+/pkg/sca_plugin @snyk/unify @snyk/codesec_unify @snyk/open-source_unify 


### PR DESCRIPTION
Updates codeowners to append the new github governance managed teams.
For more information, please check:
- https://snyksec.atlassian.net/wiki/spaces/PRODSEC/pages/4613570586/Updates+to+CODEOWNERS+and+repository+collaborators+to+match+organisation+change
[!IMPORTANT]:
If this service relies on vervet, you will need to run a command to regenerate the spec (e.g. `make generate`) before merging it.
The best option is to:
- checkout the branch `update-ownership-PRODSEC-10215-IZAh`
- run the command
- commit and push the results to this PR before you approve and merge it.