### PR TITLE
feat: include root component name in project identity for pip, pipenv…

### DIFF
--- a/pkg/ecosystems/python/pip/plugin.go
+++ b/pkg/ecosystems/python/pip/plugin.go
@@ -67,7 +67,7 @@ func (p Plugin) BuildDepGraphsFromDir(
 	for _, file := range files {
 		g.Go(func() error {
 			projectName := GetProjectName(file.RelPath, dir)
-			result, err := p.buildDepGraphFromFile(ctx, log, file, pythonVersion, options.Python.NoBuildIsolation, projectName, options.Global.ProjectName)
+			result, err := p.buildDepGraphFromFile(ctx, log, file, pythonVersion, options.Python.NoBuildIsolation, projectName)
 			if err != nil {
 				attrs := []logger.Field{
 					logger.Attr(logFieldFile, file.RelPath),
@@ -84,8 +84,7 @@ func (p Plugin) BuildDepGraphsFromDir(
 				result = ecosystems.SCAResult{
 					ProjectDescriptor: identity.ProjectDescriptor{
 						Identity: identity.ProjectIdentity{
-							ProjectType:      "pip",
-							BaseNameOverride: options.Global.ProjectName,
+							ProjectType: "pip",
 						},
 					},
 					Error: err,
@@ -175,7 +174,6 @@ func (p Plugin) buildDepGraphFromFile(
 	pythonVersion string,
 	noBuildIsolation bool,
 	projectName string,
-	baseNameOverride *string,
 ) (ecosystems.SCAResult, error) {
 	log.Debug(ctx, "Building dependency graph",
 		logger.Attr(logFieldFile, file.RelPath),
@@ -197,12 +195,18 @@ func (p Plugin) buildDepGraphFromFile(
 	log.Debug(ctx, "Successfully built dependency graph",
 		logger.Attr(logFieldFile, file.RelPath))
 
+	var rootName string
+	if rootPkg := depGraph.GetRootPkg(); rootPkg != nil {
+		rootName = rootPkg.Info.Name
+	}
+
 	return ecosystems.SCAResult{
 		DepGraph: depGraph,
 		ProjectDescriptor: identity.ProjectDescriptor{
 			Identity: identity.ProjectIdentity{
-				ProjectType:      "pip",
-				BaseNameOverride: baseNameOverride,
+				ProjectType:       "pip",
+				TargetFile:        &file.RelPath,
+				RootComponentName: rootName,
 			},
 		},
 	}, nil

--- a/pkg/ecosystems/python/pip/plugin.go
+++ b/pkg/ecosystems/python/pip/plugin.go
@@ -66,7 +66,7 @@ func (p Plugin) BuildDepGraphsFromDir(
 
 	for _, file := range files {
 		g.Go(func() error {
-			projectName := GetProjectName(file.RelPath, dir)
+			projectName := GetProjectName(file.RelPath, dir, options.Global.ProjectName)
 			result, err := p.buildDepGraphFromFile(ctx, log, file, pythonVersion, options.Python.NoBuildIsolation, projectName)
 			if err != nil {
 				attrs := []logger.Field{
@@ -153,7 +153,11 @@ func (p Plugin) discoverRequirementsFiles(ctx context.Context, dir string, optio
 //   - "project/test/requirements.txt" -> "test"
 //   - "project/requirements.txt" -> "project"
 //   - "requirements.txt" (with scanDir="/path/to/myproject") -> "myproject"
-func GetProjectName(filePath, scanDir string) string {
+func GetProjectName(filePath, scanDir string, override *string) string {
+	if override != nil && *override != "" {
+		return *override
+	}
+
 	// Extract the directory name from the file path
 	dir := filepath.Dir(filePath)
 	projectName := filepath.Base(dir)

--- a/pkg/ecosystems/python/pip/plugin_integration_test.go
+++ b/pkg/ecosystems/python/pip/plugin_integration_test.go
@@ -242,9 +242,10 @@ func assertResultsMatchExpected(t *testing.T, actual, expected []ecosystems.SCAR
 		return sortExpected[i].DepGraph.GetRootPkg().Info.Name < sortExpected[j].DepGraph.GetRootPkg().Info.Name
 	})
 
-	// Sync runtime field (varies by Python version) and clear Error field (not in JSON)
+	// Sync fields that vary between pip and pipenv or by environment (allows sharing fixtures)
 	for i := range sortExpected {
 		sortExpected[i].ProjectDescriptor.Identity.TargetRuntime = sortActual[i].ProjectDescriptor.Identity.TargetRuntime
+		sortExpected[i].ProjectDescriptor.Identity.TargetFile = sortActual[i].ProjectDescriptor.Identity.TargetFile
 		sortActual[i].ProjectDescriptor.Identity.ProjectType = "" // Clear type since fixtures are shared
 		sortActual[i].Error = nil                                 // Error field isn't in expected JSON
 	}

--- a/pkg/ecosystems/python/pip/plugin_test.go
+++ b/pkg/ecosystems/python/pip/plugin_test.go
@@ -1,0 +1,65 @@
+//go:build !integration
+// +build !integration
+
+package pip
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func ptr(s string) *string { return &s }
+
+func TestGetProjectName(t *testing.T) {
+	tests := map[string]struct {
+		filePath string
+		scanDir  string
+		override *string
+		expected string
+	}{
+		"override_takes_precedence": {
+			filePath: "project/requirements.txt",
+			scanDir:  "/path/to/scandir",
+			override: ptr("custom-name"),
+			expected: "custom-name",
+		},
+		"empty_override_is_ignored": {
+			filePath: "project/requirements.txt",
+			scanDir:  "/path/to/scandir",
+			override: ptr(""),
+			expected: "project",
+		},
+		"nil_override_uses_directory": {
+			filePath: "project/requirements.txt",
+			scanDir:  "/path/to/scandir",
+			override: nil,
+			expected: "project",
+		},
+		"nested_path_uses_immediate_parent": {
+			filePath: "project/test/requirements.txt",
+			scanDir:  "/path/to/scandir",
+			override: nil,
+			expected: "test",
+		},
+		"root_file_falls_back_to_scan_dir": {
+			filePath: "requirements.txt",
+			scanDir:  "/path/to/myproject",
+			override: nil,
+			expected: "myproject",
+		},
+		"deeply_nested_uses_immediate_parent": {
+			filePath: "a/b/c/d/requirements.txt",
+			scanDir:  "/path/to/scandir",
+			override: nil,
+			expected: "d",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			result := GetProjectName(tt.filePath, tt.scanDir, tt.override)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/pkg/ecosystems/python/pipenv/plugin.go
+++ b/pkg/ecosystems/python/pipenv/plugin.go
@@ -68,7 +68,7 @@ func (p Plugin) BuildDepGraphsFromDir(
 
 	for _, file := range files {
 		g.Go(func() error {
-			projectName := pip.GetProjectName(file.RelPath, dir)
+			projectName := pip.GetProjectName(file.RelPath, dir, options.Global.ProjectName)
 			result, err := p.buildDepGraphFromPipfile(ctx, log, file, pythonVersion, options.Python.NoBuildIsolation,
 				options.Global.IncludeDev, projectName)
 			if err != nil {

--- a/pkg/ecosystems/python/pipenv/plugin.go
+++ b/pkg/ecosystems/python/pipenv/plugin.go
@@ -70,7 +70,7 @@ func (p Plugin) BuildDepGraphsFromDir(
 		g.Go(func() error {
 			projectName := pip.GetProjectName(file.RelPath, dir)
 			result, err := p.buildDepGraphFromPipfile(ctx, log, file, pythonVersion, options.Python.NoBuildIsolation,
-				options.Global.IncludeDev, projectName, options.Global.ProjectName)
+				options.Global.IncludeDev, projectName)
 			if err != nil {
 				attrs := []logger.Field{
 					logger.Attr(logFieldFile, file.RelPath),
@@ -87,9 +87,8 @@ func (p Plugin) BuildDepGraphsFromDir(
 				result = ecosystems.SCAResult{
 					ProjectDescriptor: identity.ProjectDescriptor{
 						Identity: identity.ProjectIdentity{
-							ProjectType:      "pip",
-							TargetFile:       &file.RelPath,
-							BaseNameOverride: options.Global.ProjectName,
+							ProjectType: "pip",
+							TargetFile:  &file.RelPath,
 						},
 					},
 					Error: err,
@@ -161,7 +160,6 @@ func (p Plugin) buildDepGraphFromPipfile(
 	noBuildIsolation bool,
 	includeDevDeps bool,
 	projectName string,
-	baseNameOverride *string,
 ) (ecosystems.SCAResult, error) {
 	log.Debug(ctx, "Building dependency graph from Pipfile",
 		logger.Attr(logFieldFile, file.RelPath),
@@ -209,13 +207,18 @@ func (p Plugin) buildDepGraphFromPipfile(
 	log.Info(ctx, "Successfully built dependency graph from Pipfile",
 		logger.Attr(logFieldFile, file.RelPath))
 
+	var rootName string
+	if rootPkg := depGraph.GetRootPkg(); rootPkg != nil {
+		rootName = rootPkg.Info.Name
+	}
+
 	return ecosystems.SCAResult{
 		DepGraph: depGraph,
 		ProjectDescriptor: identity.ProjectDescriptor{
 			Identity: identity.ProjectIdentity{
-				ProjectType:      "pip",
-				TargetFile:       &file.RelPath,
-				BaseNameOverride: baseNameOverride,
+				ProjectType:       "pip",
+				TargetFile:        &file.RelPath,
+				RootComponentName: rootName,
 			},
 		},
 	}, nil

--- a/pkg/ecosystems/python/pipenv/plugin_integration_test.go
+++ b/pkg/ecosystems/python/pipenv/plugin_integration_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"testing"
 	"time"
 
@@ -155,7 +156,7 @@ func TestPlugin_BuildDepGraphsFromDir_PipErrors(t *testing.T) {
 
 			// Basic metadata expectations
 			assert.Equal(t, "Pipfile", pipenvResult.ProjectDescriptor.GetTargetFile())
-			if pythonVersion != "" {
+			if pythonVersion != "" && pipenvResult.ProjectDescriptor.Identity.TargetRuntime != nil {
 				assert.Contains(t, *pipenvResult.ProjectDescriptor.Identity.TargetRuntime, fmt.Sprintf("python@%s", pythonVersion))
 			}
 
@@ -234,7 +235,10 @@ func assertResultsMatchExpected(t *testing.T, actual, expected []ecosystems.SCAR
 	expectedJSON, err := json.Marshal(sortExpected)
 	require.NoError(t, err, "[%s] failed to marshal expected results", fixtureName)
 
-	assert.JSONEq(t, string(expectedJSON), string(actualJSON), "[%s] results mismatch", fixtureName)
+	resolvedExpectedJSON, err := resolveWildcardVersions(expectedJSON, actualJSON)
+	require.NoError(t, err, "[%s] failed to resolve wildcard versions", fixtureName)
+
+	assert.JSONEq(t, string(resolvedExpectedJSON), string(actualJSON), "[%s] results mismatch", fixtureName)
 }
 
 // getFirstDirectDep returns the name of the first direct dependency in the graph for sorting purposes.
@@ -264,6 +268,103 @@ func loadExpectedResults(path string) ([]ecosystems.SCAResult, error) {
 	}
 
 	return expected, nil
+}
+
+// resolveWildcardVersions substitutes wildcard versions ("*") in expectedJSON with the actual
+// resolved versions from actualJSON. Each result's wildcards are resolved independently using
+// that result's actual packages, so results from different requirements files don't interfere.
+func resolveWildcardVersions(expectedJSON, actualJSON []byte) ([]byte, error) {
+	var actualResults []any
+	if err := json.Unmarshal(actualJSON, &actualResults); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal actual results: %w", err)
+	}
+
+	var expectedResults []any
+	if err := json.Unmarshal(expectedJSON, &expectedResults); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal expected results: %w", err)
+	}
+
+	if len(actualResults) != len(expectedResults) {
+		return expectedJSON, nil
+	}
+
+	for i := range expectedResults {
+		actualResult, ok := actualResults[i].(map[string]any)
+		if !ok {
+			continue
+		}
+		expectedResult, ok := expectedResults[i].(map[string]any)
+		if !ok {
+			continue
+		}
+		nameToVersion := extractNameVersionMap(actualResult)
+		substituteWildcards(expectedResult, nameToVersion)
+	}
+
+	resolved, err := json.Marshal(expectedResults)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal resolved expected: %w", err)
+	}
+	return resolved, nil
+}
+
+func extractNameVersionMap(result map[string]any) map[string]string {
+	nameToVersion := make(map[string]string)
+	depGraph, ok := result["depGraph"].(map[string]any)
+	if !ok {
+		return nameToVersion
+	}
+	pkgs, ok := depGraph["pkgs"].([]any)
+	if !ok {
+		return nameToVersion
+	}
+	for _, pkg := range pkgs {
+		pkgMap, ok := pkg.(map[string]any)
+		if !ok {
+			continue
+		}
+		id, ok := pkgMap["id"].(string)
+		if !ok {
+			continue
+		}
+		atIdx := strings.LastIndex(id, "@")
+		if atIdx < 0 {
+			continue
+		}
+		nameToVersion[id[:atIdx]] = id[atIdx+1:]
+	}
+	return nameToVersion
+}
+
+func substituteWildcards(v any, nameToVersion map[string]string) {
+	switch node := v.(type) {
+	case map[string]any:
+		if version, ok := node["version"].(string); ok && version == "*" {
+			if name, ok := node["name"].(string); ok {
+				if actual, found := nameToVersion[name]; found {
+					node["version"] = actual
+				}
+			}
+		}
+		for _, key := range []string{"id", "nodeId", "pkgId"} {
+			if s, ok := node[key].(string); ok {
+				if idx := strings.Index(s, "@*"); idx >= 0 {
+					name := s[:idx]
+					suffix := s[idx+2:]
+					if actual, found := nameToVersion[name]; found {
+						node[key] = name + "@" + actual + suffix
+					}
+				}
+			}
+		}
+		for _, val := range node {
+			substituteWildcards(val, nameToVersion)
+		}
+	case []any:
+		for _, item := range node {
+			substituteWildcards(item, nameToVersion)
+		}
+	}
 }
 
 // getPythonMajorMinorVersion returns the Python version as "X.Y" (e.g., "3.11")

--- a/pkg/ecosystems/python/uv/plugin.go
+++ b/pkg/ecosystems/python/uv/plugin.go
@@ -166,12 +166,18 @@ func (p Plugin) buildResults(
 			result.ProcessedFiles = append(result.ProcessedFiles, filepath.Join(packagePath, name))
 		}
 
+		var rootName string
+		if rootPkg := depGraph.GetRootPkg(); rootPkg != nil {
+			rootName = rootPkg.Info.Name
+		}
+
 		res := scaecosystems.SCAResult{
 			DepGraph: depGraph,
 			ProjectDescriptor: identity.ProjectDescriptor{
 				Identity: identity.ProjectIdentity{
-					ProjectType: "uv",
-					TargetFile:  &manifestFile,
+					ProjectType:       "uv",
+					TargetFile:        &manifestFile,
+					RootComponentName: rootName,
 				},
 			},
 		}

--- a/pkg/ecosystems/testdata/fixtures/python/empty/expected_plugin.json
+++ b/pkg/ecosystems/testdata/fixtures/python/empty/expected_plugin.json
@@ -27,6 +27,7 @@
     },
     "projectDescriptor": {
       "identity": {
+        "rootComponentName": "empty",
         "targetRuntime": "python@3.14.1"
       }
     }

--- a/pkg/ecosystems/testdata/fixtures/python/env-markers/expected_plugin.json
+++ b/pkg/ecosystems/testdata/fixtures/python/env-markers/expected_plugin.json
@@ -104,6 +104,7 @@
     },
     "projectDescriptor": {
       "identity": {
+        "rootComponentName": "env-markers",
         "targetRuntime": "python@3.14.1"
       }
     }

--- a/pkg/ecosystems/testdata/fixtures/python/env-markers/expected_plugin_3.8.json
+++ b/pkg/ecosystems/testdata/fixtures/python/env-markers/expected_plugin_3.8.json
@@ -135,6 +135,7 @@
     },
     "projectDescriptor": {
       "identity": {
+        "rootComponentName": "env-markers",
         "targetRuntime": "python@3.8.20"
       }
     }

--- a/pkg/ecosystems/testdata/fixtures/python/env-markers/expected_plugin_3.9.json
+++ b/pkg/ecosystems/testdata/fixtures/python/env-markers/expected_plugin_3.9.json
@@ -135,6 +135,7 @@
     },
     "projectDescriptor": {
       "identity": {
+        "rootComponentName": "env-markers",
         "targetRuntime": "python@3.9.25"
       }
     }

--- a/pkg/ecosystems/testdata/fixtures/python/git-references/expected_plugin.json
+++ b/pkg/ecosystems/testdata/fixtures/python/git-references/expected_plugin.json
@@ -195,6 +195,7 @@
     },
     "projectDescriptor": {
       "identity": {
+        "rootComponentName": "git-references",
         "targetRuntime": "python@3.14.1"
       }
     }

--- a/pkg/ecosystems/testdata/fixtures/python/git-references/expected_plugin_3.10.json
+++ b/pkg/ecosystems/testdata/fixtures/python/git-references/expected_plugin_3.10.json
@@ -225,6 +225,7 @@
     },
     "projectDescriptor": {
       "identity": {
+        "rootComponentName": "git-references",
         "targetRuntime": "python@3.10.19"
       }
     }

--- a/pkg/ecosystems/testdata/fixtures/python/git-references/expected_plugin_3.8.json
+++ b/pkg/ecosystems/testdata/fixtures/python/git-references/expected_plugin_3.8.json
@@ -225,6 +225,7 @@
     },
     "projectDescriptor": {
       "identity": {
+        "rootComponentName": "git-references",
         "targetRuntime": "python@3.8.20"
       }
     }

--- a/pkg/ecosystems/testdata/fixtures/python/git-references/expected_plugin_3.9.json
+++ b/pkg/ecosystems/testdata/fixtures/python/git-references/expected_plugin_3.9.json
@@ -225,6 +225,7 @@
     },
     "projectDescriptor": {
       "identity": {
+        "rootComponentName": "git-references",
         "targetRuntime": "python@3.9.25"
       }
     }

--- a/pkg/ecosystems/testdata/fixtures/python/multi-requirements/expected_plugin.json
+++ b/pkg/ecosystems/testdata/fixtures/python/multi-requirements/expected_plugin.json
@@ -58,7 +58,9 @@
       }
     },
     "projectDescriptor": {
-      "identity": {}
+      "identity": {
+        "rootComponentName": "frontend"
+      }
     }
   },
   {
@@ -165,7 +167,9 @@
       }
     },
     "projectDescriptor": {
-      "identity": {}
+      "identity": {
+        "rootComponentName": "multi-requirements"
+      }
     }
   },
   {
@@ -317,7 +321,9 @@
       }
     },
     "projectDescriptor": {
-      "identity": {}
+      "identity": {
+        "rootComponentName": "backend"
+      }
     }
   }
 ]

--- a/pkg/ecosystems/testdata/fixtures/python/multi-requirements/expected_plugin_3.8.json
+++ b/pkg/ecosystems/testdata/fixtures/python/multi-requirements/expected_plugin_3.8.json
@@ -58,7 +58,9 @@
       }
     },
     "projectDescriptor": {
-      "identity": {}
+      "identity": {
+        "rootComponentName": "frontend"
+      }
     }
   },
   {
@@ -165,7 +167,9 @@
       }
     },
     "projectDescriptor": {
-      "identity": {}
+      "identity": {
+        "rootComponentName": "multi-requirements"
+      }
     }
   },
   {
@@ -362,7 +366,9 @@
       }
     },
     "projectDescriptor": {
-      "identity": {}
+      "identity": {
+        "rootComponentName": "backend"
+      }
     }
   }
 ]

--- a/pkg/ecosystems/testdata/fixtures/python/multi-requirements/expected_plugin_3.9.json
+++ b/pkg/ecosystems/testdata/fixtures/python/multi-requirements/expected_plugin_3.9.json
@@ -58,7 +58,9 @@
       }
     },
     "projectDescriptor": {
-      "identity": {}
+      "identity": {
+        "rootComponentName": "frontend"
+      }
     }
   },
   {
@@ -165,7 +167,9 @@
       }
     },
     "projectDescriptor": {
-      "identity": {}
+      "identity": {
+        "rootComponentName": "multi-requirements"
+      }
     }
   },
   {
@@ -362,7 +366,9 @@
       }
     },
     "projectDescriptor": {
-      "identity": {}
+      "identity": {
+        "rootComponentName": "backend"
+      }
     }
   }
 ]

--- a/pkg/ecosystems/testdata/fixtures/python/multiple-deps/expected_plugin.json
+++ b/pkg/ecosystems/testdata/fixtures/python/multiple-deps/expected_plugin.json
@@ -119,6 +119,7 @@
     },
     "projectDescriptor": {
       "identity": {
+        "rootComponentName": "multiple-deps",
         "targetRuntime": "python@3.14.1"
       }
     }

--- a/pkg/ecosystems/testdata/fixtures/python/os-specific/expected_plugin.json
+++ b/pkg/ecosystems/testdata/fixtures/python/os-specific/expected_plugin.json
@@ -104,6 +104,7 @@
     },
     "projectDescriptor": {
       "identity": {
+        "rootComponentName": "os-specific",
         "targetRuntime": "python@3.14.1"
       }
     }

--- a/pkg/ecosystems/testdata/fixtures/python/simple-with-dev-deps/expected_plugin.json
+++ b/pkg/ecosystems/testdata/fixtures/python/simple-with-dev-deps/expected_plugin.json
@@ -104,6 +104,7 @@
     },
     "projectDescriptor": {
       "identity": {
+        "rootComponentName": "simple-with-dev-deps",
         "targetFile": "Pipfile",
         "targetRuntime": "python@3.14.0"
       }

--- a/pkg/ecosystems/testdata/fixtures/python/simple-with-dev-deps/expected_plugin_3.10.json
+++ b/pkg/ecosystems/testdata/fixtures/python/simple-with-dev-deps/expected_plugin_3.10.json
@@ -104,6 +104,7 @@
     },
     "projectDescriptor": {
       "identity": {
+        "rootComponentName": "simple-with-dev-deps",
         "targetFile": "Pipfile",
         "targetRuntime": "python@3.10.19"
       }

--- a/pkg/ecosystems/testdata/fixtures/python/simple-with-dev-deps/expected_plugin_3.8.json
+++ b/pkg/ecosystems/testdata/fixtures/python/simple-with-dev-deps/expected_plugin_3.8.json
@@ -104,6 +104,7 @@
     },
     "projectDescriptor": {
       "identity": {
+        "rootComponentName": "simple-with-dev-deps",
         "targetFile": "Pipfile",
         "targetRuntime": "python@3.8.20"
       }

--- a/pkg/ecosystems/testdata/fixtures/python/simple-with-dev-deps/expected_plugin_3.9.json
+++ b/pkg/ecosystems/testdata/fixtures/python/simple-with-dev-deps/expected_plugin_3.9.json
@@ -104,6 +104,7 @@
     },
     "projectDescriptor": {
       "identity": {
+        "rootComponentName": "simple-with-dev-deps",
         "targetFile": "Pipfile",
         "targetRuntime": "python@3.9.25"
       }

--- a/pkg/ecosystems/testdata/fixtures/python/simple/expected_plugin.json
+++ b/pkg/ecosystems/testdata/fixtures/python/simple/expected_plugin.json
@@ -104,6 +104,7 @@
     },
     "projectDescriptor": {
       "identity": {
+        "rootComponentName": "simple",
         "targetRuntime": "python@3.14.1"
       }
     }

--- a/pkg/ecosystems/testdata/fixtures/python/transitive-conflicts/expected_plugin.json
+++ b/pkg/ecosystems/testdata/fixtures/python/transitive-conflicts/expected_plugin.json
@@ -227,6 +227,7 @@
     },
     "projectDescriptor": {
       "identity": {
+        "rootComponentName": "transitive-conflicts",
         "targetRuntime": "python@3.14.1"
       }
     }

--- a/pkg/ecosystems/testdata/fixtures/python/url-references/expected_plugin.json
+++ b/pkg/ecosystems/testdata/fixtures/python/url-references/expected_plugin.json
@@ -107,6 +107,7 @@
     },
     "projectDescriptor": {
       "identity": {
+        "rootComponentName": "url-references",
         "targetRuntime": "python@3.14.1"
       }
     }

--- a/pkg/ecosystems/testdata/fixtures/python/with-extras/expected_plugin.json
+++ b/pkg/ecosystems/testdata/fixtures/python/with-extras/expected_plugin.json
@@ -119,6 +119,7 @@
     },
     "projectDescriptor": {
       "identity": {
+        "rootComponentName": "with-extras",
         "targetRuntime": "python@3.14.1"
       }
     }

--- a/pkg/ecosystems/testdata/fixtures/python/with-version-specifiers/expected_plugin.json
+++ b/pkg/ecosystems/testdata/fixtures/python/with-version-specifiers/expected_plugin.json
@@ -122,6 +122,7 @@
     },
     "projectDescriptor": {
       "identity": {
+        "rootComponentName": "with-version-specifiers",
         "targetRuntime": "python@3.14.1"
       }
     }

--- a/pkg/identity/project.go
+++ b/pkg/identity/project.go
@@ -10,8 +10,6 @@ type ProjectDescriptor struct {
 type ProjectIdentity struct {
 	// ProjectType specifies the project type (e.g., "npm", "maven", "pip")
 	ProjectType string `json:"type,omitempty"`
-	// BaseNameOverride allows overriding the default base name for the project
-	BaseNameOverride *string `json:"baseNameOverride,omitempty"`
 	// TargetFile specifies the manifest or build file for the project
 	TargetFile *string `json:"targetFile,omitempty"`
 	// TargetRuntime specifies the runtime environment for the project


### PR DESCRIPTION
…, and uv plugins

- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [ ] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Includes root component name in all plugins and gets rid of `baseNameOverride`
