### PR TITLE
fix(bun): pass --no-env-file to bun why to prevent .env file loading

### DIFF
--- a/pkg/ecosystems/javascript/bun/executor.go
+++ b/pkg/ecosystems/javascript/bun/executor.go
@@ -54,7 +54,7 @@ func (e *bunCmdExecutor) Run(ctx context.Context, dir string) (io.ReadCloser, er
 		return nil, err
 	}
 
-	cmd := exec.CommandContext(ctx, resolved, "why", "*", "--top")
+	cmd := exec.CommandContext(ctx, resolved, "--no-env-file", "why", "*", "--top")
 	cmd.Dir = dir
 	cmd.Env = append(cmd.Environ(), "NO_COLOR=1")
 


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [ ] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Bun why has no need to read a .env file at runtime. It is a static operation that only produces the human readable dep graph and does not require any information from the .env file.

Therefore, pass `--no-env-file` to prevent loading of it altogether.
