### PR TITLE
refactor: move legacy integration out of orchestrator

### DIFF
--- a/pkg/ecosystems/legacy/identity.go
+++ b/pkg/ecosystems/legacy/identity.go
@@ -1,0 +1,38 @@
+package legacy
+
+import (
+	"path"
+	"strings"
+)
+
+// getProjectTargetFileBasedOnType determines if a plugin sets targetFile based on package manager type.
+func getProjectTargetFileBasedOnType(projectType, file string, isWorkspace bool) *string {
+	switch projectType {
+	case "pip":
+		_, fileName := path.Split(file)
+		// snyk-python-plugin sets targetFile for Pipfile and setup.py, but not for requirements.txt
+		if strings.HasSuffix(fileName, "requirements.txt") {
+			return nil
+		}
+		return &file
+	case "gradle":
+		_, fileName := path.Split(file)
+		// snyk-gradle-plugin sets targetFile for build.gradle.kts but not for build.gradle
+		if strings.HasSuffix(fileName, "build.gradle.kts") {
+			return &file
+		}
+		return nil
+	case "poetry", "gomodules", "golangdep", "nuget", "paket", "composer", "cocoapods", "hex", "swift":
+		// These plugins set relative path to provided targetFile
+		return &file
+	case "npm", "yarn", "pnpm":
+		if isWorkspace {
+			return &file
+		}
+		return nil
+	case "maven", "sbt", "rubygems":
+		// These plugins do not set plugin.targetFile
+		return nil
+	}
+	return nil
+}

--- a/pkg/ecosystems/legacy/plugin.go
+++ b/pkg/ecosystems/legacy/plugin.go
@@ -1,0 +1,244 @@
+package legacy
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"path"
+	"strings"
+
+	"github.com/snyk/dep-graph/go/pkg/depgraph"
+	"github.com/snyk/error-catalog-golang-public/snyk_errors"
+	"github.com/snyk/go-application-framework/pkg/configuration"
+	"github.com/snyk/go-application-framework/pkg/workflow"
+
+	extensionDepgraph "github.com/snyk/cli-extension-dep-graph/pkg/depgraph"
+	"github.com/snyk/cli-extension-dep-graph/pkg/depgraph/parsers"
+	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
+	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/logger"
+	"github.com/snyk/cli-extension-dep-graph/pkg/identity"
+)
+
+var legacyCLIWorkflowID = workflow.NewWorkflowIdentifier("legacycli")
+
+type Resolver struct {
+	ictx   workflow.InvocationContext
+	ignore []string
+}
+
+// BuildDepGraphsFromDir implements [ecosystems.SCAPlugin].
+func (l *Resolver) BuildDepGraphsFromDir(
+	ctx context.Context,
+	log logger.Logger,
+	_ string,
+	opts *ecosystems.SCAPluginOptions,
+) (*ecosystems.PluginResult, error) {
+	dgs, err := getDepGraphsFromLegacy(l.ictx, opts, l.ignore)
+	if err != nil {
+		log.Error(ctx, "failed to resolve dep-graphs from legacy plugins", logger.Err(err))
+		return nil, fmt.Errorf("failed to resolve dep-graphs from legacy plugins: %w", err)
+	}
+
+	var processed []string
+	for _, res := range dgs {
+		processed = append(processed, res.ProjectDescriptor.GetTargetFile())
+	}
+
+	return &ecosystems.PluginResult{
+		Results:        dgs,
+		ProcessedFiles: processed,
+	}, nil
+}
+
+func NewLegacyResolver(ictx workflow.InvocationContext, ignore []string) *Resolver {
+	return &Resolver{
+		ictx,
+		ignore,
+	}
+}
+
+var _ ecosystems.SCAPlugin = new(Resolver)
+
+// getDepGraphsFromLegacy invokes the legacy CLI workflow with the raw flags and returns parsed results.
+func getDepGraphsFromLegacy(
+	ictx workflow.InvocationContext,
+	opts *ecosystems.SCAPluginOptions,
+	ignores []string,
+) ([]ecosystems.SCAResult, error) {
+	if opts == nil {
+		return nil, fmt.Errorf("cannot resolve dependencies without options")
+	}
+
+	// if we already processed files, and we're not in all-projects mode, we can skip the fallback
+	// TODO: this should be the responsibility of the orchestrator.
+	if len(ignores) > 0 && !opts.Global.AllProjects {
+		return nil, nil
+	}
+
+	data, invocationErr := invokeLegacyCLI(ictx, opts, ignores)
+	invocationSucceeded := invocationErr == nil
+
+	// UV-style: get payload once, then one loop over lines—append success or error result per line.
+	// Only return a single error when there is no parseable payload (or fatal parse/type failure).
+	results, fatalErr := tryBuildResultsFromLegacyPayload(ictx, data, invocationSucceeded)
+	if fatalErr != nil {
+		return nil, fatalErr
+	}
+	if len(results) > 0 {
+		return results, nil
+	}
+	if invocationSucceeded {
+		return []ecosystems.SCAResult{}, nil
+	}
+
+	// TODO: This introduces a dep cycle in workflow.go, preventing us from using the
+	// orchestrator in the single entry point to this extension. Refactor the legacy integration
+	// to have some shared error extraction.
+	//nolint:wrapcheck // must return unwrapped so os-flows can detect and render ErrorCatalog
+	return nil, extensionDepgraph.ExtractLegacyCLIError(invocationErr, data)
+}
+
+func invokeLegacyCLI(ictx workflow.InvocationContext, opts *ecosystems.SCAPluginOptions, ignores []string) ([]workflow.Data, error) {
+	// Add --print-effective-graph-with-errors for JSONL output with error handling
+	cmdArgs := append([]string(nil), opts.Global.RawFlags...)
+	cmdArgs = append(cmdArgs, "--print-effective-graph-with-errors")
+
+	for i := range ignores {
+		_, fileName := path.Split(ignores[i])
+		ignores[i] = fileName
+	}
+	if len(ignores) > 0 {
+		cmdArgs = append(cmdArgs, "--exclude="+strings.Join(ignores, ","))
+	}
+
+	// Clone config and set the command args
+	legacyConfig := ictx.GetConfiguration().Clone()
+	legacyConfig.Set(configuration.RAW_CMD_ARGS, cmdArgs)
+
+	// Invoke legacy CLI workflow
+	legacyData, err := ictx.GetEngine().InvokeWithConfig(legacyCLIWorkflowID, legacyConfig)
+	if err != nil {
+		if strings.Contains(err.Error(), "No supported files found") && len(ignores) > 0 {
+			return nil, nil
+		}
+		ictx.GetEnhancedLogger().Error().Err(err).Msg("Legacy CLI workflow returned error")
+	}
+
+	return legacyData, err //nolint:wrapcheck // Bubble up error so it can be extracted by caller.
+}
+
+// tryBuildResultsFromLegacyPayload extracts payload from legacyData, parses JSONL, and returns SCAResults.
+func tryBuildResultsFromLegacyPayload(
+	ictx workflow.InvocationContext,
+	legacyData []workflow.Data,
+	invocationSucceeded bool,
+) ([]ecosystems.SCAResult, error) {
+	var bytes []byte
+	if len(legacyData) > 0 {
+		payload := legacyData[0].GetPayload()
+		if payload != nil {
+			var ok bool
+			bytes, ok = payload.([]byte)
+			if !ok && invocationSucceeded {
+				return nil, fmt.Errorf("expected []byte payload, got %T", payload)
+			}
+		}
+	}
+	if len(bytes) == 0 {
+		return nil, nil
+	}
+
+	results, parseErr := parseLegacyJSONLToResults(ictx, bytes)
+	if parseErr != nil {
+		if invocationSucceeded {
+			ictx.GetEnhancedLogger().Error().Err(parseErr).Msg("Failed to parse JSONL output")
+			return nil, fmt.Errorf("failed to parse legacy output: %w", parseErr)
+		}
+		return nil, nil
+	}
+	if len(results) == 0 {
+		return nil, nil
+	}
+	return results, nil
+}
+
+// parseLegacyJSONLToResults parses JSONL and returns one SCAResult per line. (nil, err) on parse failure; (nil, nil) when no lines.
+func parseLegacyJSONLToResults(ictx workflow.InvocationContext, bytes []byte) ([]ecosystems.SCAResult, error) {
+	parser := parsers.NewJSONL()
+	depGraphOutputs, parseErr := parser.ParseOutput(bytes)
+	if parseErr != nil {
+		return nil, fmt.Errorf("parse legacy JSONL: %w", parseErr)
+	}
+	if len(depGraphOutputs) == 0 {
+		return nil, nil
+	}
+	// Convert to SCAResults
+	results := make([]ecosystems.SCAResult, 0, len(depGraphOutputs))
+	for i := range depGraphOutputs {
+		output := &depGraphOutputs[i]
+		result, resErr := depGraphOutputToSCAResult(ictx, output)
+		if resErr != nil {
+			ictx.GetEnhancedLogger().Error().
+				Str("targetFile", output.NormalisedTargetFile).
+				Err(resErr).
+				Msg("Failed to convert depgraph output")
+			results = append(results, ecosystems.SCAResult{
+				ProjectDescriptor: identity.ProjectDescriptor{
+					Identity: identity.ProjectIdentity{
+						TargetFile: &output.NormalisedTargetFile,
+					},
+				},
+				Error: resErr,
+			})
+		} else {
+			results = append(results, result)
+		}
+	}
+	return results, nil
+}
+
+// depGraphOutputToSCAResult converts a parser output to an SCA result.
+func depGraphOutputToSCAResult(ictx workflow.InvocationContext, output *parsers.DepGraphOutput) (ecosystems.SCAResult, error) {
+	result := ecosystems.SCAResult{
+		ProjectDescriptor: identity.ProjectDescriptor{
+			Identity: identity.ProjectIdentity{
+				TargetFile:    &output.NormalisedTargetFile,
+				TargetRuntime: output.TargetRuntime,
+			},
+		},
+	}
+
+	// If there's an error in the output, parse as ErrorCatalog so os-flows can render it (expected with --print-effective-graph-with-errors).
+	// UV-style: one error per result (use first when the JSON API provides multiple).
+	if len(output.Error) > 0 {
+		if errs, err := snyk_errors.FromJSONAPIErrorBytes(output.Error); err == nil && len(errs) > 0 {
+			result.Error = errs[0]
+		} else {
+			result.Error = errors.New(string(output.Error))
+		}
+	}
+
+	// Parse the depgraph JSON if present (may be partial even with errors)
+	if len(output.DepGraph) > 0 {
+		var dg depgraph.DepGraph
+		if err := json.Unmarshal(output.DepGraph, &dg); err != nil {
+			// JSON parsing failed - this is a real error, not an expected CLI error
+			ictx.GetEnhancedLogger().Error().
+				Str("targetFile", output.NormalisedTargetFile).
+				Err(err).
+				Msg("Failed to unmarshal depgraph JSON")
+			return result, fmt.Errorf("failed to unmarshal depgraph: %w", err)
+		}
+
+		result.DepGraph = &dg
+		result.ProjectDescriptor.Identity.ProjectType = dg.PkgManager.Name
+		result.ProjectDescriptor.Identity.TargetFile = getProjectTargetFileBasedOnType(dg.PkgManager.Name, output.NormalisedTargetFile, output.Workspace != nil)
+
+		if rootPkg := dg.GetRootPkg(); rootPkg != nil {
+			result.ProjectDescriptor.Identity.RootComponentName = rootPkg.Info.Name
+		}
+	}
+
+	return result, nil
+}

--- a/pkg/ecosystems/legacy/plugin_test.go
+++ b/pkg/ecosystems/legacy/plugin_test.go
@@ -1,4 +1,5 @@
-package orchestrator
+//nolint:lll // Large JSON fixtures inlined in this file.
+package legacy_test
 
 import (
 	"testing"
@@ -12,25 +13,32 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
+	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/legacy"
 )
 
-func TestLegacyFallback_MapsProjectType(t *testing.T) {
-	results, err := runLegacyFallback(t, `{"depGraph":{"pkgManager":{"name":"npm"}},"normalisedTargetFile":"package.json","targetFileFromPlugin":"package.json","target":{}}`) //nolint:lll // This is fine.
-	require.NoError(t, err)
-	require.Len(t, results, 1)
+func TestResolver_MapsProjectType(t *testing.T) {
+	ictx, opts := setupLegacyCLI(t, `{"depGraph":{"pkgManager":{"name":"npm"}},"normalisedTargetFile":"package.json","targetFileFromPlugin":"package.json","target":{}}`)
+	resolver := legacy.NewLegacyResolver(ictx, nil)
 
-	assert.Equal(t, "npm", results[0].ProjectDescriptor.Identity.ProjectType)
+	results, err := resolver.BuildDepGraphsFromDir(t.Context(), nil, "", opts)
+	require.NoError(t, err)
+
+	require.Len(t, results.Results, 1)
+	assert.Equal(t, "npm", results.Results[0].ProjectDescriptor.Identity.ProjectType)
 }
 
-func TestLegacyFallback_MapsTargetFramework(t *testing.T) {
-	results, err := runLegacyFallback(t, `{"depGraph":{"pkgManager":{"name":"nuget"}},"normalisedTargetFile":"project.assets.json","targetFileFromPlugin":"project.assets.json","target":{},"targetRuntime":"net6.0"}`) //nolint:lll // This is fine.
-	require.NoError(t, err)
-	require.Len(t, results, 1)
+func TestResolver_MapsTargetFramework(t *testing.T) {
+	ictx, opts := setupLegacyCLI(t, `{"depGraph":{"pkgManager":{"name":"nuget"}},"normalisedTargetFile":"project.assets.json","targetFileFromPlugin":"project.assets.json","target":{},"targetRuntime":"net6.0"}`)
+	resolver := legacy.NewLegacyResolver(ictx, nil)
 
-	assert.Equal(t, "net6.0", *results[0].ProjectDescriptor.Identity.TargetRuntime)
+	results, err := resolver.BuildDepGraphsFromDir(t.Context(), nil, "", opts)
+	require.NoError(t, err)
+
+	require.Len(t, results.Results, 1)
+	assert.Equal(t, "net6.0", *results.Results[0].ProjectDescriptor.Identity.TargetRuntime)
 }
 
-func TestLegacyFallback_MapsTargetFile(t *testing.T) {
+func TestResolver_MapsTargetFile(t *testing.T) {
 	tests := map[string]struct {
 		body               string
 		expectedTargetFile string
@@ -123,17 +131,41 @@ func TestLegacyFallback_MapsTargetFile(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			results, err := runLegacyFallback(t, test.body)
+			ictx, opts := setupLegacyCLI(t, test.body)
+			resolver := legacy.NewLegacyResolver(ictx, nil)
 
+			res, err := resolver.BuildDepGraphsFromDir(t.Context(), nil, "", opts)
 			require.NoError(t, err)
-			require.Len(t, results, 1)
 
-			assert.Equal(t, test.expectedTargetFile, results[0].ProjectDescriptor.GetTargetFile())
+			require.Len(t, res.Results, 1)
+			assert.Equal(t, test.expectedTargetFile, res.Results[0].ProjectDescriptor.GetTargetFile())
 		})
 	}
 }
 
-func runLegacyFallback(t *testing.T, testBody string) ([]ecosystems.SCAResult, error) {
+func TestResolver_MapsRootComponentName(t *testing.T) {
+	ictx, opts := setupLegacyCLI(t, `{"depGraph":{"pkgManager":{"name":"nuget"},"pkgs":[{"id":"my-project@","info":{"name":"my-project"}}],"graph":{"rootNodeId":"root","nodes":[{"nodeId":"root","pkgId":"my-project@"}]}},"normalisedTargetFile":"project.assets.json","targetFileFromPlugin":"project.assets.json","target":{}}`)
+	resolver := legacy.NewLegacyResolver(ictx, nil)
+
+	res, err := resolver.BuildDepGraphsFromDir(t.Context(), nil, "", opts)
+	require.NoError(t, err)
+
+	require.Len(t, res.Results, 1)
+	assert.Equal(t, "my-project", res.Results[0].ProjectDescriptor.Identity.RootComponentName)
+}
+
+func TestResolver_ReturnsProcessedFiles(t *testing.T) {
+	ictx, opts := setupLegacyCLI(t, `{"depGraph":{"pkgManager":{"name":"nuget"}},"normalisedTargetFile":"project.assets.json","targetFileFromPlugin":"project.assets.json","target":{}}`)
+
+	resolver := legacy.NewLegacyResolver(ictx, nil)
+
+	res, err := resolver.BuildDepGraphsFromDir(t.Context(), nil, "", opts)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"project.assets.json"}, res.ProcessedFiles)
+}
+
+func setupLegacyCLI(t *testing.T, testBody string) (workflow.InvocationContext, *ecosystems.SCAPluginOptions) {
 	t.Helper()
 
 	ctrl := gomock.NewController(t)
@@ -153,19 +185,13 @@ func runLegacyFallback(t *testing.T, testBody string) ([]ecosystems.SCAResult, e
 		Return(
 			[]workflow.Data{
 				workflow.NewData(
-					workflow.NewTypeIdentifier(legacyCLIWorkflowID, "application/text"),
+					workflow.NewTypeIdentifier(
+						workflow.NewWorkflowIdentifier("legacycli"),
+						"application/text"),
 					"application/text",
 					[]byte(testBody)),
 			},
 			nil)
 
-	return LegacyFallback(ictx, *opts, nil)
-}
-
-func TestLegacyFallback_MapsRootComponentName(t *testing.T) {
-	results, err := runLegacyFallback(t, `{"depGraph":{"pkgManager":{"name":"nuget"},"pkgs":[{"id":"my-project@","info":{"name":"my-project"}}],"graph":{"rootNodeId":"root","nodes":[{"nodeId":"root","pkgId":"my-project@"}]}},"normalisedTargetFile":"project.assets.json","targetFileFromPlugin":"project.assets.json","target":{}}`) //nolint:lll // This is fine.
-	require.NoError(t, err)
-	require.Len(t, results, 1)
-
-	assert.Equal(t, "my-project", results[0].ProjectDescriptor.Identity.RootComponentName)
+	return ictx, opts
 }

--- a/pkg/ecosystems/orchestrator/orchestrator.go
+++ b/pkg/ecosystems/orchestrator/orchestrator.go
@@ -2,28 +2,16 @@ package orchestrator
 
 import (
 	"context"
-	"encoding/json"
-	"errors"
-	"fmt"
-	"path"
-	"strings"
 
 	"github.com/rs/zerolog"
-	"github.com/snyk/dep-graph/go/pkg/depgraph"
-	"github.com/snyk/error-catalog-golang-public/snyk_errors"
-	"github.com/snyk/go-application-framework/pkg/configuration"
 	"github.com/snyk/go-application-framework/pkg/workflow"
 
-	extensionDepgraph "github.com/snyk/cli-extension-dep-graph/pkg/depgraph"
-	"github.com/snyk/cli-extension-dep-graph/pkg/depgraph/parsers"
 	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
+	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/legacy"
 	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/logger"
 	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/python/pip"
 	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/python/pipenv"
-	"github.com/snyk/cli-extension-dep-graph/pkg/identity"
 )
-
-var legacyCLIWorkflowID = workflow.NewWorkflowIdentifier("legacycli")
 
 // ResolveDepgraphs resolves dependency graphs for a directory by invoking the legacy CLI workflow.
 // It accepts a workflow.InvocationContext to provide access to the engine, configuration, and logger.
@@ -35,15 +23,15 @@ func ResolveDepgraphs(ictx workflow.InvocationContext, dir string, opts ecosyste
 
 	pythonResult := resolvePython(ictx.Context(), enhancedLogger, dir, opts)
 
-	// Call legacy fallback to get results
-	results, err := LegacyFallback(ictx, opts, pythonResult.ProcessedFiles)
+	// Call legacy fallback to get legacyResults
+	legacyResults, err := resolveLegacy(ictx, enhancedLogger, dir, &opts, pythonResult.ProcessedFiles)
 	if err != nil {
 		return nil, err
 	}
 
 	// Create channel and send all results
-	resultsChan := make(chan ecosystems.SCAResult, len(results)+len(pythonResult.Results))
-	for _, result := range results {
+	resultsChan := make(chan ecosystems.SCAResult, len(legacyResults.Results)+len(pythonResult.Results))
+	for _, result := range legacyResults.Results {
 		resultsChan <- result
 	}
 	for _, result := range pythonResult.Results {
@@ -52,6 +40,21 @@ func ResolveDepgraphs(ictx workflow.InvocationContext, dir string, opts ecosyste
 	close(resultsChan)
 
 	return resultsChan, nil
+}
+
+func resolveLegacy(
+	ictx workflow.InvocationContext,
+	enhancedLogger *zerolog.Logger,
+	dir string,
+	opts *ecosystems.SCAPluginOptions,
+	ignores []string,
+) (*ecosystems.PluginResult, error) {
+	log := logger.NewFromZerolog(enhancedLogger)
+	res, err := legacy.NewLegacyResolver(ictx, ignores).BuildDepGraphsFromDir(ictx.Context(), log, dir, opts)
+	if err != nil {
+		return nil, err //nolint:wrapcheck // must return unwrapped so os-flows can detect and render ErrorCatalog
+	}
+	return res, nil
 }
 
 //nolint:gocritic // hugeParam: ensure `options` is not nil
@@ -80,206 +83,4 @@ func resolvePython(ctx context.Context, enhancedLogger *zerolog.Logger, dir stri
 	}
 
 	return result
-}
-
-// LegacyFallback invokes the legacy CLI workflow with the raw flags and returns parsed results.
-func LegacyFallback(
-	ictx workflow.InvocationContext,
-	//nolint:gocritic // hugeParam: ensure `options` is not nil
-	options ecosystems.SCAPluginOptions,
-	processedFiles []string,
-) ([]ecosystems.SCAResult, error) {
-	// if we already processed files, and we're not in all-projects mode, we can skip the fallback
-	if len(processedFiles) > 0 && !options.Global.AllProjects {
-		return nil, nil
-	}
-
-	log := ictx.GetEnhancedLogger()
-	config := ictx.GetConfiguration()
-	engine := ictx.GetEngine()
-
-	// Add --print-effective-graph-with-errors for JSONL output with error handling
-	cmdArgs := append([]string(nil), options.Global.RawFlags...)
-	cmdArgs = append(cmdArgs, "--print-effective-graph-with-errors")
-
-	for i := range processedFiles {
-		_, fileName := path.Split(processedFiles[i])
-		processedFiles[i] = fileName
-	}
-	if len(processedFiles) > 0 {
-		cmdArgs = append(cmdArgs, "--exclude="+strings.Join(processedFiles, ","))
-	}
-
-	// Clone config and set the command args
-	legacyConfig := config.Clone()
-	legacyConfig.Set(configuration.RAW_CMD_ARGS, cmdArgs)
-
-	// Invoke legacy CLI workflow
-	legacyData, err := engine.InvokeWithConfig(legacyCLIWorkflowID, legacyConfig)
-	if err != nil {
-		if strings.Contains(err.Error(), "No supported files found") && len(processedFiles) > 0 {
-			return nil, nil
-		}
-		log.Error().Err(err).Msg("Legacy CLI workflow returned error")
-	}
-
-	// UV-style: get payload once, then one loop over lines—append success or error result per line.
-	// Only return a single error when there is no parseable payload (or fatal parse/type failure).
-	results, fatalErr := tryBuildResultsFromLegacyPayload(legacyData, err, ictx, log)
-	if fatalErr != nil {
-		return nil, fatalErr
-	}
-	if len(results) > 0 {
-		return results, nil
-	}
-	if err == nil {
-		return []ecosystems.SCAResult{}, nil
-	}
-	//nolint:wrapcheck // must return unwrapped so os-flows can detect and render ErrorCatalog
-	return nil, extensionDepgraph.ExtractLegacyCLIError(err, legacyData)
-}
-
-// tryBuildResultsFromLegacyPayload extracts payload from legacyData, parses JSONL, and returns SCAResults.
-func tryBuildResultsFromLegacyPayload(
-	legacyData []workflow.Data, invokeErr error, ictx workflow.InvocationContext, log *zerolog.Logger,
-) ([]ecosystems.SCAResult, error) {
-	var bytes []byte
-	if len(legacyData) > 0 {
-		payload := legacyData[0].GetPayload()
-		if payload != nil {
-			var ok bool
-			bytes, ok = payload.([]byte)
-			if !ok && invokeErr == nil {
-				return nil, fmt.Errorf("expected []byte payload, got %T", payload)
-			}
-		}
-	}
-	if len(bytes) == 0 {
-		return nil, nil
-	}
-	results, parseErr := parseLegacyJSONLToResults(bytes, ictx, log)
-	if parseErr != nil {
-		if invokeErr == nil {
-			log.Error().Err(parseErr).Msg("Failed to parse JSONL output")
-			return nil, fmt.Errorf("failed to parse legacy output: %w", parseErr)
-		}
-		return nil, nil
-	}
-	if len(results) == 0 {
-		return nil, nil
-	}
-	return results, nil
-}
-
-// parseLegacyJSONLToResults parses JSONL and returns one SCAResult per line. (nil, err) on parse failure; (nil, nil) when no lines.
-func parseLegacyJSONLToResults(bytes []byte, ictx workflow.InvocationContext, log *zerolog.Logger) ([]ecosystems.SCAResult, error) {
-	parser := parsers.NewJSONL()
-	depGraphOutputs, parseErr := parser.ParseOutput(bytes)
-	if parseErr != nil {
-		return nil, fmt.Errorf("parse legacy JSONL: %w", parseErr)
-	}
-	if len(depGraphOutputs) == 0 {
-		return nil, nil
-	}
-	// Convert to SCAResults
-	results := make([]ecosystems.SCAResult, 0, len(depGraphOutputs))
-	for i := range depGraphOutputs {
-		output := &depGraphOutputs[i]
-		result, resErr := depGraphOutputToSCAResult(output, ictx)
-		if resErr != nil {
-			log.Error().
-				Str("targetFile", output.NormalisedTargetFile).
-				Err(resErr).
-				Msg("Failed to convert depgraph output")
-			results = append(results, ecosystems.SCAResult{
-				ProjectDescriptor: identity.ProjectDescriptor{
-					Identity: identity.ProjectIdentity{
-						TargetFile: &output.NormalisedTargetFile,
-					},
-				},
-				Error: resErr,
-			})
-		} else {
-			results = append(results, result)
-		}
-	}
-	return results, nil
-}
-
-// depGraphOutputToSCAResult converts a parser output to an SCA result.
-func depGraphOutputToSCAResult(output *parsers.DepGraphOutput, ictx workflow.InvocationContext) (ecosystems.SCAResult, error) {
-	log := ictx.GetEnhancedLogger()
-	result := ecosystems.SCAResult{
-		ProjectDescriptor: identity.ProjectDescriptor{
-			Identity: identity.ProjectIdentity{
-				TargetFile:    &output.NormalisedTargetFile,
-				TargetRuntime: output.TargetRuntime,
-			},
-		},
-	}
-
-	// If there's an error in the output, parse as ErrorCatalog so os-flows can render it (expected with --print-effective-graph-with-errors).
-	// UV-style: one error per result (use first when the JSON API provides multiple).
-	if len(output.Error) > 0 {
-		if errs, err := snyk_errors.FromJSONAPIErrorBytes(output.Error); err == nil && len(errs) > 0 {
-			result.Error = errs[0]
-		} else {
-			result.Error = errors.New(string(output.Error))
-		}
-	}
-
-	// Parse the depgraph JSON if present (may be partial even with errors)
-	if len(output.DepGraph) > 0 {
-		var dg depgraph.DepGraph
-		if err := json.Unmarshal(output.DepGraph, &dg); err != nil {
-			// JSON parsing failed - this is a real error, not an expected CLI error
-			log.Error().
-				Str("targetFile", output.NormalisedTargetFile).
-				Err(err).
-				Msg("Failed to unmarshal depgraph JSON")
-			return result, fmt.Errorf("failed to unmarshal depgraph: %w", err)
-		}
-
-		result.DepGraph = &dg
-		result.ProjectDescriptor.Identity.ProjectType = dg.PkgManager.Name
-		result.ProjectDescriptor.Identity.TargetFile = getProjectTargetFileBasedOnType(dg.PkgManager.Name, output.NormalisedTargetFile, output.Workspace != nil)
-
-		if rootPkg := dg.GetRootPkg(); rootPkg != nil {
-			result.ProjectDescriptor.Identity.RootComponentName = rootPkg.Info.Name
-		}
-	}
-
-	return result, nil
-}
-
-// getProjectTargetFileBasedOnType determines if a plugin sets targetFile based on package manager type.
-func getProjectTargetFileBasedOnType(projectType, file string, isWorkspace bool) *string {
-	switch projectType {
-	case "pip":
-		_, fileName := path.Split(file)
-		// snyk-python-plugin sets targetFile for Pipfile and setup.py, but not for requirements.txt
-		if strings.HasSuffix(fileName, "requirements.txt") {
-			return nil
-		}
-		return &file
-	case "gradle":
-		_, fileName := path.Split(file)
-		// snyk-gradle-plugin sets targetFile for build.gradle.kts but not for build.gradle
-		if strings.HasSuffix(fileName, "build.gradle.kts") {
-			return &file
-		}
-		return nil
-	case "poetry", "gomodules", "golangdep", "nuget", "paket", "composer", "cocoapods", "hex", "swift":
-		// These plugins set relative path to provided targetFile
-		return &file
-	case "npm", "yarn", "pnpm":
-		if isWorkspace {
-			return &file
-		}
-		return nil
-	case "maven", "sbt", "rubygems":
-		// These plugins do not set plugin.targetFile
-		return nil
-	}
-	return nil
 }


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Moves all the integration with the legacy CLI (invoke `snyk test`, parse outputs) out of the orchestrator and into a resolver of its own, i.e. behind a `SCAPlugin` interface.
