### PR TITLE
feat: set target file for identity

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
-* @snyk/unify @snyk/codesec_unify @snyk/os-managed
+* @snyk/unify @snyk/codesec_unify @snyk/open-source_composition-analysis
 
-/pkg/ecosystems/ @snyk/os-managed
+/pkg/ecosystems/ @snyk/open-source_composition-analysis
 /pkg/depgraph @snyk/unify @snyk/codesec_unify 
 /pkg/sca_plugin @snyk/unify @snyk/codesec_unify 

--- a/pkg/depgraph/legacy_resolution.go
+++ b/pkg/depgraph/legacy_resolution.go
@@ -58,7 +58,8 @@ func chooseGraphArgument(config configuration.Configuration) (string, parsers.Ou
 
 func mapToWorkflowData(depGraphs []parsers.DepGraphOutput, logger *zerolog.Logger) []workflow.Data {
 	depGraphList := make([]workflow.Data, 0, len(depGraphs))
-	for _, depGraph := range depGraphs {
+	for i := range depGraphs {
+		depGraph := &depGraphs[i]
 		data := workflow.NewData(DataTypeID, contentTypeJSON, depGraph.DepGraph)
 		data.SetMetaData(contentLocationKey, depGraph.NormalisedTargetFile)
 		data.SetMetaData(MetaKeyNormalisedTargetFile, depGraph.NormalisedTargetFile)

--- a/pkg/depgraph/parsers/depgraph_output.go
+++ b/pkg/depgraph/parsers/depgraph_output.go
@@ -7,5 +7,6 @@ type DepGraphOutput struct {
 	TargetRuntime        *string
 	Target               []byte
 	DepGraph             []byte
+	Workspace            []byte
 	Error                []byte
 }

--- a/pkg/depgraph/parsers/jsonl_output_parser.go
+++ b/pkg/depgraph/parsers/jsonl_output_parser.go
@@ -24,6 +24,7 @@ type jsonLine struct {
 	TargetRuntime        *string         `json:"targetRuntime"`
 	Target               json.RawMessage `json:"target"`
 	Error                json.RawMessage `json:"error"`
+	Workspace            json.RawMessage `json:"workspace"`
 }
 
 // ParseOutput parses JSONL formatted dependency graph output.
@@ -50,6 +51,7 @@ func (j *JSONLOutputParser) ParseOutput(data []byte) ([]DepGraphOutput, error) {
 			Target:               parsed.Target,
 			TargetRuntime:        parsed.TargetRuntime,
 			DepGraph:             parsed.DepGraph,
+			Workspace:            parsed.Workspace,
 			Error:                parsed.Error,
 		})
 	}

--- a/pkg/ecosystems/options.go
+++ b/pkg/ecosystems/options.go
@@ -25,6 +25,7 @@ type GlobalOptions struct {
 	AllowOutOfSync                bool                 // Derived from --strict-out-of-sync (inverted); parsed in NewPluginOptionsFromRawFlags.
 	ForceSingleGraph              bool                 `arg:"--force-single-graph"`
 	ForceIncludeWorkspacePackages bool                 `arg:"--internal-uv-workspace-packages"`
+	ProjectName                   *string              `arg:"--project-name"`
 	RawFlags                      []string
 }
 

--- a/pkg/ecosystems/options.go
+++ b/pkg/ecosystems/options.go
@@ -123,3 +123,8 @@ func (o *SCAPluginOptions) WithForceIncludeWorkspacePackages(forceIncludeWorkspa
 	o.Global.ForceIncludeWorkspacePackages = forceIncludeWorkspacePackages
 	return o
 }
+
+func (o *SCAPluginOptions) WithProjectName(projectName string) *SCAPluginOptions {
+	o.Global.ProjectName = &projectName
+	return o
+}

--- a/pkg/ecosystems/orchestrator/orchestrator.go
+++ b/pkg/ecosystems/orchestrator/orchestrator.go
@@ -236,3 +236,29 @@ func depGraphOutputToSCAResult(output *parsers.DepGraphOutput, ictx workflow.Inv
 
 	return result, nil
 }
+
+// getProjectTargetFileBasedOnType determines if a plugin sets targetFile based on package manager type.
+// Plugin audit: https://snyksec.atlassian.net/wiki/spaces/TOE1/pages/4651909131/Plugin+Audit
+func getProjectTargetFileBasedOnType(projectType, file string) *string {
+	switch projectType {
+	case "pip":
+		// snyk-python-plugin sets targetFile for Pipfile and setup.py, but not for requirements.txt
+		if strings.HasSuffix(file, "requirements.txt") {
+			return nil
+		}
+		return &file
+	case "gradle":
+		// snyk-gradle-plugin sets targetFile for build.gradle.kts but not for build.gradle
+		if strings.HasSuffix(file, "build.gradle.kts") {
+			return &file
+		}
+		return nil
+	case "poetry", "gomodules", "golangdep", "nuget", "paket", "composer", "cocoapods", "hex", "swift":
+		// These plugins set relative path to provided targetFile
+		return &file
+	case "npm", "yarn", "pnpm", "maven", "sbt", "rubygems":
+		// These plugins do not set plugin.targetFile
+		return nil
+	}
+	return nil
+}

--- a/pkg/ecosystems/orchestrator/orchestrator.go
+++ b/pkg/ecosystems/orchestrator/orchestrator.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"path"
 	"strings"
 
 	"github.com/rs/zerolog"
@@ -84,6 +85,11 @@ func LegacyFallback(
 	options ecosystems.SCAPluginOptions,
 	processedFiles []string,
 ) ([]ecosystems.SCAResult, error) {
+	// if we already processed files, and we're not in all-projects mode, we can skip the fallback
+	if len(processedFiles) > 0 && !options.Global.AllProjects {
+		return nil, nil
+	}
+
 	log := ictx.GetEnhancedLogger()
 	config := ictx.GetConfiguration()
 	engine := ictx.GetEngine()
@@ -229,6 +235,7 @@ func depGraphOutputToSCAResult(output *parsers.DepGraphOutput, ictx workflow.Inv
 
 		if dg.PkgManager.Name != "" {
 			result.ProjectDescriptor.Identity.Type = dg.PkgManager.Name
+			result.ProjectDescriptor.Identity.TargetFile = getProjectTargetFileBasedOnType(dg.PkgManager.Name, output.NormalisedTargetFile, output.Workspace != nil)
 			// Extract runtime from depgraph if available
 			result.ProjectDescriptor.Identity.TargetRuntime = output.TargetRuntime
 		}
@@ -238,25 +245,31 @@ func depGraphOutputToSCAResult(output *parsers.DepGraphOutput, ictx workflow.Inv
 }
 
 // getProjectTargetFileBasedOnType determines if a plugin sets targetFile based on package manager type.
-// Plugin audit: https://snyksec.atlassian.net/wiki/spaces/TOE1/pages/4651909131/Plugin+Audit
-func getProjectTargetFileBasedOnType(projectType, file string) *string {
+func getProjectTargetFileBasedOnType(projectType, file string, isWorkspace bool) *string {
 	switch projectType {
 	case "pip":
+		_, fileName := path.Split(file)
 		// snyk-python-plugin sets targetFile for Pipfile and setup.py, but not for requirements.txt
-		if strings.HasSuffix(file, "requirements.txt") {
+		if strings.HasSuffix(fileName, "requirements.txt") {
 			return nil
 		}
 		return &file
 	case "gradle":
+		_, fileName := path.Split(file)
 		// snyk-gradle-plugin sets targetFile for build.gradle.kts but not for build.gradle
-		if strings.HasSuffix(file, "build.gradle.kts") {
+		if strings.HasSuffix(fileName, "build.gradle.kts") {
 			return &file
 		}
 		return nil
 	case "poetry", "gomodules", "golangdep", "nuget", "paket", "composer", "cocoapods", "hex", "swift":
 		// These plugins set relative path to provided targetFile
 		return &file
-	case "npm", "yarn", "pnpm", "maven", "sbt", "rubygems":
+	case "npm", "yarn", "pnpm":
+		if isWorkspace {
+			return &file
+		}
+		return nil
+	case "maven", "sbt", "rubygems":
 		// These plugins do not set plugin.targetFile
 		return nil
 	}

--- a/pkg/ecosystems/orchestrator/orchestrator_test.go
+++ b/pkg/ecosystems/orchestrator/orchestrator_test.go
@@ -15,31 +15,7 @@ import (
 )
 
 func TestLegacyFallback_MapsProjectType(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	ictx := gafmocks.NewMockInvocationContext(ctrl)
-	engine := gafmocks.NewMockEngine(ctrl)
-	cfg := configuration.New()
-	logger := zerolog.Nop()
-
-	opts := ecosystems.NewPluginOptions()
-
-	ictx.EXPECT().GetConfiguration().Return(cfg).AnyTimes()
-	ictx.EXPECT().GetEngine().Return(engine).AnyTimes()
-	ictx.EXPECT().GetEnhancedLogger().Return(&logger).AnyTimes()
-
-	engine.EXPECT().
-		InvokeWithConfig(gomock.Any(), gomock.Any()).
-		Return(
-			[]workflow.Data{
-				workflow.NewData(
-					workflow.NewTypeIdentifier(legacyCLIWorkflowID, "application/text"),
-					"application/text",
-					[]byte(`{"depGraph":{"pkgManager":{"name":"npm"}},"normalisedTargetFile":"package.json","targetFileFromPlugin":"package.json","target":{}}`)),
-			},
-			nil)
-
-	results, err := LegacyFallback(ictx, *opts, nil)
-
+	results, err := runLegacyFallback(t, `{"depGraph":{"pkgManager":{"name":"npm"}},"normalisedTargetFile":"package.json","targetFileFromPlugin":"package.json","target":{}}`) //nolint:lll // This is fine.
 	require.NoError(t, err)
 	require.Len(t, results, 1)
 
@@ -47,6 +23,119 @@ func TestLegacyFallback_MapsProjectType(t *testing.T) {
 }
 
 func TestLegacyFallback_MapsTargetFramework(t *testing.T) {
+	results, err := runLegacyFallback(t, `{"depGraph":{"pkgManager":{"name":"nuget"}},"normalisedTargetFile":"project.assets.json","targetFileFromPlugin":"project.assets.json","target":{},"targetRuntime":"net6.0"}`) //nolint:lll // This is fine.
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	assert.Equal(t, "net6.0", *results[0].ProjectDescriptor.Identity.TargetRuntime)
+}
+
+func TestLegacyFallback_MapsTargetFile(t *testing.T) {
+	tests := map[string]struct {
+		body               string
+		expectedTargetFile string
+	}{
+		"npm": {
+			body: `{"depGraph":{"pkgManager":{"name":"npm"}},"normalisedTargetFile":"package-lock.json","target":{}}`,
+		},
+		"npm workspaces": {
+			body:               `{"depGraph":{"pkgManager":{"name":"npm"}},"normalisedTargetFile":"package-lock.json","target":{},"workspace":{}}`,
+			expectedTargetFile: "package-lock.json",
+		},
+		"yarn": {
+			body: `{"depGraph":{"pkgManager":{"name":"yarn"}},"normalisedTargetFile":"yarn.lock","target":{}}`,
+		},
+		"yarn workspaces": {
+			body:               `{"depGraph":{"pkgManager":{"name":"yarn"}},"normalisedTargetFile":"yarn.lock","target":{},"workspace":{}}`,
+			expectedTargetFile: "yarn.lock",
+		},
+		"pnpm": {
+			body: `{"depGraph":{"pkgManager":{"name":"pnpm"}},"normalisedTargetFile":"pnpm.lock","target":{}}`,
+		},
+		"pnpm workspaces": {
+			body:               `{"depGraph":{"pkgManager":{"name":"pnpm"}},"normalisedTargetFile":"pnpm.lock","target":{},"workspace":{}}`,
+			expectedTargetFile: "pnpm.lock",
+		},
+		"pip requirements.txt": {
+			body: `{"depGraph":{"pkgManager":{"name":"pip"}},"normalisedTargetFile":"requirements.txt","target":{}}`,
+		},
+		"pip pipfile": {
+			body:               `{"depGraph":{"pkgManager":{"name":"pip"}},"normalisedTargetFile":"Pipfile","target":{}}`,
+			expectedTargetFile: "Pipfile",
+		},
+		"pip setup.py": {
+			body:               `{"depGraph":{"pkgManager":{"name":"pip"}},"normalisedTargetFile":"setup.py","target":{}}`,
+			expectedTargetFile: "setup.py",
+		},
+		"gradle": {
+			body: `{"depGraph":{"pkgManager":{"name":"gradle"}},"normalisedTargetFile":"build.gradle","target":{}}`,
+		},
+		"gradle build.gradle.kts": {
+			body:               `{"depGraph":{"pkgManager":{"name":"gradle"}},"normalisedTargetFile":"build.gradle.kts","target":{}}`,
+			expectedTargetFile: "build.gradle.kts",
+		},
+		"poetry": {
+			body:               `{"depGraph":{"pkgManager":{"name":"poetry"}},"normalisedTargetFile":"poetry.lock","target":{}}`,
+			expectedTargetFile: "poetry.lock",
+		},
+		"gomodules": {
+			body:               `{"depGraph":{"pkgManager":{"name":"gomodules"}},"normalisedTargetFile":"go.mod","target":{}}`,
+			expectedTargetFile: "go.mod",
+		},
+		"golangdep": {
+			body:               `{"depGraph":{"pkgManager":{"name":"golangdep"}},"normalisedTargetFile":"Gopkg.lock","target":{}}`,
+			expectedTargetFile: "Gopkg.lock",
+		},
+		"nuget": {
+			body:               `{"depGraph":{"pkgManager":{"name":"nuget"}},"normalisedTargetFile":"project.assets.json","target":{}}`,
+			expectedTargetFile: "project.assets.json",
+		},
+		"paket": {
+			body:               `{"depGraph":{"pkgManager":{"name":"paket"}},"normalisedTargetFile":"paket.lock","target":{}}`,
+			expectedTargetFile: "paket.lock",
+		},
+		"composer": {
+			body:               `{"depGraph":{"pkgManager":{"name":"composer"}},"normalisedTargetFile":"composer.lock","target":{}}`,
+			expectedTargetFile: "composer.lock",
+		},
+		"cocoapods": {
+			body:               `{"depGraph":{"pkgManager":{"name":"cocoapods"}},"normalisedTargetFile":"Podfile.lock","target":{}}`,
+			expectedTargetFile: "Podfile.lock",
+		},
+		"hex": {
+			body:               `{"depGraph":{"pkgManager":{"name":"hex"}},"normalisedTargetFile":"mix.lock","target":{}}`,
+			expectedTargetFile: "mix.lock",
+		},
+		"swift": {
+			body:               `{"depGraph":{"pkgManager":{"name":"swift"}},"normalisedTargetFile":"Package.swift","target":{}}`,
+			expectedTargetFile: "Package.swift",
+		},
+		"maven": {
+			body: `{"depGraph":{"pkgManager":{"name":"maven"}},"normalisedTargetFile":"pom.xml","target":{}}`,
+		},
+		"sbt": {
+			body: `{"depGraph":{"pkgManager":{"name":"sbt"}},"normalisedTargetFile":"build.sbt","target":{}}`,
+		},
+		"rubygems": {
+			body: `{"depGraph":{"pkgManager":{"name":"rubygems"}},"normalisedTargetFile":"Gemfile.lock","target":{}}`,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			results, err := runLegacyFallback(t, test.body)
+
+			require.NoError(t, err)
+			require.Len(t, results, 1)
+
+			assert.Equal(t, test.expectedTargetFile, results[0].ProjectDescriptor.GetTargetFile())
+		})
+	}
+}
+
+func runLegacyFallback(t *testing.T, testBody string) ([]ecosystems.SCAResult, error) {
+	t.Helper()
+
 	ctrl := gomock.NewController(t)
 	ictx := gafmocks.NewMockInvocationContext(ctrl)
 	engine := gafmocks.NewMockEngine(ctrl)
@@ -66,14 +155,9 @@ func TestLegacyFallback_MapsTargetFramework(t *testing.T) {
 				workflow.NewData(
 					workflow.NewTypeIdentifier(legacyCLIWorkflowID, "application/text"),
 					"application/text",
-					[]byte(`{"depGraph":{"pkgManager":{"name":"nuget"}},"normalisedTargetFile":"project.assets.json","targetFileFromPlugin":"project.assets.json","target":{},"targetRuntime":"net6.0"}`)), //nolint:lll // This is fine.
+					[]byte(testBody)),
 			},
 			nil)
 
-	results, err := LegacyFallback(ictx, *opts, nil)
-
-	require.NoError(t, err)
-	require.Len(t, results, 1)
-
-	assert.Equal(t, "net6.0", *results[0].ProjectDescriptor.Identity.TargetRuntime)
+	return LegacyFallback(ictx, *opts, nil)
 }

--- a/pkg/ecosystems/python/pip/depgraph.go
+++ b/pkg/ecosystems/python/pip/depgraph.go
@@ -65,7 +65,8 @@ func getNodeID(item *InstallItem) string {
 // ToDependencyGraph converts a pip install Report into a DepGraph using the dep-graph builder.
 // The root node represents the project and points to all direct dependencies.
 // The pkgManager parameter specifies the package manager name (e.g., PkgManagerPip, PkgManagerPipenv).
-func (r *Report) ToDependencyGraph(ctx context.Context, log logger.Logger, pkgManager PkgManagerName) (*depgraph.DepGraph, error) {
+// The projectName parameter sets the root package name (defaults to "root" if empty).
+func (r *Report) ToDependencyGraph(ctx context.Context, log logger.Logger, pkgManager PkgManagerName, projectName string) (*depgraph.DepGraph, error) {
 	if r == nil {
 		return nil, fmt.Errorf("report cannot be nil")
 	}
@@ -73,10 +74,15 @@ func (r *Report) ToDependencyGraph(ctx context.Context, log logger.Logger, pkgMa
 	numPackages := len(r.Install)
 	log.Debug(ctx, "Converting pip report to dependency graph", logger.Attr("total_packages", numPackages))
 
+	// Use provided project name or default to "root"
+	if projectName == "" {
+		projectName = "root"
+	}
+
 	// Create a builder with the specified package manager and a root package
 	builder, err := depgraph.NewBuilder(
 		&depgraph.PkgManager{Name: pkgManager.String()},
-		&depgraph.PkgInfo{Name: "root", Version: "0.0.0"},
+		&depgraph.PkgInfo{Name: projectName, Version: "0.0.0"},
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create depgraph builder: %w", err)

--- a/pkg/ecosystems/python/pip/depgraph_test.go
+++ b/pkg/ecosystems/python/pip/depgraph_test.go
@@ -73,7 +73,7 @@ func TestReport_ToDependencyGraph(t *testing.T) {
 			},
 		}
 
-		dg, err := report.ToDependencyGraph(context.Background(), logger.Nop(), PkgManagerPip)
+		dg, err := report.ToDependencyGraph(context.Background(), logger.Nop(), PkgManagerPip, "")
 		require.NoError(t, err)
 		require.NotNil(t, dg)
 
@@ -137,7 +137,7 @@ func TestReport_ToDependencyGraph(t *testing.T) {
 			},
 		}
 
-		dg, err := report.ToDependencyGraph(context.Background(), logger.Nop(), PkgManagerPip)
+		dg, err := report.ToDependencyGraph(context.Background(), logger.Nop(), PkgManagerPip, "")
 		require.NoError(t, err)
 		require.NotNil(t, dg)
 
@@ -183,7 +183,7 @@ func TestReport_ToDependencyGraph(t *testing.T) {
 			},
 		}
 
-		dg, err := report.ToDependencyGraph(context.Background(), logger.Nop(), PkgManagerPip)
+		dg, err := report.ToDependencyGraph(context.Background(), logger.Nop(), PkgManagerPip, "")
 		require.NoError(t, err)
 		require.NotNil(t, dg)
 
@@ -199,7 +199,7 @@ func TestReport_ToDependencyGraph(t *testing.T) {
 			Install: []InstallItem{},
 		}
 
-		dg, err := report.ToDependencyGraph(context.Background(), logger.Nop(), PkgManagerPip)
+		dg, err := report.ToDependencyGraph(context.Background(), logger.Nop(), PkgManagerPip, "")
 		require.NoError(t, err)
 		require.NotNil(t, dg)
 
@@ -210,7 +210,7 @@ func TestReport_ToDependencyGraph(t *testing.T) {
 
 	t.Run("nil report", func(t *testing.T) {
 		var report *Report
-		_, err := report.ToDependencyGraph(context.Background(), logger.Nop(), PkgManagerPip)
+		_, err := report.ToDependencyGraph(context.Background(), logger.Nop(), PkgManagerPip, "")
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "cannot be nil")
 	})
@@ -268,7 +268,7 @@ func TestReport_ToDependencyGraph(t *testing.T) {
 			},
 		}
 
-		dg, err := report.ToDependencyGraph(context.Background(), logger.Nop(), PkgManagerPip)
+		dg, err := report.ToDependencyGraph(context.Background(), logger.Nop(), PkgManagerPip, "")
 		require.NoError(t, err)
 		require.NotNil(t, dg)
 
@@ -330,7 +330,7 @@ func TestReport_ToDependencyGraph(t *testing.T) {
 			},
 		}
 
-		dg, err := report.ToDependencyGraph(context.Background(), logger.Nop(), PkgManagerPip)
+		dg, err := report.ToDependencyGraph(context.Background(), logger.Nop(), PkgManagerPip, "")
 		require.NoError(t, err)
 		require.NotNil(t, dg)
 
@@ -388,7 +388,7 @@ func TestToDependencyGraph_PruningBehavior(t *testing.T) {
 			},
 		}
 
-		dg, err := report.ToDependencyGraph(context.Background(), logger.Nop(), PkgManagerPip)
+		dg, err := report.ToDependencyGraph(context.Background(), logger.Nop(), PkgManagerPip, "")
 		require.NoError(t, err)
 
 		// Find pkg-a's deps
@@ -452,7 +452,7 @@ func TestToDependencyGraph_PruningBehavior(t *testing.T) {
 			},
 		}
 
-		dg, err := report.ToDependencyGraph(context.Background(), logger.Nop(), PkgManagerPip)
+		dg, err := report.ToDependencyGraph(context.Background(), logger.Nop(), PkgManagerPip, "")
 		require.NoError(t, err)
 
 		// Find pkg-a and pkg-b deps
@@ -515,7 +515,7 @@ func TestToDependencyGraph_PruningBehavior(t *testing.T) {
 			},
 		}
 
-		dg, err := report.ToDependencyGraph(context.Background(), logger.Nop(), PkgManagerPip)
+		dg, err := report.ToDependencyGraph(context.Background(), logger.Nop(), PkgManagerPip, "")
 		require.NoError(t, err)
 
 		// Find pkg-c's deps - should only have ONE pkg-d, not duplicated

--- a/pkg/ecosystems/python/pip/plugin.go
+++ b/pkg/ecosystems/python/pip/plugin.go
@@ -66,8 +66,8 @@ func (p Plugin) BuildDepGraphsFromDir(
 
 	for _, file := range files {
 		g.Go(func() error {
-			projectName := GetProjectName(file.RelPath, dir, options)
-			result, err := p.buildDepGraphFromFile(ctx, log, file, pythonVersion, options.Python.NoBuildIsolation, projectName)
+			projectName := GetProjectName(file.RelPath, dir)
+			result, err := p.buildDepGraphFromFile(ctx, log, file, pythonVersion, options.Python.NoBuildIsolation, projectName, options.Global.ProjectName)
 			if err != nil {
 				attrs := []logger.Field{
 					logger.Attr(logFieldFile, file.RelPath),
@@ -84,7 +84,8 @@ func (p Plugin) BuildDepGraphsFromDir(
 				result = ecosystems.SCAResult{
 					ProjectDescriptor: identity.ProjectDescriptor{
 						Identity: identity.ProjectIdentity{
-							Type: "pip",
+							Type:             "pip",
+							BaseNameOverride: options.Global.ProjectName,
 						},
 					},
 					Error: err,
@@ -144,18 +145,12 @@ func (p Plugin) discoverRequirementsFiles(ctx context.Context, dir string, optio
 	return files, nil
 }
 
-// GetProjectName determines the project name based on the file path and options.
-// If --project-name is set, it uses that. Otherwise, it uses the directory name
-// containing the file. For example:
+// GetProjectName determines the project name based on the file path.
+// It uses the directory name containing the file. For example:
 //   - "project/test/requirements.txt" -> "test"
 //   - "project/requirements.txt" -> "project"
 //   - "requirements.txt" (with scanDir="/path/to/myproject") -> "myproject"
-func GetProjectName(filePath, scanDir string, options *ecosystems.SCAPluginOptions) string {
-	// If --project-name is explicitly set, use it
-	if options.Global.ProjectName != nil && *options.Global.ProjectName != "" {
-		return *options.Global.ProjectName
-	}
-
+func GetProjectName(filePath, scanDir string) string {
 	// Extract the directory name from the file path
 	dir := filepath.Dir(filePath)
 	projectName := filepath.Base(dir)
@@ -176,6 +171,7 @@ func (p Plugin) buildDepGraphFromFile(
 	pythonVersion string,
 	noBuildIsolation bool,
 	projectName string,
+	baseNameOverride *string,
 ) (ecosystems.SCAResult, error) {
 	log.Debug(ctx, "Building dependency graph",
 		logger.Attr(logFieldFile, file.RelPath),
@@ -201,7 +197,8 @@ func (p Plugin) buildDepGraphFromFile(
 		DepGraph: depGraph,
 		ProjectDescriptor: identity.ProjectDescriptor{
 			Identity: identity.ProjectIdentity{
-				Type: "pip",
+				Type:             "pip",
+				BaseNameOverride: baseNameOverride,
 			},
 		},
 	}, nil

--- a/pkg/ecosystems/python/pip/plugin.go
+++ b/pkg/ecosystems/python/pip/plugin.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"sync"
 
@@ -65,7 +66,8 @@ func (p Plugin) BuildDepGraphsFromDir(
 
 	for _, file := range files {
 		g.Go(func() error {
-			result, err := p.buildDepGraphFromFile(ctx, log, file, pythonVersion, options.Python.NoBuildIsolation)
+			projectName := GetProjectName(file.RelPath, dir, options)
+			result, err := p.buildDepGraphFromFile(ctx, log, file, pythonVersion, options.Python.NoBuildIsolation, projectName)
 			if err != nil {
 				attrs := []logger.Field{
 					logger.Attr(logFieldFile, file.RelPath),
@@ -82,8 +84,7 @@ func (p Plugin) BuildDepGraphsFromDir(
 				result = ecosystems.SCAResult{
 					ProjectDescriptor: identity.ProjectDescriptor{
 						Identity: identity.ProjectIdentity{
-							Type:       "pip",
-							TargetFile: &file.RelPath,
+							Type: "pip",
 						},
 					},
 					Error: err,
@@ -101,9 +102,9 @@ func (p Plugin) BuildDepGraphsFromDir(
 		return nil, fmt.Errorf("error building dependency graphs: %w", err)
 	}
 
-	processedFiles := make([]string, 0, len(results))
-	for _, result := range results {
-		processedFiles = append(processedFiles, result.ProjectDescriptor.GetTargetFile())
+	processedFiles := make([]string, 0, len(files))
+	for _, file := range files {
+		processedFiles = append(processedFiles, file.RelPath)
 	}
 
 	return &ecosystems.PluginResult{
@@ -143,6 +144,30 @@ func (p Plugin) discoverRequirementsFiles(ctx context.Context, dir string, optio
 	return files, nil
 }
 
+// GetProjectName determines the project name based on the file path and options.
+// If --project-name is set, it uses that. Otherwise, it uses the directory name
+// containing the file. For example:
+//   - "project/test/requirements.txt" -> "test"
+//   - "project/requirements.txt" -> "project"
+//   - "requirements.txt" (with scanDir="/path/to/myproject") -> "myproject"
+func GetProjectName(filePath, scanDir string, options *ecosystems.SCAPluginOptions) string {
+	// If --project-name is explicitly set, use it
+	if options.Global.ProjectName != nil && *options.Global.ProjectName != "" {
+		return *options.Global.ProjectName
+	}
+
+	// Extract the directory name from the file path
+	dir := filepath.Dir(filePath)
+	projectName := filepath.Base(dir)
+
+	// If we're at the root or the directory name is ".", use the scan directory name
+	if projectName == "." || projectName == "/" || projectName == "" {
+		return filepath.Base(scanDir)
+	}
+
+	return projectName
+}
+
 // buildDepGraphFromFile builds a dependency graph from a requirements.txt file.
 func (p Plugin) buildDepGraphFromFile(
 	ctx context.Context,
@@ -150,10 +175,12 @@ func (p Plugin) buildDepGraphFromFile(
 	file discovery.FindResult,
 	pythonVersion string,
 	noBuildIsolation bool,
+	projectName string,
 ) (ecosystems.SCAResult, error) {
 	log.Debug(ctx, "Building dependency graph",
 		logger.Attr(logFieldFile, file.RelPath),
-		logger.Attr("python_version", pythonVersion))
+		logger.Attr("python_version", pythonVersion),
+		logger.Attr("project_name", projectName))
 
 	// Get pip install report (dry-run, no actual installation)
 	report, err := GetInstallReport(ctx, log, file.Path, noBuildIsolation)
@@ -162,7 +189,7 @@ func (p Plugin) buildDepGraphFromFile(
 	}
 
 	// Convert report to dependency graph
-	depGraph, err := report.ToDependencyGraph(ctx, log, PkgManagerPip)
+	depGraph, err := report.ToDependencyGraph(ctx, log, PkgManagerPip, projectName)
 	if err != nil {
 		return ecosystems.SCAResult{}, fmt.Errorf("failed to convert pip report to dependency graph for %s: %w", file.RelPath, err)
 	}
@@ -174,8 +201,7 @@ func (p Plugin) buildDepGraphFromFile(
 		DepGraph: depGraph,
 		ProjectDescriptor: identity.ProjectDescriptor{
 			Identity: identity.ProjectIdentity{
-				Type:       "pip",
-				TargetFile: &file.RelPath,
+				Type: "pip",
 			},
 		},
 	}, nil

--- a/pkg/ecosystems/python/pip/plugin_integration_test.go
+++ b/pkg/ecosystems/python/pip/plugin_integration_test.go
@@ -157,7 +157,6 @@ func TestPlugin_BuildDepGraphsFromDir_PipErrors(t *testing.T) {
 			pipResult := result.Results[0]
 
 			// Basic metadata expectations
-			assert.Equal(t, "requirements.txt", pipResult.ProjectDescriptor.GetTargetFile())
 			if pythonVersion != "" && pipResult.ProjectDescriptor.Identity.TargetRuntime != nil {
 				assert.Contains(t, *pipResult.ProjectDescriptor.Identity.TargetRuntime, fmt.Sprintf("python@%s", pythonVersion))
 			}
@@ -234,13 +233,13 @@ func assertResultsMatchExpected(t *testing.T, actual, expected []ecosystems.SCAR
 	sortActual := make([]ecosystems.SCAResult, len(actual))
 	copy(sortActual, actual)
 	sort.Slice(sortActual, func(i, j int) bool {
-		return sortActual[i].ProjectDescriptor.GetTargetFile() < sortActual[j].ProjectDescriptor.GetTargetFile()
+		return sortActual[i].DepGraph.GetRootPkg().Info.Name < sortActual[j].DepGraph.GetRootPkg().Info.Name
 	})
 
 	sortExpected := make([]ecosystems.SCAResult, len(expected))
 	copy(sortExpected, expected)
 	sort.Slice(sortExpected, func(i, j int) bool {
-		return sortExpected[i].ProjectDescriptor.GetTargetFile() < sortExpected[j].ProjectDescriptor.GetTargetFile()
+		return sortExpected[i].DepGraph.GetRootPkg().Info.Name < sortExpected[j].DepGraph.GetRootPkg().Info.Name
 	})
 
 	// Sync runtime field (varies by Python version) and clear Error field (not in JSON)

--- a/pkg/ecosystems/python/pipenv/plugin.go
+++ b/pkg/ecosystems/python/pipenv/plugin.go
@@ -68,8 +68,9 @@ func (p Plugin) BuildDepGraphsFromDir(
 
 	for _, file := range files {
 		g.Go(func() error {
-			projectName := pip.GetProjectName(file.RelPath, dir, options)
-			result, err := p.buildDepGraphFromPipfile(ctx, log, file, pythonVersion, options.Python.NoBuildIsolation, options.Global.IncludeDev, projectName)
+			projectName := pip.GetProjectName(file.RelPath, dir)
+			result, err := p.buildDepGraphFromPipfile(ctx, log, file, pythonVersion, options.Python.NoBuildIsolation,
+				options.Global.IncludeDev, projectName, options.Global.ProjectName)
 			if err != nil {
 				attrs := []logger.Field{
 					logger.Attr(logFieldFile, file.RelPath),
@@ -86,8 +87,9 @@ func (p Plugin) BuildDepGraphsFromDir(
 				result = ecosystems.SCAResult{
 					ProjectDescriptor: identity.ProjectDescriptor{
 						Identity: identity.ProjectIdentity{
-							Type:       "pip",
-							TargetFile: &file.RelPath,
+							Type:             "pip",
+							TargetFile:       &file.RelPath,
+							BaseNameOverride: options.Global.ProjectName,
 						},
 					},
 					Error: err,
@@ -155,6 +157,7 @@ func (p Plugin) buildDepGraphFromPipfile(
 	noBuildIsolation bool,
 	includeDevDeps bool,
 	projectName string,
+	baseNameOverride *string,
 ) (ecosystems.SCAResult, error) {
 	log.Debug(ctx, "Building dependency graph from Pipfile",
 		logger.Attr(logFieldFile, file.RelPath),
@@ -206,8 +209,9 @@ func (p Plugin) buildDepGraphFromPipfile(
 		DepGraph: depGraph,
 		ProjectDescriptor: identity.ProjectDescriptor{
 			Identity: identity.ProjectIdentity{
-				Type:       "pip",
-				TargetFile: &file.RelPath,
+				Type:             "pip",
+				TargetFile:       &file.RelPath,
+				BaseNameOverride: baseNameOverride,
 			},
 		},
 	}, nil

--- a/pkg/ecosystems/python/pipenv/plugin.go
+++ b/pkg/ecosystems/python/pipenv/plugin.go
@@ -68,7 +68,8 @@ func (p Plugin) BuildDepGraphsFromDir(
 
 	for _, file := range files {
 		g.Go(func() error {
-			result, err := p.buildDepGraphFromPipfile(ctx, log, file, pythonVersion, options.Python.NoBuildIsolation, options.Global.IncludeDev)
+			projectName := pip.GetProjectName(file.RelPath, dir, options)
+			result, err := p.buildDepGraphFromPipfile(ctx, log, file, pythonVersion, options.Python.NoBuildIsolation, options.Global.IncludeDev, projectName)
 			if err != nil {
 				attrs := []logger.Field{
 					logger.Attr(logFieldFile, file.RelPath),
@@ -85,7 +86,7 @@ func (p Plugin) BuildDepGraphsFromDir(
 				result = ecosystems.SCAResult{
 					ProjectDescriptor: identity.ProjectDescriptor{
 						Identity: identity.ProjectIdentity{
-							Type:       "pipenv",
+							Type:       "pip",
 							TargetFile: &file.RelPath,
 						},
 					},
@@ -153,10 +154,12 @@ func (p Plugin) buildDepGraphFromPipfile(
 	pythonVersion string,
 	noBuildIsolation bool,
 	includeDevDeps bool,
+	projectName string,
 ) (ecosystems.SCAResult, error) {
 	log.Debug(ctx, "Building dependency graph from Pipfile",
 		logger.Attr(logFieldFile, file.RelPath),
-		logger.Attr("python_version", pythonVersion))
+		logger.Attr("python_version", pythonVersion),
+		logger.Attr("project_name", projectName))
 
 	// Parse Pipfile
 	pipfile, err := ParsePipfile(file.Path)
@@ -191,7 +194,7 @@ func (p Plugin) buildDepGraphFromPipfile(
 	}
 
 	// Convert report to dependency graph
-	depGraph, err := report.ToDependencyGraph(ctx, log, pip.PkgManagerPipenv)
+	depGraph, err := report.ToDependencyGraph(ctx, log, pip.PkgManagerPipenv, projectName)
 	if err != nil {
 		return ecosystems.SCAResult{}, fmt.Errorf("failed to convert pip report to dependency graph: %w", err)
 	}
@@ -203,7 +206,7 @@ func (p Plugin) buildDepGraphFromPipfile(
 		DepGraph: depGraph,
 		ProjectDescriptor: identity.ProjectDescriptor{
 			Identity: identity.ProjectIdentity{
-				Type:       "pipenv",
+				Type:       "pip",
 				TargetFile: &file.RelPath,
 			},
 		},

--- a/pkg/ecosystems/testdata/fixtures/python/empty/expected_plugin.json
+++ b/pkg/ecosystems/testdata/fixtures/python/empty/expected_plugin.json
@@ -7,9 +7,9 @@
       },
       "pkgs": [
         {
-          "id": "root@0.0.0",
+          "id": "empty@0.0.0",
           "info": {
-            "name": "root",
+            "name": "empty",
             "version": "0.0.0"
           }
         }
@@ -19,7 +19,7 @@
         "nodes": [
           {
             "nodeId": "root-node",
-            "pkgId": "root@0.0.0",
+            "pkgId": "empty@0.0.0",
             "deps": []
           }
         ]
@@ -27,7 +27,6 @@
     },
     "projectDescriptor": {
       "identity": {
-        "targetFile": "requirements.txt",
         "targetRuntime": "python@3.14.1"
       }
     }

--- a/pkg/ecosystems/testdata/fixtures/python/env-markers/expected_plugin.json
+++ b/pkg/ecosystems/testdata/fixtures/python/env-markers/expected_plugin.json
@@ -7,9 +7,9 @@
       },
       "pkgs": [
         {
-          "id": "root@0.0.0",
+          "id": "env-markers@0.0.0",
           "info": {
-            "name": "root",
+            "name": "env-markers",
             "version": "0.0.0"
           }
         },
@@ -54,7 +54,7 @@
         "nodes": [
           {
             "nodeId": "root-node",
-            "pkgId": "root@0.0.0",
+            "pkgId": "env-markers@0.0.0",
             "deps": [
               {
                 "nodeId": "requests@2.31.0"
@@ -104,7 +104,6 @@
     },
     "projectDescriptor": {
       "identity": {
-        "targetFile": "requirements.txt",
         "targetRuntime": "python@3.14.1"
       }
     }

--- a/pkg/ecosystems/testdata/fixtures/python/env-markers/expected_plugin_3.8.json
+++ b/pkg/ecosystems/testdata/fixtures/python/env-markers/expected_plugin_3.8.json
@@ -7,9 +7,9 @@
       },
       "pkgs": [
         {
-          "id": "root@0.0.0",
+          "id": "env-markers@0.0.0",
           "info": {
-            "name": "root",
+            "name": "env-markers",
             "version": "0.0.0"
           }
         },
@@ -68,7 +68,7 @@
         "nodes": [
           {
             "nodeId": "root-node",
-            "pkgId": "root@0.0.0",
+            "pkgId": "env-markers@0.0.0",
             "deps": [
               {
                 "nodeId": "importlib-metadata@6.8.0"
@@ -135,7 +135,6 @@
     },
     "projectDescriptor": {
       "identity": {
-        "targetFile": "requirements.txt",
         "targetRuntime": "python@3.8.20"
       }
     }

--- a/pkg/ecosystems/testdata/fixtures/python/env-markers/expected_plugin_3.9.json
+++ b/pkg/ecosystems/testdata/fixtures/python/env-markers/expected_plugin_3.9.json
@@ -7,9 +7,9 @@
       },
       "pkgs": [
         {
-          "id": "root@0.0.0",
+          "id": "env-markers@0.0.0",
           "info": {
-            "name": "root",
+            "name": "env-markers",
             "version": "0.0.0"
           }
         },
@@ -68,7 +68,7 @@
         "nodes": [
           {
             "nodeId": "root-node",
-            "pkgId": "root@0.0.0",
+            "pkgId": "env-markers@0.0.0",
             "deps": [
               {
                 "nodeId": "importlib-metadata@6.8.0"
@@ -135,7 +135,6 @@
     },
     "projectDescriptor": {
       "identity": {
-        "targetFile": "requirements.txt",
         "targetRuntime": "python@3.9.25"
       }
     }

--- a/pkg/ecosystems/testdata/fixtures/python/git-references/expected_plugin.json
+++ b/pkg/ecosystems/testdata/fixtures/python/git-references/expected_plugin.json
@@ -7,9 +7,9 @@
       },
       "pkgs": [
         {
-          "id": "root@0.0.0",
+          "id": "git-references@0.0.0",
           "info": {
-            "name": "root",
+            "name": "git-references",
             "version": "0.0.0"
           }
         },
@@ -96,7 +96,7 @@
         "nodes": [
           {
             "nodeId": "root-node",
-            "pkgId": "root@0.0.0",
+            "pkgId": "git-references@0.0.0",
             "deps": [
               {
                 "nodeId": "black@23.12.1"
@@ -195,7 +195,6 @@
     },
     "projectDescriptor": {
       "identity": {
-        "targetFile": "requirements.txt",
         "targetRuntime": "python@3.14.1"
       }
     }

--- a/pkg/ecosystems/testdata/fixtures/python/git-references/expected_plugin_3.10.json
+++ b/pkg/ecosystems/testdata/fixtures/python/git-references/expected_plugin_3.10.json
@@ -7,9 +7,9 @@
       },
       "pkgs": [
         {
-          "id": "root@0.0.0",
+          "id": "git-references@0.0.0",
           "info": {
-            "name": "root",
+            "name": "git-references",
             "version": "0.0.0"
           }
         },
@@ -110,7 +110,7 @@
         "nodes": [
           {
             "nodeId": "root-node",
-            "pkgId": "root@0.0.0",
+            "pkgId": "git-references@0.0.0",
             "deps": [
               {
                 "nodeId": "black@23.12.1"
@@ -225,7 +225,6 @@
     },
     "projectDescriptor": {
       "identity": {
-        "targetFile": "requirements.txt",
         "targetRuntime": "python@3.10.19"
       }
     }

--- a/pkg/ecosystems/testdata/fixtures/python/git-references/expected_plugin_3.8.json
+++ b/pkg/ecosystems/testdata/fixtures/python/git-references/expected_plugin_3.8.json
@@ -7,9 +7,9 @@
       },
       "pkgs": [
         {
-          "id": "root@0.0.0",
+          "id": "git-references@0.0.0",
           "info": {
-            "name": "root",
+            "name": "git-references",
             "version": "0.0.0"
           }
         },
@@ -110,7 +110,7 @@
         "nodes": [
           {
             "nodeId": "root-node",
-            "pkgId": "root@0.0.0",
+            "pkgId": "git-references@0.0.0",
             "deps": [
               {
                 "nodeId": "black@23.12.1"
@@ -225,7 +225,6 @@
     },
     "projectDescriptor": {
       "identity": {
-        "targetFile": "requirements.txt",
         "targetRuntime": "python@3.8.20"
       }
     }

--- a/pkg/ecosystems/testdata/fixtures/python/git-references/expected_plugin_3.9.json
+++ b/pkg/ecosystems/testdata/fixtures/python/git-references/expected_plugin_3.9.json
@@ -7,9 +7,9 @@
       },
       "pkgs": [
         {
-          "id": "root@0.0.0",
+          "id": "git-references@0.0.0",
           "info": {
-            "name": "root",
+            "name": "git-references",
             "version": "0.0.0"
           }
         },
@@ -110,7 +110,7 @@
         "nodes": [
           {
             "nodeId": "root-node",
-            "pkgId": "root@0.0.0",
+            "pkgId": "git-references@0.0.0",
             "deps": [
               {
                 "nodeId": "black@23.12.1"
@@ -225,7 +225,6 @@
     },
     "projectDescriptor": {
       "identity": {
-        "targetFile": "requirements.txt",
         "targetRuntime": "python@3.9.25"
       }
     }

--- a/pkg/ecosystems/testdata/fixtures/python/invalid-syntax/expected_plugin.json
+++ b/pkg/ecosystems/testdata/fixtures/python/invalid-syntax/expected_plugin.json
@@ -3,7 +3,6 @@
     "error": {},
     "projectDescriptor": {
       "identity": {
-        "targetFile": "requirements.txt",
         "targetRuntime": "python@3.14.1"
       }
     }

--- a/pkg/ecosystems/testdata/fixtures/python/multi-requirements/expected_plugin.json
+++ b/pkg/ecosystems/testdata/fixtures/python/multi-requirements/expected_plugin.json
@@ -7,9 +7,9 @@
       },
       "pkgs": [
         {
-          "id": "root@0.0.0",
+          "id": "frontend@0.0.0",
           "info": {
-            "name": "root",
+            "name": "frontend",
             "version": "0.0.0"
           }
         },
@@ -33,7 +33,7 @@
         "nodes": [
           {
             "nodeId": "root-node",
-            "pkgId": "root@0.0.0",
+            "pkgId": "frontend@0.0.0",
             "deps": [
               {
                 "nodeId": "jinja2@3.1.2"
@@ -58,10 +58,7 @@
       }
     },
     "projectDescriptor": {
-      "identity": {
-        "targetFile": "frontend/requirements.txt",
-        "targetRuntime": "python@3.14.1"
-      }
+      "identity": {}
     }
   },
   {
@@ -72,9 +69,9 @@
       },
       "pkgs": [
         {
-          "id": "root@0.0.0",
+          "id": "multi-requirements@0.0.0",
           "info": {
-            "name": "root",
+            "name": "multi-requirements",
             "version": "0.0.0"
           }
         },
@@ -119,7 +116,7 @@
         "nodes": [
           {
             "nodeId": "root-node",
-            "pkgId": "root@0.0.0",
+            "pkgId": "multi-requirements@0.0.0",
             "deps": [
               {
                 "nodeId": "requests@2.31.0"
@@ -168,10 +165,7 @@
       }
     },
     "projectDescriptor": {
-      "identity": {
-        "targetFile": "requirements.txt",
-        "targetRuntime": "python@3.14.0"
-      }
+      "identity": {}
     }
   },
   {
@@ -182,9 +176,9 @@
       },
       "pkgs": [
         {
-          "id": "root@0.0.0",
+          "id": "backend@0.0.0",
           "info": {
-            "name": "root",
+            "name": "backend",
             "version": "0.0.0"
           }
         },
@@ -243,7 +237,7 @@
         "nodes": [
           {
             "nodeId": "root-node",
-            "pkgId": "root@0.0.0",
+            "pkgId": "backend@0.0.0",
             "deps": [
               {
                 "nodeId": "flask@3.0.0"
@@ -323,10 +317,7 @@
       }
     },
     "projectDescriptor": {
-      "identity": {
-        "targetFile": "backend/requirements.txt",
-        "targetRuntime": "python@3.14.0"
-      }
+      "identity": {}
     }
   }
 ]

--- a/pkg/ecosystems/testdata/fixtures/python/multi-requirements/expected_plugin_3.8.json
+++ b/pkg/ecosystems/testdata/fixtures/python/multi-requirements/expected_plugin_3.8.json
@@ -7,9 +7,9 @@
       },
       "pkgs": [
         {
-          "id": "root@0.0.0",
+          "id": "frontend@0.0.0",
           "info": {
-            "name": "root",
+            "name": "frontend",
             "version": "0.0.0"
           }
         },
@@ -33,7 +33,7 @@
         "nodes": [
           {
             "nodeId": "root-node",
-            "pkgId": "root@0.0.0",
+            "pkgId": "frontend@0.0.0",
             "deps": [
               {
                 "nodeId": "jinja2@3.1.2"
@@ -58,10 +58,7 @@
       }
     },
     "projectDescriptor": {
-      "identity": {
-        "targetFile": "frontend/requirements.txt",
-        "targetRuntime": "python@3.8.20"
-      }
+      "identity": {}
     }
   },
   {
@@ -72,9 +69,9 @@
       },
       "pkgs": [
         {
-          "id": "root@0.0.0",
+          "id": "multi-requirements@0.0.0",
           "info": {
-            "name": "root",
+            "name": "multi-requirements",
             "version": "0.0.0"
           }
         },
@@ -119,7 +116,7 @@
         "nodes": [
           {
             "nodeId": "root-node",
-            "pkgId": "root@0.0.0",
+            "pkgId": "multi-requirements@0.0.0",
             "deps": [
               {
                 "nodeId": "requests@2.31.0"
@@ -168,10 +165,7 @@
       }
     },
     "projectDescriptor": {
-      "identity": {
-        "targetFile": "requirements.txt",
-        "targetRuntime": "python@3.8.20"
-      }
+      "identity": {}
     }
   },
   {
@@ -182,9 +176,9 @@
       },
       "pkgs": [
         {
-          "id": "root@0.0.0",
+          "id": "backend@0.0.0",
           "info": {
-            "name": "root",
+            "name": "backend",
             "version": "0.0.0"
           }
         },
@@ -257,7 +251,7 @@
         "nodes": [
           {
             "nodeId": "root-node",
-            "pkgId": "root@0.0.0",
+            "pkgId": "backend@0.0.0",
             "deps": [
               {
                 "nodeId": "flask@3.0.0"
@@ -368,10 +362,7 @@
       }
     },
     "projectDescriptor": {
-      "identity": {
-        "targetFile": "backend/requirements.txt",
-        "targetRuntime": "python@3.8.20"
-      }
+      "identity": {}
     }
   }
 ]

--- a/pkg/ecosystems/testdata/fixtures/python/multi-requirements/expected_plugin_3.9.json
+++ b/pkg/ecosystems/testdata/fixtures/python/multi-requirements/expected_plugin_3.9.json
@@ -7,9 +7,9 @@
       },
       "pkgs": [
         {
-          "id": "root@0.0.0",
+          "id": "frontend@0.0.0",
           "info": {
-            "name": "root",
+            "name": "frontend",
             "version": "0.0.0"
           }
         },
@@ -33,7 +33,7 @@
         "nodes": [
           {
             "nodeId": "root-node",
-            "pkgId": "root@0.0.0",
+            "pkgId": "frontend@0.0.0",
             "deps": [
               {
                 "nodeId": "jinja2@3.1.2"
@@ -58,10 +58,7 @@
       }
     },
     "projectDescriptor": {
-      "identity": {
-        "targetFile": "frontend/requirements.txt",
-        "targetRuntime": "python@3.9.25"
-      }
+      "identity": {}
     }
   },
   {
@@ -72,9 +69,9 @@
       },
       "pkgs": [
         {
-          "id": "root@0.0.0",
+          "id": "multi-requirements@0.0.0",
           "info": {
-            "name": "root",
+            "name": "multi-requirements",
             "version": "0.0.0"
           }
         },
@@ -119,7 +116,7 @@
         "nodes": [
           {
             "nodeId": "root-node",
-            "pkgId": "root@0.0.0",
+            "pkgId": "multi-requirements@0.0.0",
             "deps": [
               {
                 "nodeId": "requests@2.31.0"
@@ -168,10 +165,7 @@
       }
     },
     "projectDescriptor": {
-      "identity": {
-        "targetFile": "requirements.txt",
-        "targetRuntime": "python@3.9.25"
-      }
+      "identity": {}
     }
   },
   {
@@ -182,9 +176,9 @@
       },
       "pkgs": [
         {
-          "id": "root@0.0.0",
+          "id": "backend@0.0.0",
           "info": {
-            "name": "root",
+            "name": "backend",
             "version": "0.0.0"
           }
         },
@@ -257,7 +251,7 @@
         "nodes": [
           {
             "nodeId": "root-node",
-            "pkgId": "root@0.0.0",
+            "pkgId": "backend@0.0.0",
             "deps": [
               {
                 "nodeId": "flask@3.0.0"
@@ -368,10 +362,7 @@
       }
     },
     "projectDescriptor": {
-      "identity": {
-        "targetFile": "backend/requirements.txt",
-        "targetRuntime": "python@3.9.25"
-      }
+      "identity": {}
     }
   }
 ]

--- a/pkg/ecosystems/testdata/fixtures/python/multiple-deps/expected_plugin.json
+++ b/pkg/ecosystems/testdata/fixtures/python/multiple-deps/expected_plugin.json
@@ -7,9 +7,9 @@
       },
       "pkgs": [
         {
-          "id": "root@0.0.0",
+          "id": "multiple-deps@0.0.0",
           "info": {
-            "name": "root",
+            "name": "multiple-deps",
             "version": "0.0.0"
           }
         },
@@ -61,7 +61,7 @@
         "nodes": [
           {
             "nodeId": "root-node",
-            "pkgId": "root@0.0.0",
+            "pkgId": "multiple-deps@0.0.0",
             "deps": [
               {
                 "nodeId": "click@8.1.7"
@@ -119,7 +119,6 @@
     },
     "projectDescriptor": {
       "identity": {
-        "targetFile": "requirements.txt",
         "targetRuntime": "python@3.14.1"
       }
     }

--- a/pkg/ecosystems/testdata/fixtures/python/nonexistent-package/expected_plugin.json
+++ b/pkg/ecosystems/testdata/fixtures/python/nonexistent-package/expected_plugin.json
@@ -3,7 +3,6 @@
     "error": {},
     "projectDescriptor": {
       "identity": {
-        "targetFile": "requirements.txt",
         "targetRuntime": "python@3.14.1"
       }
     }

--- a/pkg/ecosystems/testdata/fixtures/python/os-specific/expected_plugin.json
+++ b/pkg/ecosystems/testdata/fixtures/python/os-specific/expected_plugin.json
@@ -7,9 +7,9 @@
       },
       "pkgs": [
         {
-          "id": "root@0.0.0",
+          "id": "os-specific@0.0.0",
           "info": {
-            "name": "root",
+            "name": "os-specific",
             "version": "0.0.0"
           }
         },
@@ -54,7 +54,7 @@
         "nodes": [
           {
             "nodeId": "root-node",
-            "pkgId": "root@0.0.0",
+            "pkgId": "os-specific@0.0.0",
             "deps": [
               {
                 "nodeId": "requests@2.31.0"
@@ -104,7 +104,6 @@
     },
     "projectDescriptor": {
       "identity": {
-        "targetFile": "requirements.txt",
         "targetRuntime": "python@3.14.1"
       }
     }

--- a/pkg/ecosystems/testdata/fixtures/python/simple-with-dev-deps/expected_plugin.json
+++ b/pkg/ecosystems/testdata/fixtures/python/simple-with-dev-deps/expected_plugin.json
@@ -7,9 +7,9 @@
       },
       "pkgs": [
         {
-          "id": "root@0.0.0",
+          "id": "simple-with-dev-deps@0.0.0",
           "info": {
-            "name": "root",
+            "name": "simple-with-dev-deps",
             "version": "0.0.0"
           }
         },
@@ -54,7 +54,7 @@
         "nodes": [
           {
             "nodeId": "root-node",
-            "pkgId": "root@0.0.0",
+            "pkgId": "simple-with-dev-deps@0.0.0",
             "deps": [
               {
                 "nodeId": "requests@2.31.0"

--- a/pkg/ecosystems/testdata/fixtures/python/simple-with-dev-deps/expected_plugin_3.10.json
+++ b/pkg/ecosystems/testdata/fixtures/python/simple-with-dev-deps/expected_plugin_3.10.json
@@ -7,9 +7,9 @@
       },
       "pkgs": [
         {
-          "id": "root@0.0.0",
+          "id": "simple-with-dev-deps@0.0.0",
           "info": {
-            "name": "root",
+            "name": "simple-with-dev-deps",
             "version": "0.0.0"
           }
         },
@@ -54,7 +54,7 @@
         "nodes": [
           {
             "nodeId": "root-node",
-            "pkgId": "root@0.0.0",
+            "pkgId": "simple-with-dev-deps@0.0.0",
             "deps": [
               {
                 "nodeId": "requests@2.31.0"

--- a/pkg/ecosystems/testdata/fixtures/python/simple-with-dev-deps/expected_plugin_3.8.json
+++ b/pkg/ecosystems/testdata/fixtures/python/simple-with-dev-deps/expected_plugin_3.8.json
@@ -7,9 +7,9 @@
       },
       "pkgs": [
         {
-          "id": "root@0.0.0",
+          "id": "simple-with-dev-deps@0.0.0",
           "info": {
-            "name": "root",
+            "name": "simple-with-dev-deps",
             "version": "0.0.0"
           }
         },
@@ -54,7 +54,7 @@
         "nodes": [
           {
             "nodeId": "root-node",
-            "pkgId": "root@0.0.0",
+            "pkgId": "simple-with-dev-deps@0.0.0",
             "deps": [
               {
                 "nodeId": "requests@2.31.0"

--- a/pkg/ecosystems/testdata/fixtures/python/simple-with-dev-deps/expected_plugin_3.9.json
+++ b/pkg/ecosystems/testdata/fixtures/python/simple-with-dev-deps/expected_plugin_3.9.json
@@ -7,9 +7,9 @@
       },
       "pkgs": [
         {
-          "id": "root@0.0.0",
+          "id": "simple-with-dev-deps@0.0.0",
           "info": {
-            "name": "root",
+            "name": "simple-with-dev-deps",
             "version": "0.0.0"
           }
         },
@@ -54,7 +54,7 @@
         "nodes": [
           {
             "nodeId": "root-node",
-            "pkgId": "root@0.0.0",
+            "pkgId": "simple-with-dev-deps@0.0.0",
             "deps": [
               {
                 "nodeId": "requests@2.31.0"

--- a/pkg/ecosystems/testdata/fixtures/python/simple/expected_plugin.json
+++ b/pkg/ecosystems/testdata/fixtures/python/simple/expected_plugin.json
@@ -7,9 +7,9 @@
       },
       "pkgs": [
         {
-          "id": "root@0.0.0",
+          "id": "simple@0.0.0",
           "info": {
-            "name": "root",
+            "name": "simple",
             "version": "0.0.0"
           }
         },
@@ -54,7 +54,7 @@
         "nodes": [
           {
             "nodeId": "root-node",
-            "pkgId": "root@0.0.0",
+            "pkgId": "simple@0.0.0",
             "deps": [
               {
                 "nodeId": "requests@2.31.0"
@@ -104,7 +104,6 @@
     },
     "projectDescriptor": {
       "identity": {
-        "targetFile": "requirements.txt",
         "targetRuntime": "python@3.14.1"
       }
     }

--- a/pkg/ecosystems/testdata/fixtures/python/transitive-conflicts/expected_plugin.json
+++ b/pkg/ecosystems/testdata/fixtures/python/transitive-conflicts/expected_plugin.json
@@ -7,9 +7,9 @@
       },
       "pkgs": [
         {
-          "id": "root@0.0.0",
+          "id": "transitive-conflicts@0.0.0",
           "info": {
-            "name": "root",
+            "name": "transitive-conflicts",
             "version": "0.0.0"
           }
         },
@@ -96,7 +96,7 @@
         "nodes": [
           {
             "nodeId": "root-node",
-            "pkgId": "root@0.0.0",
+            "pkgId": "transitive-conflicts@0.0.0",
             "deps": [
               {
                 "nodeId": "boto3@1.28.0"
@@ -227,7 +227,6 @@
     },
     "projectDescriptor": {
       "identity": {
-        "targetFile": "requirements.txt",
         "targetRuntime": "python@3.14.1"
       }
     }

--- a/pkg/ecosystems/testdata/fixtures/python/url-references/expected_plugin.json
+++ b/pkg/ecosystems/testdata/fixtures/python/url-references/expected_plugin.json
@@ -7,9 +7,9 @@
       },
       "pkgs": [
         {
-          "id": "root@0.0.0",
+          "id": "url-references@0.0.0",
           "info": {
-            "name": "root",
+            "name": "url-references",
             "version": "0.0.0"
           }
         },
@@ -54,7 +54,7 @@
         "nodes": [
           {
             "nodeId": "root-node",
-            "pkgId": "root@0.0.0",
+            "pkgId": "url-references@0.0.0",
             "deps": [
               {
                 "nodeId": "certifi@2023.7.22"
@@ -107,7 +107,6 @@
     },
     "projectDescriptor": {
       "identity": {
-        "targetFile": "requirements.txt",
         "targetRuntime": "python@3.14.1"
       }
     }

--- a/pkg/ecosystems/testdata/fixtures/python/with-extras/expected_plugin.json
+++ b/pkg/ecosystems/testdata/fixtures/python/with-extras/expected_plugin.json
@@ -7,9 +7,9 @@
       },
       "pkgs": [
         {
-          "id": "root@0.0.0",
+          "id": "with-extras@0.0.0",
           "info": {
-            "name": "root",
+            "name": "with-extras",
             "version": "0.0.0"
           }
         },
@@ -61,7 +61,7 @@
         "nodes": [
           {
             "nodeId": "root-node",
-            "pkgId": "root@0.0.0",
+            "pkgId": "with-extras@0.0.0",
             "deps": [
               {
                 "nodeId": "requests@2.31.0"
@@ -119,7 +119,6 @@
     },
     "projectDescriptor": {
       "identity": {
-        "targetFile": "requirements.txt",
         "targetRuntime": "python@3.14.1"
       }
     }

--- a/pkg/ecosystems/testdata/fixtures/python/with-version-specifiers/expected_plugin.json
+++ b/pkg/ecosystems/testdata/fixtures/python/with-version-specifiers/expected_plugin.json
@@ -7,9 +7,9 @@
       },
       "pkgs": [
         {
-          "id": "root@0.0.0",
+          "id": "with-version-specifiers@0.0.0",
           "info": {
-            "name": "root",
+            "name": "with-version-specifiers",
             "version": "0.0.0"
           }
         },
@@ -61,7 +61,7 @@
         "nodes": [
           {
             "nodeId": "root-node",
-            "pkgId": "root@0.0.0",
+            "pkgId": "with-version-specifiers@0.0.0",
             "deps": [
               {
                 "nodeId": "click@*"
@@ -122,7 +122,6 @@
     },
     "projectDescriptor": {
       "identity": {
-        "targetFile": "requirements.txt",
         "targetRuntime": "python@3.14.1"
       }
     }

--- a/pkg/identity/project.go
+++ b/pkg/identity/project.go
@@ -3,19 +3,19 @@ package identity
 // ProjectDescriptor contains the complete description of a project,
 // including its identity and build arguments.
 type ProjectDescriptor struct {
-	Identity ProjectIdentity
+	Identity ProjectIdentity `json:"identity"`
 }
 
 // ProjectIdentity defines the core identifying characteristics of a project.
 type ProjectIdentity struct {
 	// Type specifies the project type (e.g., "npm", "maven", "pip")
-	Type string
+	Type string `json:"type,omitempty"`
 	// BaseNameOverride allows overriding the default base name for the project
-	BaseNameOverride *string
+	BaseNameOverride *string `json:"baseNameOverride,omitempty"`
 	// TargetFile specifies the manifest or build file for the project
-	TargetFile *string
+	TargetFile *string `json:"targetFile,omitempty"`
 	// TargetRuntime specifies the runtime environment for the project
-	TargetRuntime *string
+	TargetRuntime *string `json:"targetRuntime,omitempty"`
 }
 
 // GetTargetFile extracts the target file from a ProjectDescriptor.


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [ ] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Set target file for identity based on ecosystem.

Add --project-name flag and set pip/pipenv root to be equal to the name of the directory where the file is located just like the original python plugin. 
