### PR TITLE
feat: add new --allow-incomplete-sbom-flag [CSENG-175]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 setup: true
 
 orbs:
-  path-filtering: circleci/path-filtering@1
+  path-filtering: circleci/path-filtering@3.0.0
 
 workflows:
   setup:

--- a/pkg/depgraph/flags.go
+++ b/pkg/depgraph/flags.go
@@ -9,6 +9,7 @@ const (
 const (
 	FlagFailFast                      = "fail-fast"
 	FlagAllProjects                   = "all-projects"
+	FlagPrintOutputJsonlWithErrors    = "print-output-jsonl-with-errors"
 	FlagDev                           = "dev"
 	FlagExclude                       = "exclude"
 	FlagFile                          = "file"
@@ -49,6 +50,7 @@ func getFlagSet() *pflag.FlagSet {
 
 	flagSet.Bool(FlagFailFast, false, "Fail fast when scanning all projects")
 	flagSet.Bool(FlagAllProjects, false, "Enable all projects")
+	flagSet.Bool(FlagPrintOutputJsonlWithErrors, false, "Print output JSONL with errors")
 	flagSet.Bool(FlagDev, false, "Include dev dependencies")
 	flagSet.String(FlagFile, "", "Input file")
 	flagSet.String(FlagDetectionDepth, "", "Detection depth")

--- a/pkg/depgraph/legacy_resolution.go
+++ b/pkg/depgraph/legacy_resolution.go
@@ -12,6 +12,11 @@ import (
 	"github.com/snyk/cli-extension-dep-graph/pkg/depgraph/parsers"
 )
 
+const (
+	printGraphCliArg                 = "--print-graph"
+	printOutputJsonlWithErrorsCliArg = "--print-output-jsonl-with-errors"
+)
+
 var legacyWorkflowID = workflow.NewWorkflowIdentifier(legacyCLIWorkflowIDStr)
 
 func handleLegacyResolution(ctx workflow.InvocationContext, config configuration.Configuration, logger *zerolog.Logger) ([]workflow.Data, error) {
@@ -53,7 +58,11 @@ func chooseGraphArgument(config configuration.Configuration) (string, parsers.Ou
 		return "--print-effective-graph-with-errors", parsers.NewJSONL()
 	}
 
-	return "--print-graph", parsers.NewPlainText()
+	if config.GetBool(FlagPrintOutputJsonlWithErrors) {
+		return printOutputJsonlWithErrorsCliArg, parsers.NewJSONL()
+	}
+
+	return printGraphCliArg, parsers.NewPlainText()
 }
 
 func mapToWorkflowData(depGraphs []parsers.DepGraphOutput, logger *zerolog.Logger) []workflow.Data {
@@ -91,6 +100,10 @@ func prepareLegacyFlags(argument string, cfg configuration.Configuration, logger
 
 	if allProjects := cfg.GetBool("all-projects"); allProjects {
 		cmdArgs = append(cmdArgs, "--all-projects")
+	}
+
+	if cfg.GetBool(FlagPrintOutputJsonlWithErrors) {
+		cmdArgs = append(cmdArgs, printOutputJsonlWithErrorsCliArg)
 	}
 
 	if cfg.GetBool(FlagFailFast) {

--- a/pkg/depgraph/legacy_resolution.go
+++ b/pkg/depgraph/legacy_resolution.go
@@ -59,7 +59,7 @@ func chooseGraphArgument(config configuration.Configuration) (string, parsers.Ou
 	}
 
 	if config.GetBool(FlagPrintOutputJsonlWithErrors) {
-		return printOutputJsonlWithErrorsCliArg, parsers.NewJSONL()
+		return printGraphCliArg, parsers.NewJSONL()
 	}
 
 	return printGraphCliArg, parsers.NewPlainText()

--- a/pkg/depgraph/legacy_resolution_test.go
+++ b/pkg/depgraph/legacy_resolution_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/snyk/go-application-framework/pkg/workflow"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/snyk/cli-extension-dep-graph/pkg/depgraph/parsers"
 )
 
 //go:embed testdata/legacy_cli_output
@@ -208,6 +210,35 @@ func Test_LegacyResolution(t *testing.T) {
 		})
 	}
 
+	t.Run("GIVEN FlagPrintOutputJsonlWithErrors is set WHEN prepareLegacyFlags THEN arg is included in cmd args", func(t *testing.T) {
+		// GIVEN: a fresh config with only the new flag enabled
+		isolatedConfig := configuration.New()
+		isolatedConfig.Set(FlagPrintOutputJsonlWithErrors, true)
+
+		nopLog := zerolog.Nop()
+		// WHEN
+		prepareLegacyFlags("--print-output-jsonl-with-errors", isolatedConfig, &nopLog)
+
+		// THEN
+		cmdArgs, ok := isolatedConfig.Get(configuration.RAW_CMD_ARGS).([]string)
+		require.True(t, ok, "RAW_CMD_ARGS should be a []string")
+		assert.Contains(t, cmdArgs, "--print-output-jsonl-with-errors")
+	})
+
+	t.Run("GIVEN FlagPrintOutputJsonlWithErrors is NOT set WHEN prepareLegacyFlags THEN arg is NOT included in cmd args", func(t *testing.T) {
+		// GIVEN: a fresh config without the flag
+		isolatedConfig := configuration.New()
+
+		nopLog := zerolog.Nop()
+		// WHEN
+		prepareLegacyFlags("--print-graph", isolatedConfig, &nopLog)
+
+		// THEN
+		cmdArgs, ok := isolatedConfig.Get(configuration.RAW_CMD_ARGS).([]string)
+		require.True(t, ok, "RAW_CMD_ARGS should be a []string")
+		assert.NotContains(t, cmdArgs, "--print-output-jsonl-with-errors")
+	})
+
 	t.Run("should not include target directory if file flag provided", func(t *testing.T) {
 		config.Set(FlagFile, "path/to/target/file.js")
 		config.Set("targetDirectory", "path/to/target")
@@ -336,4 +367,59 @@ func verifyMeta(t *testing.T, data workflow.Data, key, expectedValue string) {
 	value, err := data.GetMetaData(key)
 	require.NoError(t, err)
 	assert.Equal(t, expectedValue, value)
+}
+
+func Test_chooseGraphArgument(t *testing.T) {
+	t.Run("GIVEN FlagPrintOutputJsonlWithErrors is set WHEN chooseGraphArgument THEN returns correct arg with JSONL parser", func(t *testing.T) {
+		// GIVEN
+		config := configuration.New()
+		config.Set(FlagPrintOutputJsonlWithErrors, true)
+
+		// WHEN
+		arg, parser := chooseGraphArgument(config)
+
+		// THEN
+		assert.Equal(t, "--print-output-jsonl-with-errors", arg)
+		assert.IsType(t, &parsers.JSONLOutputParser{}, parser)
+	})
+
+	t.Run("GIVEN no flags are set WHEN chooseGraphArgument is called THEN returns default --print-graph with PlainText parser", func(t *testing.T) {
+		// GIVEN
+		config := configuration.New()
+
+		// WHEN
+		arg, parser := chooseGraphArgument(config)
+
+		// THEN
+		assert.Equal(t, "--print-graph", arg)
+		assert.IsType(t, &parsers.PlainTextOutputParser{}, parser)
+	})
+
+	t.Run("GIVEN FlagPrintEffectiveGraph and FlagPrintOutputJsonlWithErrors both set WHEN chooseGraphArgument THEN effective-graph wins", func(t *testing.T) {
+		// GIVEN
+		config := configuration.New()
+		config.Set(FlagPrintEffectiveGraph, true)
+		config.Set(FlagPrintOutputJsonlWithErrors, true)
+
+		// WHEN
+		arg, parser := chooseGraphArgument(config)
+
+		// THEN
+		assert.Equal(t, "--print-effective-graph", arg)
+		assert.IsType(t, &parsers.JSONLOutputParser{}, parser)
+	})
+
+	t.Run("GIVEN FlagPrintEffectiveGraphWithErrors set alongside JSONL flag WHEN chooseGraphArgument THEN WithErrors wins", func(t *testing.T) {
+		// GIVEN
+		config := configuration.New()
+		config.Set(FlagPrintEffectiveGraphWithErrors, true)
+		config.Set(FlagPrintOutputJsonlWithErrors, true)
+
+		// WHEN
+		arg, parser := chooseGraphArgument(config)
+
+		// THEN
+		assert.Equal(t, "--print-effective-graph-with-errors", arg)
+		assert.IsType(t, &parsers.JSONLOutputParser{}, parser)
+	})
 }

--- a/pkg/depgraph/legacy_resolution_test.go
+++ b/pkg/depgraph/legacy_resolution_test.go
@@ -379,7 +379,7 @@ func Test_chooseGraphArgument(t *testing.T) {
 		arg, parser := chooseGraphArgument(config)
 
 		// THEN
-		assert.Equal(t, "--print-output-jsonl-with-errors", arg)
+		assert.Equal(t, "--print-graph", arg)
 		assert.IsType(t, &parsers.JSONLOutputParser{}, parser)
 	})
 

--- a/pkg/depgraph/sbom_resolution.go
+++ b/pkg/depgraph/sbom_resolution.go
@@ -295,7 +295,13 @@ func executeLegacyWorkflow(
 ) ([]workflow.Data, error) {
 	legacyConfig := config.Clone()
 	legacyConfig.Unset(FlagPrintEffectiveGraph)
-	legacyConfig.Set(FlagPrintEffectiveGraphWithErrors, true)
+
+	if config.GetBool(FlagPrintOutputJsonlWithErrors) {
+		legacyConfig.Set(FlagPrintOutputJsonlWithErrors, true)
+		legacyConfig.Set(FlagPrintEffectiveGraphWithErrors, false)
+	} else {
+		legacyConfig.Set(FlagPrintEffectiveGraphWithErrors, true)
+	}
 
 	legacyData, err := depGraphWorkflowFunc(ctx, legacyConfig, logger)
 	if err == nil {

--- a/pkg/depgraph/sbom_resolution_test.go
+++ b/pkg/depgraph/sbom_resolution_test.go
@@ -1519,6 +1519,90 @@ func Test_callback_SBOMResolution(t *testing.T) {
 	})
 }
 
+func Test_executeLegacyWorkflow_FlagPrintOutputJsonlWithErrors(t *testing.T) {
+	t.Run("GIVEN FlagPrintOutputJsonlWithErrors set WHEN executeLegacyWorkflow THEN disables effective-graph-with-errors in legacy config", func(t *testing.T) {
+		// GIVEN
+		ctx := setupTestContext(t, false)
+		ctx.config.Set(FlagPrintOutputJsonlWithErrors, true)
+
+		resolutionHandler := NewCalledResolutionHandlerFunc([]workflow.Data{}, nil)
+		mockPlugin := &mockScaPlugin{}
+
+		// WHEN
+		_, err := handleSBOMResolutionDI(
+			ctx.invocationContext,
+			ctx.config,
+			&nopLogger,
+			[]ecosystems.SCAPlugin{mockPlugin},
+			resolutionHandler.Func(),
+		)
+
+		// THEN
+		require.NoError(t, err)
+		require.True(t, resolutionHandler.Called, "legacy resolution handler should have been called")
+		assert.True(t, resolutionHandler.Config.GetBool(FlagPrintOutputJsonlWithErrors),
+			"FlagPrintOutputJsonlWithErrors should be forwarded to legacy config")
+		assert.False(t, resolutionHandler.Config.GetBool(FlagPrintEffectiveGraphWithErrors),
+			"FlagPrintEffectiveGraphWithErrors must be disabled when FlagPrintOutputJsonlWithErrors is used")
+		assert.False(t, resolutionHandler.Config.GetBool(FlagPrintEffectiveGraph),
+			"FlagPrintEffectiveGraph should be unset in legacy config")
+	})
+
+	t.Run("GIVEN FlagPrintOutputJsonlWithErrors not set WHEN executeLegacyWorkflow THEN enables effective-graph-with-errors by default", func(t *testing.T) {
+		// GIVEN
+		ctx := setupTestContext(t, false)
+		// FlagPrintOutputJsonlWithErrors is false by default
+
+		resolutionHandler := NewCalledResolutionHandlerFunc([]workflow.Data{}, nil)
+		mockPlugin := &mockScaPlugin{}
+
+		// WHEN
+		_, err := handleSBOMResolutionDI(
+			ctx.invocationContext,
+			ctx.config,
+			&nopLogger,
+			[]ecosystems.SCAPlugin{mockPlugin},
+			resolutionHandler.Func(),
+		)
+
+		// THEN
+		require.NoError(t, err)
+		require.True(t, resolutionHandler.Called, "legacy resolution handler should have been called")
+		assert.True(t, resolutionHandler.Config.GetBool(FlagPrintEffectiveGraphWithErrors),
+			"FlagPrintEffectiveGraphWithErrors must be enabled by default for SBOM resolution")
+		assert.False(t, resolutionHandler.Config.GetBool(FlagPrintOutputJsonlWithErrors),
+			"FlagPrintOutputJsonlWithErrors should remain false when not explicitly set")
+		assert.False(t, resolutionHandler.Config.GetBool(FlagPrintEffectiveGraph),
+			"FlagPrintEffectiveGraph should be unset in legacy config")
+	})
+
+	t.Run("GIVEN FlagPrintOutputJsonlWithErrors is set WHEN executeLegacyWorkflow runs THEN parent config is not mutated", func(t *testing.T) {
+		// GIVEN
+		ctx := setupTestContext(t, false)
+		ctx.config.Set(FlagPrintOutputJsonlWithErrors, true)
+		ctx.config.Set(FlagPrintEffectiveGraph, true)
+
+		resolutionHandler := NewCalledResolutionHandlerFunc([]workflow.Data{}, nil)
+		mockPlugin := &mockScaPlugin{}
+
+		// WHEN
+		_, err := handleSBOMResolutionDI(
+			ctx.invocationContext,
+			ctx.config,
+			&nopLogger,
+			[]ecosystems.SCAPlugin{mockPlugin},
+			resolutionHandler.Func(),
+		)
+		require.NoError(t, err)
+
+		// THEN: original config should not be modified
+		assert.True(t, ctx.config.GetBool(FlagPrintEffectiveGraph),
+			"parent config FlagPrintEffectiveGraph should remain unchanged after executeLegacyWorkflow")
+		assert.True(t, ctx.config.GetBool(FlagPrintOutputJsonlWithErrors),
+			"parent config FlagPrintOutputJsonlWithErrors should remain unchanged after executeLegacyWorkflow")
+	})
+}
+
 func Test_parseExcludeFlag(t *testing.T) {
 	testCases := []struct {
 		name     string


### PR DESCRIPTION
## Checklist

- [x] Tests written and linted
- [ ] Documentation written
- [x] Commit history is tidy

---

## What this does

When running `snyk sbom --all-projects`, the CLI previously used `fail-fast` mode: if **any** project in the workspace failed to resolve (e.g. missing lockfile, unsupported manifest), the entire SBOM generation was aborted and no output was produced.

This PR introduces the `--allow-incomplete-sbom` flag that lets users opt in to a **partial-success** mode. When the flag is set alongside `--all-projects`:

- Projects that resolve successfully are included in the generated SBOM.
- Projects that fail are collected as structured `ScanError` entries (with a `subject` path and human-readable `text` message) and forwarded to the SBOM service alongside the successful dep-graphs.

## References
https://docs.google.com/document/d/1vhRKlienHz1kbrCI-2BJ3maO6ykmlAz-hSApgo8MGEw/edit
https://docs.google.com/document/d/1i4exfAq3Dvoy_mKwQAwL3LYE6_Qkt7jQVYVOSzijZdw/edit
https://docs.google.com/document/d/1j0gNbzCALFF3WfIxLd5PVBtglJb4kYGQdheoM27VMaY/edit