### PR TITLE
feat: extract targetRuntime from legacy output

### DIFF
--- a/pkg/depgraph/parsers/depgraph_output.go
+++ b/pkg/depgraph/parsers/depgraph_output.go
@@ -4,6 +4,7 @@ package parsers
 type DepGraphOutput struct {
 	NormalisedTargetFile string
 	TargetFileFromPlugin *string
+	TargetRuntime        *string
 	Target               []byte
 	DepGraph             []byte
 	Error                []byte

--- a/pkg/depgraph/parsers/jsonl_output_parser.go
+++ b/pkg/depgraph/parsers/jsonl_output_parser.go
@@ -21,6 +21,7 @@ type jsonLine struct {
 	DepGraph             json.RawMessage `json:"depGraph"`
 	NormalisedTargetFile string          `json:"normalisedTargetFile"`
 	TargetFileFromPlugin *string         `json:"targetFileFromPlugin"`
+	TargetRuntime        *string         `json:"targetRuntime"`
 	Target               json.RawMessage `json:"target"`
 	Error                json.RawMessage `json:"error"`
 }
@@ -47,6 +48,7 @@ func (j *JSONLOutputParser) ParseOutput(data []byte) ([]DepGraphOutput, error) {
 			NormalisedTargetFile: parsed.NormalisedTargetFile,
 			TargetFileFromPlugin: parsed.TargetFileFromPlugin,
 			Target:               parsed.Target,
+			TargetRuntime:        parsed.TargetRuntime,
 			DepGraph:             parsed.DepGraph,
 			Error:                parsed.Error,
 		})

--- a/pkg/ecosystems/orchestrator/orchestrator.go
+++ b/pkg/ecosystems/orchestrator/orchestrator.go
@@ -230,7 +230,7 @@ func depGraphOutputToSCAResult(output *parsers.DepGraphOutput, ictx workflow.Inv
 		if dg.PkgManager.Name != "" {
 			result.ProjectDescriptor.Identity.Type = dg.PkgManager.Name
 			// Extract runtime from depgraph if available
-			result.ProjectDescriptor.Identity.TargetRuntime = &dg.PkgManager.Name
+			result.ProjectDescriptor.Identity.TargetRuntime = output.TargetRuntime
 		}
 	}
 

--- a/pkg/ecosystems/orchestrator/orchestrator_test.go
+++ b/pkg/ecosystems/orchestrator/orchestrator_test.go
@@ -45,3 +45,35 @@ func TestLegacyFallback_MapsProjectType(t *testing.T) {
 
 	assert.Equal(t, "npm", results[0].ProjectDescriptor.Identity.Type)
 }
+
+func TestLegacyFallback_MapsTargetFramework(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	ictx := gafmocks.NewMockInvocationContext(ctrl)
+	engine := gafmocks.NewMockEngine(ctrl)
+	cfg := configuration.New()
+	logger := zerolog.Nop()
+
+	opts := ecosystems.NewPluginOptions()
+
+	ictx.EXPECT().GetConfiguration().Return(cfg).AnyTimes()
+	ictx.EXPECT().GetEngine().Return(engine).AnyTimes()
+	ictx.EXPECT().GetEnhancedLogger().Return(&logger).AnyTimes()
+
+	engine.EXPECT().
+		InvokeWithConfig(gomock.Any(), gomock.Any()).
+		Return(
+			[]workflow.Data{
+				workflow.NewData(
+					workflow.NewTypeIdentifier(legacyCLIWorkflowID, "application/text"),
+					"application/text",
+					[]byte(`{"depGraph":{"pkgManager":{"name":"nuget"}},"normalisedTargetFile":"project.assets.json","targetFileFromPlugin":"project.assets.json","target":{},"targetRuntime":"net6.0"}`)), //nolint:lll // This is fine.
+			},
+			nil)
+
+	results, err := LegacyFallback(ictx, *opts, nil)
+
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	assert.Equal(t, "net6.0", *results[0].ProjectDescriptor.Identity.TargetRuntime)
+}


### PR DESCRIPTION
### What this does

Extract `targetRuntime` from JSONL output of legacy CLI.
