### PR TITLE
feat: add new consolidated --print-graph flag [CSENG-182]

### DIFF
--- a/pkg/depgraph/flags.go
+++ b/pkg/depgraph/flags.go
@@ -35,8 +35,11 @@ const (
 	FlagUnmanagedMaxDepth             = "max-depth"
 	FlagIncludeProvenance             = "include-provenance"
 	FlagUseSBOMResolution             = "use-sbom-resolution"
+	FlagPrintGraph                    = "print-graph"
+	FlagJSONLOutput                   = "jsonl-output"
 	FlagPrintEffectiveGraph           = "effective-graph"
 	FlagPrintEffectiveGraphWithErrors = "effective-graph-with-errors"
+	FlagPrintErrors                   = "print-errors"
 	FlagDotnetRuntimeResolution       = "dotnet-runtime-resolution"
 	FlagDotnetTargetFramework         = "dotnet-target-framework"
 	FlagUvWorkspacePackages           = "internal-uv-workspace-packages"
@@ -74,8 +77,11 @@ func getFlagSet() *pflag.FlagSet {
 	flagSet.Int(FlagUnmanagedMaxDepth, 0, "Specify the maximum level of archive extraction for unmanaged scanning.")
 	flagSet.Bool(FlagIncludeProvenance, false, "Include checksums in purl to support package provenance.")
 	flagSet.Bool(FlagUseSBOMResolution, false, "Use SBOM resolution instead of legacy CLI.")
+	flagSet.Bool(FlagPrintGraph, false, "Return the dependency graph.")
+	flagSet.Bool(FlagJSONLOutput, false, "Return dependency graph output as JSONL when supported.")
 	flagSet.Bool(FlagPrintEffectiveGraph, false, "Return the pruned dependency graph.")
 	flagSet.Bool(FlagPrintEffectiveGraphWithErrors, false, "Return errors in the pruned dependency graph output.")
+	flagSet.Bool(FlagPrintErrors, false, "Return errors in dependency graph output.")
 	flagSet.Bool(FlagDotnetRuntimeResolution, false, "Required. You must use this option when you test .NET projects using Runtime Resolution Scanning.")
 	flagSet.String(FlagDotnetTargetFramework, "",
 		"Optional. You may use this option if your solution contains multiple <TargetFramework> directives. "+

--- a/pkg/depgraph/legacy_resolution.go
+++ b/pkg/depgraph/legacy_resolution.go
@@ -45,12 +45,23 @@ func handleLegacyResolution(ctx workflow.InvocationContext, config configuration
 }
 
 func chooseGraphArgument(config configuration.Configuration) (string, parsers.OutputParser) {
-	if config.GetBool(FlagPrintEffectiveGraph) {
+	// Legacy compatibility path.
+	if !config.GetBool(FlagPrintGraph) && config.GetBool(FlagPrintEffectiveGraphWithErrors) {
+		return "--print-effective-graph-with-errors", parsers.NewJSONL()
+	}
+	if !config.GetBool(FlagPrintGraph) && config.GetBool(FlagPrintEffectiveGraph) && config.GetBool(FlagPrintErrors) {
+		return "--print-effective-graph-with-errors", parsers.NewJSONL()
+	}
+	if !config.GetBool(FlagPrintGraph) && config.GetBool(FlagPrintEffectiveGraph) {
 		return "--print-effective-graph", parsers.NewJSONL()
 	}
 
-	if config.GetBool(FlagPrintEffectiveGraphWithErrors) {
-		return "--print-effective-graph-with-errors", parsers.NewJSONL()
+	// Consolidated print-graph path. All axes are passed as explicit toggles.
+	if config.GetBool(FlagPrintGraph) {
+		if config.GetBool(FlagJSONLOutput) {
+			return "--print-graph", parsers.NewJSONL()
+		}
+		return "--print-graph", parsers.NewPlainText()
 	}
 
 	return "--print-graph", parsers.NewPlainText()
@@ -87,6 +98,15 @@ func mapToWorkflowData(depGraphs []parsers.DepGraphOutput, logger *zerolog.Logge
 func prepareLegacyFlags(argument string, cfg configuration.Configuration, logger *zerolog.Logger) {
 	cmdArgs := []string{"test", "--json"}
 	cmdArgs = append(cmdArgs, argument)
+	if cfg.GetBool(FlagPrintGraph) && cfg.GetBool(FlagJSONLOutput) {
+		cmdArgs = append(cmdArgs, "--jsonl-output")
+	}
+	if cfg.GetBool(FlagPrintGraph) && cfg.GetBool(FlagPrintEffectiveGraph) {
+		cmdArgs = append(cmdArgs, "--effective-graph")
+	}
+	if cfg.GetBool(FlagPrintGraph) && cfg.GetBool(FlagPrintErrors) {
+		cmdArgs = append(cmdArgs, "--print-errors")
+	}
 
 	if allProjects := cfg.GetBool("all-projects"); allProjects {
 		cmdArgs = append(cmdArgs, "--all-projects")

--- a/pkg/depgraph/legacy_resolution_test.go
+++ b/pkg/depgraph/legacy_resolution_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/snyk/go-application-framework/pkg/workflow"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/snyk/cli-extension-dep-graph/pkg/depgraph/parsers"
 )
 
 //go:embed testdata/legacy_cli_output
@@ -336,4 +338,126 @@ func verifyMeta(t *testing.T, data workflow.Data, key, expectedValue string) {
 	value, err := data.GetMetaData(key)
 	require.NoError(t, err)
 	assert.Equal(t, expectedValue, value)
+}
+
+func TestChooseGraphArgument(t *testing.T) {
+	testCases := []struct {
+		name         string
+		setup        func(cfg configuration.Configuration)
+		wantArgument string
+		wantParser   string
+	}{
+		{
+			name:         "defaults to plain print graph",
+			setup:        func(_ configuration.Configuration) {},
+			wantArgument: "--print-graph",
+			wantParser:   "plain",
+		},
+		{
+			name: "legacy effective graph",
+			setup: func(cfg configuration.Configuration) {
+				cfg.Set(FlagPrintEffectiveGraph, true)
+			},
+			wantArgument: "--print-effective-graph",
+			wantParser:   "jsonl",
+		},
+		{
+			name: "legacy effective graph with errors",
+			setup: func(cfg configuration.Configuration) {
+				cfg.Set(FlagPrintEffectiveGraphWithErrors, true)
+			},
+			wantArgument: "--print-effective-graph-with-errors",
+			wantParser:   "jsonl",
+		},
+		{
+			name: "new print graph plus effective graph",
+			setup: func(cfg configuration.Configuration) {
+				cfg.Set(FlagPrintGraph, true)
+				cfg.Set(FlagPrintEffectiveGraph, true)
+			},
+			wantArgument: "--print-graph",
+			wantParser:   "plain",
+		},
+		{
+			name: "new print graph plus effective graph plus print errors",
+			setup: func(cfg configuration.Configuration) {
+				cfg.Set(FlagPrintGraph, true)
+				cfg.Set(FlagJSONLOutput, true)
+				cfg.Set(FlagPrintEffectiveGraph, true)
+				cfg.Set(FlagPrintErrors, true)
+			},
+			wantArgument: "--print-graph",
+			wantParser:   "jsonl",
+		},
+		{
+			name: "new print graph plus jsonl plus print errors",
+			setup: func(cfg configuration.Configuration) {
+				cfg.Set(FlagPrintGraph, true)
+				cfg.Set(FlagJSONLOutput, true)
+				cfg.Set(FlagPrintErrors, true)
+			},
+			wantArgument: "--print-graph",
+			wantParser:   "jsonl",
+		},
+		{
+			name: "print graph with print errors and no jsonl remains plain",
+			setup: func(cfg configuration.Configuration) {
+				cfg.Set(FlagPrintGraph, true)
+				cfg.Set(FlagPrintErrors, true)
+			},
+			wantArgument: "--print-graph",
+			wantParser:   "plain",
+		},
+		{
+			name: "print graph with jsonl output uses jsonl parser",
+			setup: func(cfg configuration.Configuration) {
+				cfg.Set(FlagPrintGraph, true)
+				cfg.Set(FlagJSONLOutput, true)
+			},
+			wantArgument: "--print-graph",
+			wantParser:   "jsonl",
+		},
+		{
+			name: "mixed legacy effective with new print errors",
+			setup: func(cfg configuration.Configuration) {
+				cfg.Set(FlagPrintEffectiveGraph, true)
+				cfg.Set(FlagPrintErrors, true)
+			},
+			wantArgument: "--print-effective-graph-with-errors",
+			wantParser:   "jsonl",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := configuration.New()
+			tc.setup(cfg)
+
+			argument, parser := chooseGraphArgument(cfg)
+
+			assert.Equal(t, tc.wantArgument, argument)
+			if tc.wantParser == "jsonl" {
+				assert.IsType(t, parsers.NewJSONL(), parser)
+			} else {
+				assert.IsType(t, parsers.NewPlainText(), parser)
+			}
+		})
+	}
+}
+
+func TestPrepareLegacyFlags_ConsolidatedPrintGraphToggles(t *testing.T) {
+	cfg := configuration.New()
+	logger := zerolog.Nop()
+	cfg.Set(FlagPrintGraph, true)
+	cfg.Set(FlagJSONLOutput, true)
+	cfg.Set(FlagPrintEffectiveGraph, true)
+	cfg.Set(FlagPrintErrors, true)
+
+	prepareLegacyFlags("--print-graph", cfg, &logger)
+	args := cfg.GetStringSlice(configuration.RAW_CMD_ARGS)
+
+	assert.Contains(t, args, "--print-graph")
+	assert.Contains(t, args, "--jsonl-output")
+	assert.Contains(t, args, "--effective-graph")
+	assert.Contains(t, args, "--print-errors")
 }

--- a/pkg/depgraph/sbom_resolution.go
+++ b/pkg/depgraph/sbom_resolution.go
@@ -294,8 +294,11 @@ func executeLegacyWorkflow(
 	findings []scaplugin.Finding,
 ) ([]workflow.Data, error) {
 	legacyConfig := config.Clone()
+	legacyConfig.Set(FlagPrintGraph, true)
+	legacyConfig.Set(FlagJSONLOutput, true)
+	legacyConfig.Set(FlagPrintErrors, true)
 	legacyConfig.Unset(FlagPrintEffectiveGraph)
-	legacyConfig.Set(FlagPrintEffectiveGraphWithErrors, true)
+	legacyConfig.Unset(FlagPrintEffectiveGraphWithErrors)
 
 	legacyData, err := depGraphWorkflowFunc(ctx, legacyConfig, logger)
 	if err == nil {


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

The existing `--print-effective-graph` and `--print-effective-graph-with-errors` flags were designed as monolithic toggles that each bundled output format and content concerns together. This made it difficult to extend or compose behaviour without introducing yet more flag combinations.

This PR introduces a new consolidated `--print-graph` flag as the single entry point for requesting dependency graph output, with orthogonal toggles controlling independent axes of behaviour:

- `--jsonl-output` — emit the graph as JSONL instead of plain text
- `--effective-graph` — return the pruned/effective graph
- `--print-errors` — include resolution errors in the output

The legacy flags (`--print-effective-graph`, `--print-effective-graph-with-errors`) are preserved and handled via a compatibility path in `chooseGraphArgument`, so existing callers are not broken.

The SBOM resolution path (`sbom_resolution.go`) has been migrated to use the new consolidated flags (`--print-graph` + `--jsonl-output` + `--print-errors`), replacing the previous direct use of `--print-effective-graph-with-errors`.
