### PR TITLE
feat: emit root package name on project identity

### DIFF
--- a/pkg/ecosystems/orchestrator/orchestrator.go
+++ b/pkg/ecosystems/orchestrator/orchestrator.go
@@ -212,7 +212,8 @@ func depGraphOutputToSCAResult(output *parsers.DepGraphOutput, ictx workflow.Inv
 	result := ecosystems.SCAResult{
 		ProjectDescriptor: identity.ProjectDescriptor{
 			Identity: identity.ProjectIdentity{
-				TargetFile: &output.NormalisedTargetFile,
+				TargetFile:    &output.NormalisedTargetFile,
+				TargetRuntime: output.TargetRuntime,
 			},
 		},
 	}
@@ -240,12 +241,11 @@ func depGraphOutputToSCAResult(output *parsers.DepGraphOutput, ictx workflow.Inv
 		}
 
 		result.DepGraph = &dg
+		result.ProjectDescriptor.Identity.ProjectType = dg.PkgManager.Name
+		result.ProjectDescriptor.Identity.TargetFile = getProjectTargetFileBasedOnType(dg.PkgManager.Name, output.NormalisedTargetFile, output.Workspace != nil)
 
-		if dg.PkgManager.Name != "" {
-			result.ProjectDescriptor.Identity.Type = dg.PkgManager.Name
-			result.ProjectDescriptor.Identity.TargetFile = getProjectTargetFileBasedOnType(dg.PkgManager.Name, output.NormalisedTargetFile, output.Workspace != nil)
-			// Extract runtime from depgraph if available
-			result.ProjectDescriptor.Identity.TargetRuntime = output.TargetRuntime
+		if rootPkg := dg.GetRootPkg(); rootPkg != nil {
+			result.ProjectDescriptor.Identity.RootComponentName = rootPkg.Info.Name
 		}
 	}
 

--- a/pkg/ecosystems/orchestrator/orchestrator_test.go
+++ b/pkg/ecosystems/orchestrator/orchestrator_test.go
@@ -19,7 +19,7 @@ func TestLegacyFallback_MapsProjectType(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, results, 1)
 
-	assert.Equal(t, "npm", results[0].ProjectDescriptor.Identity.Type)
+	assert.Equal(t, "npm", results[0].ProjectDescriptor.Identity.ProjectType)
 }
 
 func TestLegacyFallback_MapsTargetFramework(t *testing.T) {
@@ -160,4 +160,12 @@ func runLegacyFallback(t *testing.T, testBody string) ([]ecosystems.SCAResult, e
 			nil)
 
 	return LegacyFallback(ictx, *opts, nil)
+}
+
+func TestLegacyFallback_MapsRootComponentName(t *testing.T) {
+	results, err := runLegacyFallback(t, `{"depGraph":{"pkgManager":{"name":"nuget"},"pkgs":[{"id":"my-project@","info":{"name":"my-project"}}],"graph":{"rootNodeId":"root","nodes":[{"nodeId":"root","pkgId":"my-project@"}]}},"normalisedTargetFile":"project.assets.json","targetFileFromPlugin":"project.assets.json","target":{}}`) //nolint:lll // This is fine.
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	assert.Equal(t, "my-project", results[0].ProjectDescriptor.Identity.RootComponentName)
 }

--- a/pkg/ecosystems/python/pip/plugin.go
+++ b/pkg/ecosystems/python/pip/plugin.go
@@ -84,7 +84,7 @@ func (p Plugin) BuildDepGraphsFromDir(
 				result = ecosystems.SCAResult{
 					ProjectDescriptor: identity.ProjectDescriptor{
 						Identity: identity.ProjectIdentity{
-							Type:             "pip",
+							ProjectType:      "pip",
 							BaseNameOverride: options.Global.ProjectName,
 						},
 					},
@@ -201,7 +201,7 @@ func (p Plugin) buildDepGraphFromFile(
 		DepGraph: depGraph,
 		ProjectDescriptor: identity.ProjectDescriptor{
 			Identity: identity.ProjectIdentity{
-				Type:             "pip",
+				ProjectType:      "pip",
 				BaseNameOverride: baseNameOverride,
 			},
 		},

--- a/pkg/ecosystems/python/pip/plugin_integration_test.go
+++ b/pkg/ecosystems/python/pip/plugin_integration_test.go
@@ -245,8 +245,8 @@ func assertResultsMatchExpected(t *testing.T, actual, expected []ecosystems.SCAR
 	// Sync runtime field (varies by Python version) and clear Error field (not in JSON)
 	for i := range sortExpected {
 		sortExpected[i].ProjectDescriptor.Identity.TargetRuntime = sortActual[i].ProjectDescriptor.Identity.TargetRuntime
-		sortActual[i].ProjectDescriptor.Identity.Type = "" // Clear type since fixtures are shared
-		sortActual[i].Error = nil                          // Error field isn't in expected JSON
+		sortActual[i].ProjectDescriptor.Identity.ProjectType = "" // Clear type since fixtures are shared
+		sortActual[i].Error = nil                                 // Error field isn't in expected JSON
 	}
 
 	// Compare by JSON representation to ignore internal unexported fields in depgraph.DepGraph

--- a/pkg/ecosystems/python/pipenv/plugin.go
+++ b/pkg/ecosystems/python/pipenv/plugin.go
@@ -87,7 +87,7 @@ func (p Plugin) BuildDepGraphsFromDir(
 				result = ecosystems.SCAResult{
 					ProjectDescriptor: identity.ProjectDescriptor{
 						Identity: identity.ProjectIdentity{
-							Type:             "pip",
+							ProjectType:      "pip",
 							TargetFile:       &file.RelPath,
 							BaseNameOverride: options.Global.ProjectName,
 						},
@@ -213,7 +213,7 @@ func (p Plugin) buildDepGraphFromPipfile(
 		DepGraph: depGraph,
 		ProjectDescriptor: identity.ProjectDescriptor{
 			Identity: identity.ProjectIdentity{
-				Type:             "pip",
+				ProjectType:      "pip",
 				TargetFile:       &file.RelPath,
 				BaseNameOverride: baseNameOverride,
 			},

--- a/pkg/ecosystems/python/pipenv/plugin_integration_test.go
+++ b/pkg/ecosystems/python/pipenv/plugin_integration_test.go
@@ -220,7 +220,7 @@ func assertResultsMatchExpected(t *testing.T, actual, expected []ecosystems.SCAR
 	for i := range sortExpected {
 		sortExpected[i].ProjectDescriptor.Identity.TargetRuntime = sortActual[i].ProjectDescriptor.Identity.TargetRuntime
 		sortExpected[i].ProjectDescriptor.Identity.TargetFile = sortActual[i].ProjectDescriptor.Identity.TargetFile
-		sortActual[i].ProjectDescriptor.Identity.Type = "" // Clear type since fixtures are shared
+		sortActual[i].ProjectDescriptor.Identity.ProjectType = "" // Clear type since fixtures are shared
 		if sortExpected[i].DepGraph != nil && sortActual[i].DepGraph != nil {
 			sortExpected[i].DepGraph.PkgManager = sortActual[i].DepGraph.PkgManager
 		}

--- a/pkg/ecosystems/python/uv/plugin.go
+++ b/pkg/ecosystems/python/uv/plugin.go
@@ -71,8 +71,8 @@ func (p Plugin) BuildDepGraphsFromDir(
 			errorResult := scaecosystems.SCAResult{
 				ProjectDescriptor: identity.ProjectDescriptor{
 					Identity: identity.ProjectIdentity{
-						Type:       "uv",
-						TargetFile: &lockFilePath,
+						ProjectType: "uv",
+						TargetFile:  &lockFilePath,
 					},
 				},
 				Error: wrappedErr,
@@ -118,8 +118,8 @@ func (p Plugin) buildResults(
 			Results: []scaecosystems.SCAResult{{
 				ProjectDescriptor: identity.ProjectDescriptor{
 					Identity: identity.ProjectIdentity{
-						Type:       "uv",
-						TargetFile: &lockFilePath,
+						ProjectType: "uv",
+						TargetFile:  &lockFilePath,
 					},
 				},
 				Error: noRootErr,
@@ -170,8 +170,8 @@ func (p Plugin) buildResults(
 			DepGraph: depGraph,
 			ProjectDescriptor: identity.ProjectDescriptor{
 				Identity: identity.ProjectIdentity{
-					Type:       "uv",
-					TargetFile: &manifestFile,
+					ProjectType: "uv",
+					TargetFile:  &manifestFile,
 				},
 			},
 		}

--- a/pkg/identity/project.go
+++ b/pkg/identity/project.go
@@ -8,14 +8,16 @@ type ProjectDescriptor struct {
 
 // ProjectIdentity defines the core identifying characteristics of a project.
 type ProjectIdentity struct {
-	// Type specifies the project type (e.g., "npm", "maven", "pip")
-	Type string `json:"type,omitempty"`
+	// ProjectType specifies the project type (e.g., "npm", "maven", "pip")
+	ProjectType string `json:"type,omitempty"`
 	// BaseNameOverride allows overriding the default base name for the project
 	BaseNameOverride *string `json:"baseNameOverride,omitempty"`
 	// TargetFile specifies the manifest or build file for the project
 	TargetFile *string `json:"targetFile,omitempty"`
 	// TargetRuntime specifies the runtime environment for the project
 	TargetRuntime *string `json:"targetRuntime,omitempty"`
+	// RootComponentName specifies the component's name that is at the root of the project
+	RootComponentName string `json:"rootComponentName,omitempty"`
 }
 
 // GetTargetFile extracts the target file from a ProjectDescriptor.


### PR DESCRIPTION
### What this does

Since the os-flows extension needs the root package name for identity, let's add it to this extensions interface so that os-flows don't have to extract it from the dep-graph.

Opinionated change: also renames `Type` to `ProjectType`.
