### PR TITLE
feat: use --exclude-paths for processed file exclusions

### DIFF
--- a/internal/legacycli/legacy_resolution.go
+++ b/internal/legacycli/legacy_resolution.go
@@ -115,6 +115,11 @@ func PrepareLegacyFlags(argument string, cfg configuration.Configuration, logger
 		logger.Print("Exclude:", exclude)
 	}
 
+	if excludePaths := cfg.GetString(workflow.FlagExcludePaths); excludePaths != "" {
+		cmdArgs = append(cmdArgs, "--exclude-paths="+excludePaths)
+		logger.Print("Exclude paths:", excludePaths)
+	}
+
 	if detectionDepth := cfg.GetString(workflow.FlagDetectionDepth); detectionDepth != "" {
 		cmdArgs = append(cmdArgs, "--detection-depth="+detectionDepth)
 		logger.Print("Detection depth:", detectionDepth)

--- a/internal/workflow/flags.go
+++ b/internal/workflow/flags.go
@@ -6,6 +6,7 @@ const (
 	FlagPrintOutputJsonlWithErrors    = "print-output-jsonl-with-errors"
 	FlagDev                           = "dev"
 	FlagExclude                       = "exclude"
+	FlagExcludePaths                  = "exclude-paths"
 	FlagFile                          = "file"
 	FlagDetectionDepth                = "detection-depth"
 	FlagPruneRepeatedSubdependencies  = "prune-repeated-subdependencies"

--- a/pkg/depgraph/flags.go
+++ b/pkg/depgraph/flags.go
@@ -41,6 +41,7 @@ func getFlagSet() *pflag.FlagSet {
 	flagSet.String(workflow.FlagNugetPkgsFolder, "", "Specify a custom path to the packages folder when using NuGet.")
 	flagSet.Int(workflow.FlagUnmanagedMaxDepth, 0, "Specify the maximum level of archive extraction for unmanaged scanning.")
 	flagSet.Bool(workflow.FlagIncludeProvenance, false, "Include checksums in purl to support package provenance.")
+	flagSet.String(workflow.FlagExcludePaths, "", "Comma-separated paths to exclude from scanning.")
 	flagSet.Bool(workflow.FlagUseSBOMResolution, false, "Use SBOM resolution instead of legacy CLI.")
 	flagSet.Bool(workflow.FlagPrintEffectiveGraph, false, "Return the pruned dependency graph.")
 	flagSet.Bool(workflow.FlagPrintEffectiveGraphWithErrors, false, "Return errors in the pruned dependency graph output.")

--- a/pkg/depgraph/sbom_resolution.go
+++ b/pkg/depgraph/sbom_resolution.go
@@ -86,6 +86,7 @@ func handleSBOMResolutionDI(
 	}
 	allowOutOfSync := !strictOutOfSync
 	exclude := parseExcludeFlag(config.GetString(workflow.FlagExclude))
+	excludePaths := parseExcludeFlag(config.GetString(workflow.FlagExcludePaths))
 	failFast := config.GetBool(workflow.FlagFailFast)
 	forceSingleGraph := config.GetBool(workflow.FlagForceSingleGraph)
 
@@ -95,6 +96,7 @@ func handleSBOMResolutionDI(
 		WithIncludeDev(dev).
 		WithAllowOutOfSync(allowOutOfSync).
 		WithExclude(exclude).
+		WithExcludePaths(excludePaths).
 		WithFailFast(failFast).
 		WithForceSingleGraph(forceSingleGraph)
 	if targetFile != "" {
@@ -282,12 +284,15 @@ func applyProcessedFilesExclusions(config configuration.Configuration, processed
 		return
 	}
 
-	exclude := config.GetString(workflow.FlagExclude)
-	if exclude != "" {
-		exclude = fmt.Sprintf("%s,", exclude)
+	// Use --exclude-paths (not --exclude) so processed file paths are matched
+	// exactly. --exclude only matches by basename, which would incorrectly
+	// exclude all same-named manifests across a workspace.
+	parts := make([]string, 0, len(processedFiles)+1)
+	if existing := config.GetString(workflow.FlagExcludePaths); existing != "" {
+		parts = append(parts, existing)
 	}
-	exclude = fmt.Sprintf("%s%s", exclude, strings.Join(processedFiles, ","))
-	config.Set(workflow.FlagExclude, exclude)
+	parts = append(parts, processedFiles...)
+	config.Set(workflow.FlagExcludePaths, strings.Join(parts, ","))
 }
 
 func executeLegacyWorkflow(

--- a/pkg/depgraph/sbom_resolution_test.go
+++ b/pkg/depgraph/sbom_resolution_test.go
@@ -444,6 +444,7 @@ func Test_callback_SBOMResolution(t *testing.T) {
 			expectedWorkflowDataLen          int
 			expectLegacyResolutionToBeCalled bool
 			expectedExclude                  string
+			expectedExcludePaths             string
 			pluginsShouldNotBeCalled         []int
 		}{
 			{
@@ -463,6 +464,7 @@ func Test_callback_SBOMResolution(t *testing.T) {
 				expectedWorkflowDataLen:          2,
 				expectLegacyResolutionToBeCalled: false,
 				expectedExclude:                  "",
+				expectedExcludePaths:             "",
 			},
 			{
 				name:           "should return all findings when FlagAllProjects is true",
@@ -479,7 +481,8 @@ func Test_callback_SBOMResolution(t *testing.T) {
 				// Expected: 2 SBOM findings + 1 legacy workflow depgraph = 3
 				expectedWorkflowDataLen:          3,
 				expectLegacyResolutionToBeCalled: true,
-				expectedExclude:                  "uv.lock,pyproject.toml,requirements.txt,setup.py",
+				expectedExclude:                  "",
+				expectedExcludePaths:             "uv.lock,pyproject.toml,requirements.txt,setup.py",
 			},
 			{
 				name:           "should continue to next plugin when first plugin returns zero findings and FlagAllProjects is false",
@@ -496,6 +499,7 @@ func Test_callback_SBOMResolution(t *testing.T) {
 				expectedWorkflowDataLen:          1,
 				expectLegacyResolutionToBeCalled: false,
 				expectedExclude:                  "",
+				expectedExcludePaths:             "",
 			},
 			{
 				name:           "should stop at first plugin and return its findings when FlagAllProjects is false",
@@ -516,6 +520,7 @@ func Test_callback_SBOMResolution(t *testing.T) {
 				expectedWorkflowDataLen:          2,
 				expectLegacyResolutionToBeCalled: false,
 				expectedExclude:                  "",
+				expectedExcludePaths:             "",
 				pluginsShouldNotBeCalled:         []int{1},
 			},
 			{
@@ -539,7 +544,8 @@ func Test_callback_SBOMResolution(t *testing.T) {
 				// Expected: 4 SBOM findings + 1 legacy workflow depgraph = 5
 				expectedWorkflowDataLen:          5,
 				expectLegacyResolutionToBeCalled: true,
-				expectedExclude:                  "uv.lock,pyproject.toml,requirements.txt,setup.py,package.json,go.mod",
+				expectedExclude:                  "",
+				expectedExcludePaths:             "uv.lock,pyproject.toml,requirements.txt,setup.py,package.json,go.mod",
 			},
 			{
 				name:           "should call legacy resolution workflow when no SBOM findings are found and FlagAllProjects is false",
@@ -552,9 +558,10 @@ func Test_callback_SBOMResolution(t *testing.T) {
 				expectedWorkflowDataLen:          1,
 				expectLegacyResolutionToBeCalled: true,
 				expectedExclude:                  "",
+				expectedExcludePaths:             "",
 			},
 			{
-				name:           "should append ProcessedFiles to existing FlagExclude when FlagAllProjects is true",
+				name:           "should put ProcessedFiles in FlagExcludePaths and leave user FlagExclude untouched",
 				allProjects:    true,
 				initialExclude: "existing-file.txt,another-file.py",
 				plugins: []ecosystems.SCAPlugin{
@@ -568,7 +575,8 @@ func Test_callback_SBOMResolution(t *testing.T) {
 				// Expected: 2 SBOM findings + 1 legacy workflow depgraph = 3
 				expectedWorkflowDataLen:          3,
 				expectLegacyResolutionToBeCalled: true,
-				expectedExclude:                  "existing-file.txt,another-file.py,uv.lock,pyproject.toml,requirements.txt,setup.py",
+				expectedExclude:                  "existing-file.txt,another-file.py",
+				expectedExcludePaths:             "uv.lock,pyproject.toml,requirements.txt,setup.py",
 			},
 		}
 
@@ -619,8 +627,10 @@ func Test_callback_SBOMResolution(t *testing.T) {
 				assert.Equal(t, tc.expectLegacyResolutionToBeCalled, resolutionHandler.Called)
 
 				if tc.expectLegacyResolutionToBeCalled {
-					actualExclude := resolutionHandler.Config.GetString(workflow.FlagExclude)
-					assert.Equal(t, tc.expectedExclude, actualExclude, "FlagExclude should contain ProcessedFiles from plugins")
+					assert.Equal(t, tc.expectedExclude, resolutionHandler.Config.GetString(workflow.FlagExclude),
+						"FlagExclude should retain user-supplied value (not be modified by ProcessedFiles)")
+					assert.Equal(t, tc.expectedExcludePaths, resolutionHandler.Config.GetString(workflow.FlagExcludePaths),
+						"FlagExcludePaths should contain ProcessedFiles from plugins")
 				}
 
 				for _, idx := range tc.pluginsShouldNotBeCalled {
@@ -676,7 +686,8 @@ func Test_callback_SBOMResolution(t *testing.T) {
 		assert.Len(t, workflowData, 1)
 		// Legacy resolution should have been called
 		assert.True(t, resolutionHandler.Called, "ResolutionHandlerFunc should be called")
-		assert.Equal(t, "uv.lock", resolutionHandler.Config.GetString(workflow.FlagExclude), "ProcessedFiles should be excluded from legacy resolution")
+		assert.Equal(t, "uv.lock", resolutionHandler.Config.GetString(workflow.FlagExcludePaths),
+			"ProcessedFiles should be excluded via FlagExcludePaths")
 	})
 
 	t.Run("should handle exit code 3 when no SBOM findings are found", func(t *testing.T) {
@@ -750,7 +761,8 @@ func Test_callback_SBOMResolution(t *testing.T) {
 		assert.Nil(t, workflowData)
 		// Legacy resolution should have been called
 		assert.True(t, resolutionHandler.Called, "ResolutionHandlerFunc should be called")
-		assert.Equal(t, "uv.lock", resolutionHandler.Config.GetString(workflow.FlagExclude), "ProcessedFiles should be excluded from legacy resolution")
+		assert.Equal(t, "uv.lock", resolutionHandler.Config.GetString(workflow.FlagExcludePaths),
+			"ProcessedFiles should be excluded via FlagExcludePaths")
 	})
 
 	t.Run("should skip findings with errors when legacy workflow returns no data", func(t *testing.T) {
@@ -799,8 +811,8 @@ func Test_callback_SBOMResolution(t *testing.T) {
 		assert.NotNil(t, workflowData)
 		assert.Len(t, workflowData, 1, "Should return only the valid finding since legacy workflow returns nil")
 		assert.True(t, resolutionHandler.Called, "ResolutionHandlerFunc should be called")
-		assert.Equal(t, "project1/uv.lock,project2/uv.lock", resolutionHandler.Config.GetString(workflow.FlagExclude),
-			"ProcessedFiles should be excluded from legacy resolution")
+		assert.Equal(t, "project1/uv.lock,project2/uv.lock", resolutionHandler.Config.GetString(workflow.FlagExcludePaths),
+			"ProcessedFiles should be excluded from legacy resolution via FlagExcludePaths")
 	})
 
 	t.Run("should log snyk_errors.Error details for support debugging", func(t *testing.T) {
@@ -1351,7 +1363,8 @@ func Test_callback_SBOMResolution(t *testing.T) {
 		require.NoError(t, err)
 		assert.NotNil(t, workflowData)
 		assert.True(t, resolutionHandler.Called, "ResolutionHandlerFunc should be called")
-		assert.Equal(t, "project1/uv.lock", resolutionHandler.Config.GetString(workflow.FlagExclude), "ProcessedFiles should be excluded from legacy resolution")
+		assert.Equal(t, "project1/uv.lock", resolutionHandler.Config.GetString(workflow.FlagExcludePaths),
+			"ProcessedFiles should be excluded via FlagExcludePaths")
 		assert.Contains(t, capturedOutput, "project1/uv.lock")
 	})
 
@@ -1511,8 +1524,8 @@ func Test_callback_SBOMResolution(t *testing.T) {
 		require.NoError(t, err)
 		assert.NotNil(t, workflowData)
 
-		assert.Equal(t, "project1/uv.lock,project2/uv.lock", resolutionHandler.Config.GetString(workflow.FlagExclude),
-			"ProcessedFiles should be excluded from legacy resolution")
+		assert.Equal(t, "project1/uv.lock,project2/uv.lock", resolutionHandler.Config.GetString(workflow.FlagExcludePaths),
+			"ProcessedFiles should be excluded from legacy resolution via FlagExcludePaths")
 		assert.Contains(t, capturedOutput, "project1/uv.lock", "Output should mention the first problem file")
 		assert.Contains(t, capturedOutput, "project2/uv.lock", "Output should mention the second problem file")
 		assert.Contains(t, capturedOutput, "Detailed error to help the customer debug the issue",
@@ -1711,51 +1724,51 @@ func Test_extractProblemResults(t *testing.T) {
 
 func Test_applyProcessedFilesExclusions(t *testing.T) {
 	testCases := []struct {
-		name            string
-		initialExclude  string
-		processedFiles  []string
-		expectedExclude string
+		name                 string
+		initialExcludePaths  string
+		processedFiles       []string
+		expectedExcludePaths string
 	}{
 		{
-			name:            "no processed files does not modify config",
-			initialExclude:  "",
-			processedFiles:  []string{},
-			expectedExclude: "",
+			name:                 "no processed files does not modify config",
+			initialExcludePaths:  "",
+			processedFiles:       []string{},
+			expectedExcludePaths: "",
 		},
 		{
-			name:            "nil processed files does not modify config",
-			initialExclude:  "",
-			processedFiles:  nil,
-			expectedExclude: "",
+			name:                 "nil processed files does not modify config",
+			initialExcludePaths:  "",
+			processedFiles:       nil,
+			expectedExcludePaths: "",
 		},
 		{
-			name:            "single processed file",
-			processedFiles:  []string{"file1.py"},
-			expectedExclude: "file1.py",
+			name:                 "single processed file",
+			processedFiles:       []string{"file1.py"},
+			expectedExcludePaths: "file1.py",
 		},
 		{
-			name:            "multiple processed files",
-			processedFiles:  []string{"file1.py", "file2.py", "file3.py"},
-			expectedExclude: "file1.py,file2.py,file3.py",
+			name:                 "multiple processed files",
+			processedFiles:       []string{"file1.py", "file2.py", "file3.py"},
+			expectedExcludePaths: "file1.py,file2.py,file3.py",
 		},
 		{
-			name:            "appends to existing exclude",
-			initialExclude:  "existing.txt",
-			processedFiles:  []string{"file1.py", "file2.py"},
-			expectedExclude: "existing.txt,file1.py,file2.py",
+			name:                 "appends to existing exclude-paths",
+			initialExcludePaths:  "existing.txt",
+			processedFiles:       []string{"file1.py", "file2.py"},
+			expectedExcludePaths: "existing.txt,file1.py,file2.py",
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			config := configuration.New()
-			if tc.initialExclude != "" {
-				config.Set(workflow.FlagExclude, tc.initialExclude)
+			if tc.initialExcludePaths != "" {
+				config.Set(workflow.FlagExcludePaths, tc.initialExcludePaths)
 			}
 
 			applyProcessedFilesExclusions(config, tc.processedFiles)
 
-			assert.Equal(t, tc.expectedExclude, config.GetString(workflow.FlagExclude))
+			assert.Equal(t, tc.expectedExcludePaths, config.GetString(workflow.FlagExcludePaths))
 		})
 	}
 }
@@ -1807,9 +1820,9 @@ func Test_processedFilesFlowFromPluginsToExcludeConfig(t *testing.T) {
 
 	require.NoError(t, err)
 	require.True(t, resolutionHandler.Called)
-	actualExclude := resolutionHandler.Config.GetString(workflow.FlagExclude)
-	assert.Equal(t, "file1.py,file2.py,file3.py", actualExclude,
-		"ProcessedFiles from all plugins should be combined into FlagExclude")
+	actualExcludePaths := resolutionHandler.Config.GetString(workflow.FlagExcludePaths)
+	assert.Equal(t, "file1.py,file2.py,file3.py", actualExcludePaths,
+		"ProcessedFiles from all plugins should be combined into FlagExcludePaths")
 }
 
 func Test_uvWorkspacePackages_passesOptionToPlugin(t *testing.T) {

--- a/pkg/ecosystems/legacy/plugin.go
+++ b/pkg/ecosystems/legacy/plugin.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"path"
 	"strings"
 
 	"github.com/snyk/dep-graph/go/pkg/depgraph"
@@ -107,12 +106,12 @@ func invokeLegacyCLI(ictx workflow.InvocationContext, opts *ecosystems.SCAPlugin
 	cmdArgs := append([]string(nil), opts.Global.RawFlags...)
 	cmdArgs = append(cmdArgs, "--print-effective-graph-with-errors")
 
-	for i := range ignores {
-		_, fileName := path.Split(ignores[i])
-		ignores[i] = fileName
-	}
+	// Use --exclude-paths so the legacy CLI matches exact paths rather than
+	// basenames. --exclude would incorrectly exclude every manifest that
+	// shares a basename with one of the processed files (e.g. all
+	// package.json files in a workspace).
 	if len(ignores) > 0 {
-		cmdArgs = append(cmdArgs, "--exclude="+strings.Join(ignores, ","))
+		cmdArgs = mergeExcludePathsArg(cmdArgs, ignores)
 	}
 
 	// Clone config and set the command args
@@ -129,6 +128,38 @@ func invokeLegacyCLI(ictx workflow.InvocationContext, opts *ecosystems.SCAPlugin
 	}
 
 	return legacyData, err //nolint:wrapcheck // Bubble up error so it can be extracted by caller.
+}
+
+// mergeExcludePathsArg appends ignores to the args, merging with any
+// user-supplied --exclude-paths value already present in cmdArgs so user
+// input is not silently dropped.
+func mergeExcludePathsArg(cmdArgs, ignores []string) []string {
+	const flag = "--exclude-paths"
+	const flagEq = flag + "="
+
+	for i, arg := range cmdArgs {
+		if strings.HasPrefix(arg, flagEq) {
+			existing := strings.TrimPrefix(arg, flagEq)
+			cmdArgs[i] = flagEq + joinNonEmpty(existing, strings.Join(ignores, ","))
+			return cmdArgs
+		}
+		if arg == flag && i+1 < len(cmdArgs) {
+			cmdArgs[i+1] = joinNonEmpty(cmdArgs[i+1], strings.Join(ignores, ","))
+			return cmdArgs
+		}
+	}
+	return append(cmdArgs, flagEq+strings.Join(ignores, ","))
+}
+
+func joinNonEmpty(a, b string) string {
+	switch {
+	case a == "":
+		return b
+	case b == "":
+		return a
+	default:
+		return a + "," + b
+	}
 }
 
 // tryBuildResultsFromLegacyPayload extracts payload from legacyData, parses JSONL, and returns SCAResults.

--- a/pkg/ecosystems/legacy/plugin_test.go
+++ b/pkg/ecosystems/legacy/plugin_test.go
@@ -2,6 +2,7 @@
 package legacy_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -163,6 +164,75 @@ func TestResolver_ReturnsProcessedFiles(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, []string{"project.assets.json"}, res.ProcessedFiles)
+}
+
+func TestResolver_IgnoredFilesUseExcludePaths(t *testing.T) {
+	ictx, opts, capturedArgs := setupLegacyCLICapturingArgs(t,
+		`{"depGraph":{"pkgManager":{"name":"npm"}},"normalisedTargetFile":"package.json","target":{}}`)
+	opts.WithAllProjects(true)
+
+	ignored := []string{"packages/api/package.json", "packages/web/package.json"}
+	resolver := legacy.NewLegacyResolver(ictx, ignored)
+
+	_, err := resolver.BuildDepGraphsFromDir(t.Context(), nil, "", opts)
+	require.NoError(t, err)
+
+	assert.Contains(t, *capturedArgs,
+		"--exclude-paths=packages/api/package.json,packages/web/package.json",
+		"processed files should be forwarded as --exclude-paths so paths are matched exactly")
+	for _, arg := range *capturedArgs {
+		assert.False(t, strings.HasPrefix(arg, "--exclude="),
+			"should not use --exclude (basename match) for processed files: %q", arg)
+	}
+}
+
+func TestResolver_IgnoredFilesMergeWithUserExcludePaths(t *testing.T) {
+	ictx, opts, capturedArgs := setupLegacyCLICapturingArgs(t,
+		`{"depGraph":{"pkgManager":{"name":"npm"}},"normalisedTargetFile":"package.json","target":{}}`)
+	opts.WithAllProjects(true).
+		WithRawFlags("--exclude-paths=user/manual.json")
+
+	resolver := legacy.NewLegacyResolver(ictx, []string{"packages/api/package.json"})
+
+	_, err := resolver.BuildDepGraphsFromDir(t.Context(), nil, "", opts)
+	require.NoError(t, err)
+
+	assert.Contains(t, *capturedArgs,
+		"--exclude-paths=user/manual.json,packages/api/package.json",
+		"processed files should be merged with user-supplied --exclude-paths value")
+}
+
+func setupLegacyCLICapturingArgs(t *testing.T, testBody string) (workflow.InvocationContext, *ecosystems.SCAPluginOptions, *[]string) {
+	t.Helper()
+
+	ctrl := gomock.NewController(t)
+	ictx := gafmocks.NewMockInvocationContext(ctrl)
+	engine := gafmocks.NewMockEngine(ctrl)
+	cfg := configuration.New()
+	logger := zerolog.Nop()
+
+	opts := ecosystems.NewPluginOptions()
+
+	ictx.EXPECT().GetConfiguration().Return(cfg).AnyTimes()
+	ictx.EXPECT().GetEngine().Return(engine).AnyTimes()
+	ictx.EXPECT().GetEnhancedLogger().Return(&logger).AnyTimes()
+
+	captured := &[]string{}
+	engine.EXPECT().
+		InvokeWithConfig(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ workflow.Identifier, config configuration.Configuration) ([]workflow.Data, error) {
+			if args, ok := config.Get(configuration.RAW_CMD_ARGS).([]string); ok {
+				*captured = args
+			}
+			return []workflow.Data{
+				workflow.NewData(
+					workflow.NewTypeIdentifier(workflow.NewWorkflowIdentifier("legacycli"), "application/text"),
+					"application/text",
+					[]byte(testBody)),
+			}, nil
+		})
+
+	return ictx, opts, captured
 }
 
 func setupLegacyCLI(t *testing.T, testBody string) (workflow.InvocationContext, *ecosystems.SCAPluginOptions) {

--- a/pkg/ecosystems/options.go
+++ b/pkg/ecosystems/options.go
@@ -22,6 +22,7 @@ type GlobalOptions struct {
 	AllProjects                   bool                 `arg:"--all-projects"`
 	IncludeDev                    bool                 `arg:"--dev,-d"`
 	Exclude                       CommaSeparatedString `arg:"--exclude"`
+	ExcludePaths                  CommaSeparatedString `arg:"--exclude-paths"`
 	FailFast                      bool                 `arg:"--fail-fast"`
 	AllowOutOfSync                bool                 // Derived from --strict-out-of-sync (inverted); parsed in NewPluginOptionsFromRawFlags.
 	ForceSingleGraph              bool                 `arg:"--force-single-graph"`
@@ -122,6 +123,11 @@ func (o *SCAPluginOptions) WithRawFlags(rawflags string) *SCAPluginOptions {
 
 func (o *SCAPluginOptions) WithExclude(exclude []string) *SCAPluginOptions {
 	o.Global.Exclude = append(o.Global.Exclude, exclude...)
+	return o
+}
+
+func (o *SCAPluginOptions) WithExcludePaths(excludePaths []string) *SCAPluginOptions {
+	o.Global.ExcludePaths = append(o.Global.ExcludePaths, excludePaths...)
 	return o
 }
 

--- a/pkg/ecosystems/options_test.go
+++ b/pkg/ecosystems/options_test.go
@@ -22,6 +22,7 @@ func TestNewPluginOptionsFromRawFlags_AllFields(t *testing.T) {
 				"--all-projects",
 				"--dev",
 				"--exclude", "foo",
+				"--exclude-paths", "packages/api/package.json",
 				"--no-build-isolation",
 				"--fail-fast",
 				"--strict-out-of-sync", "false",
@@ -39,6 +40,7 @@ func TestNewPluginOptionsFromRawFlags_AllFields(t *testing.T) {
 					AllProjects:                   true,
 					IncludeDev:                    true,
 					Exclude:                       []string{"foo"},
+					ExcludePaths:                  []string{"packages/api/package.json"},
 					FailFast:                      true,
 					AllowOutOfSync:                true,
 					ForceSingleGraph:              true,
@@ -172,6 +174,18 @@ func TestNewPluginOptionsFromRawFlags_AllFields(t *testing.T) {
 			expected: &SCAPluginOptions{
 				Global: GlobalOptions{
 					Exclude: []string{"test1", "test2", "test3"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "exclude-paths with multiple comma-separated values",
+			rawFlags: []string{
+				"--exclude-paths=packages/api/package.json,packages/web/package.json",
+			},
+			expected: &SCAPluginOptions{
+				Global: GlobalOptions{
+					ExcludePaths: []string{"packages/api/package.json", "packages/web/package.json"},
 				},
 			},
 			wantErr: false,

--- a/pkg/ecosystems/python/uv/plugin.go
+++ b/pkg/ecosystems/python/uv/plugin.go
@@ -185,13 +185,6 @@ func (p Plugin) buildResults(
 		result.Results = append(result.Results, res)
 	}
 
-	// TODO(uv): remove the below when we are able to pass these to the CLI correctly. Currently the
-	// `--exclude` flag does not accept paths, it only accepts file or dir names, which does not
-	// work for our use case.
-	if true {
-		result.ProcessedFiles = []string{}
-	}
-
 	return result, nil
 }
 


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

## What this does

Introduces support for a new `--exclude-relative` CLI flag that accepts **relative paths** (comma-separated) for excluding files and directories during multi-project scans. This replaces the lossy `path.Split` workaround from PR #147, which stripped paths down to basenames before forwarding them to the legacy CLI's `--exclude` flag.

### The problem

The existing `--exclude` flag only accepts basenames (e.g. `package.json`, `node_modules`). When the orchestrator hands off "processed files" to the legacy CLI for fallback resolution, it needs to tell the CLI *which specific files* to skip. PR #147 worked around this by calling `path.Split` to extract just the filename:

```
processedFiles before path.Split:  packages/api/package.json, packages/web/package.json
processedFiles after path.Split:   package.json, package.json
```

This caused **all** `package.json` files to be excluded, breaking workspace-style projects (bun, uv, yarn workspaces) where multiple packages share the same manifest filename but live at different paths.

The UV plugin had an additional workaround that cleared `ProcessedFiles` entirely to avoid this bug, which meant processed files were never properly excluded from fallback resolution.

### What changed

**Flag registration & forwarding**
- Registered `--exclude-relative` in `flags.go` as a string flag
- `legacy_resolution.go` forwards it to the legacy CLI when set
- `sbom_resolution.go` parses it via `parseExcludeFlag` and passes it to plugin options via `WithExcludeRelative()`

**Orchestrator (`LegacyFallback`)**
- Removed the `path.Split` loop — processed files now retain their relative paths
- Processed files are forwarded using `--exclude-relative=` instead of `--exclude=`
- Any user-provided `--exclude-relative` from `RawFlags` is **merged** with the auto-generated processed file exclusions, preventing user flags from being silently dropped

**SBOM resolution (`applyProcessedFilesExclusions`)**
- Now writes to `FlagExcludeRelative` instead of `FlagExclude`
- Merges with any existing `--exclude-relative` value rather than clobbering it
- Simplified string building using `strings.Join` on a pre-allocated slice

**Plugin options**
- Added `ExcludeRelative CommaSeparatedString` field to `GlobalOptions`
- Added `WithExcludeRelative()` builder method on `SCAPluginOptions`

**UV plugin cleanup**
- Removed the `if true { result.ProcessedFiles = []string{} }` workaround and its TODO comment — the UV plugin now correctly reports processed files

### Companion PR

This depends on [snyk/cli#6741](https://github.com/snyk/cli/pull/6741), which implements `--exclude-relative` in the legacy CLI's `find-files.ts` with proper validation (rejects absolute paths and `..` references) and path-based exclusion in the file discovery engine.

## Trade-offs & callouts

1. **`--exclude` behaviour is unchanged.** This is a purely additive change. The existing `--exclude` flag continues to work as before (basename-only matching). No existing CLI contracts are modified.

2. **Go plugins don't yet consume `--exclude-relative` internally.** The Go-side file discovery (`files.go`) already supports relative path glob matching via `filepath.Match`, but individual plugins don't filter against `ExcludeRelative` during their own discovery phase. This means the flag currently only takes effect during legacy CLI fallback and SBOM orchestration. Adding per-plugin filtering is a natural follow-up but is not a regression — the current behaviour is equivalent to what existed before this PR.

3. **Flag merging in `LegacyFallback`.** When a user explicitly passes `--exclude-relative=foo` and the orchestrator also has processed files to exclude, both are merged into a single `--exclude-relative` argument. This is intentional to avoid silently shadowing user input. The merge is simple string concatenation of comma-separated values.

4. **No `ARG_MAX` risk in practice.** Processed file paths are relative and typically short. Even in very large monorepos, the combined `--exclude-relative` argument is unlikely to approach OS argument length limits.