### PR TITLE
feat: Introduce PluginRegistry with dependency-aware plugin orchestration

### DIFF
--- a/pkg/depgraph/sbom_resolution_test.go
+++ b/pkg/depgraph/sbom_resolution_test.go
@@ -41,6 +41,10 @@ type mockScaPlugin struct {
 	options *ecosystems.SCAPluginOptions
 }
 
+func (m *mockScaPlugin) GetName() string {
+	return ""
+}
+
 func (m *mockScaPlugin) BuildDepGraphsFromDir(
 	_ context.Context,
 	_ logger.Logger,

--- a/pkg/ecosystems/javascript/bun/plugin.go
+++ b/pkg/ecosystems/javascript/bun/plugin.go
@@ -13,7 +13,10 @@ import (
 	"github.com/snyk/cli-extension-dep-graph/pkg/identity"
 )
 
-const logFieldLockFile = "lockFile"
+const (
+	PluginName       = "bun"
+	logFieldLockFile = "lockFile"
+)
 
 // Plugin implements ecosystems.SCAPlugin for Bun projects.
 // It uses `bun why '*' --top` to resolve the full dependency graph without
@@ -24,6 +27,10 @@ type Plugin struct {
 
 // Compile-time check that Plugin implements the SCAPlugin interface.
 var _ ecosystems.SCAPlugin = (*Plugin)(nil)
+
+func (p Plugin) GetName() string {
+	return PluginName
+}
 
 // BuildDepGraphsFromDir discovers bun.lock files under dir and produces dep
 // graphs for each one. Workspace projects yield one SCAResult per workspace

--- a/pkg/ecosystems/legacy/plugin.go
+++ b/pkg/ecosystems/legacy/plugin.go
@@ -22,9 +22,15 @@ import (
 
 var legacyCLIWorkflowID = workflow.NewWorkflowIdentifier("legacycli")
 
+const PluginName = "legacycli"
+
 type Resolver struct {
 	ictx   workflow.InvocationContext
 	ignore []string
+}
+
+func (l *Resolver) GetName() string {
+	return PluginName
 }
 
 // BuildDepGraphsFromDir implements [ecosystems.SCAPlugin].

--- a/pkg/ecosystems/orchestrator/registry.go
+++ b/pkg/ecosystems/orchestrator/registry.go
@@ -1,0 +1,172 @@
+package orchestrator
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/rs/zerolog"
+	"github.com/snyk/go-application-framework/pkg/workflow"
+
+	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
+	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/javascript/bun"
+	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/legacy"
+	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/logger"
+	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/python/pip"
+	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/python/pipenv"
+	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/python/uv"
+)
+
+type pluginEntry struct {
+	plugin       ecosystems.SCAPlugin
+	dependencies []string
+}
+
+type PluginRegistry struct {
+	entries []pluginEntry
+	plugins []ecosystems.SCAPlugin
+}
+
+func NewDefaultPluginRegistry() *PluginRegistry {
+	r := &PluginRegistry{
+		entries: make([]pluginEntry, 0),
+		plugins: make([]ecosystems.SCAPlugin, 0),
+	}
+
+	// javascript
+	r.register(bun.Plugin{})
+	// python
+	r.register(uv.Plugin{})
+	r.register(pip.Plugin{}, uv.PluginName)
+	r.register(pipenv.Plugin{}, uv.PluginName)
+
+	return r
+}
+
+func (r *PluginRegistry) ResolveDepgraphs(ictx workflow.InvocationContext, dir string, opts *ecosystems.SCAPluginOptions) <-chan ecosystems.SCAResult {
+	resultsChan := make(chan ecosystems.SCAResult)
+
+	go func() {
+		defer close(resultsChan)
+
+		ctx := ictx.Context()
+		enhancedLogger := ictx.GetEnhancedLogger()
+		processedFiles := make([]string, 0)
+
+		for _, plugin := range r.plugins {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+
+			files := executePluginWithResults(ctx, plugin, enhancedLogger, dir, opts, resultsChan)
+			if len(files) > 0 && !opts.Global.AllProjects {
+				return
+			}
+			processedFiles = append(processedFiles, files...)
+			opts.WithExclude(files)
+		}
+
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
+		executePluginWithResults(ctx, legacy.NewLegacyResolver(ictx, processedFiles), enhancedLogger, dir, opts, resultsChan)
+	}()
+
+	return resultsChan
+}
+
+func (r *PluginRegistry) register(plugin ecosystems.SCAPlugin, dependencies ...string) {
+	r.entries = append(r.entries, pluginEntry{
+		plugin:       plugin,
+		dependencies: dependencies,
+	})
+	r.plugins = r.sortPlugins()
+}
+
+func (r *PluginRegistry) sortPlugins() []ecosystems.SCAPlugin {
+	if len(r.entries) == 0 {
+		return nil
+	}
+
+	pluginMap := make(map[string]int)
+	for i, entry := range r.entries {
+		pluginMap[entry.plugin.GetName()] = i
+	}
+
+	inDegree := make([]int, len(r.entries))
+	for i, entry := range r.entries {
+		for _, dep := range entry.dependencies {
+			if _, exists := pluginMap[dep]; exists {
+				inDegree[i]++
+			}
+		}
+	}
+
+	queue := make([]int, 0)
+	for i, degree := range inDegree {
+		if degree == 0 {
+			queue = append(queue, i)
+		}
+	}
+
+	result := make([]ecosystems.SCAPlugin, 0, len(r.entries))
+
+	for len(queue) > 0 {
+		idx := queue[0]
+		queue = queue[1:]
+
+		result = append(result, r.entries[idx].plugin)
+
+		pluginName := r.entries[idx].plugin.GetName()
+		for i, entry := range r.entries {
+			for _, dep := range entry.dependencies {
+				if dep == pluginName {
+					inDegree[i]--
+					if inDegree[i] == 0 {
+						queue = append(queue, i)
+					}
+				}
+			}
+		}
+	}
+
+	if len(result) != len(r.entries) {
+		return nil
+	}
+
+	return result
+}
+
+func executePluginWithResults(
+	ctx context.Context,
+	plugin ecosystems.SCAPlugin,
+	enhancedLogger *zerolog.Logger,
+	dir string,
+	opts *ecosystems.SCAPluginOptions,
+	resultsChan chan ecosystems.SCAResult,
+) []string {
+	enhancedLogger.Info().Msg(fmt.Sprintf("Executing %s plugin", plugin.GetName()))
+	results, err := plugin.BuildDepGraphsFromDir(ctx, logger.NewFromZerolog(enhancedLogger), dir, opts)
+	if err != nil {
+		enhancedLogger.Warn().Err(err).Msg(fmt.Sprintf("%s plugin failed", plugin.GetName()))
+		return nil
+	}
+
+	if results != nil {
+		for _, result := range results.Results {
+			select {
+			case resultsChan <- result:
+			case <-ctx.Done():
+				return nil
+			}
+		}
+
+		return results.ProcessedFiles
+	}
+
+	return nil
+}

--- a/pkg/ecosystems/orchestrator/registry.go
+++ b/pkg/ecosystems/orchestrator/registry.go
@@ -26,20 +26,28 @@ type PluginRegistry struct {
 	plugins []ecosystems.SCAPlugin
 }
 
-func NewDefaultPluginRegistry() *PluginRegistry {
+func NewDefaultPluginRegistry() (*PluginRegistry, error) {
 	r := &PluginRegistry{
 		entries: make([]pluginEntry, 0),
 		plugins: make([]ecosystems.SCAPlugin, 0),
 	}
 
 	// javascript
-	r.register(bun.Plugin{})
+	if err := r.register(bun.Plugin{}); err != nil {
+		return nil, fmt.Errorf("failed to register bun plugin: %w", err)
+	}
 	// python
-	r.register(uv.Plugin{})
-	r.register(pip.Plugin{}, uv.PluginName)
-	r.register(pipenv.Plugin{}, uv.PluginName)
+	if err := r.register(uv.Plugin{}); err != nil {
+		return nil, fmt.Errorf("failed to register uv plugin: %w", err)
+	}
+	if err := r.register(pip.Plugin{}, uv.PluginName); err != nil {
+		return nil, fmt.Errorf("failed to register pip plugin: %w", err)
+	}
+	if err := r.register(pipenv.Plugin{}, uv.PluginName); err != nil {
+		return nil, fmt.Errorf("failed to register pipenv plugin: %w", err)
+	}
 
-	return r
+	return r, nil
 }
 
 func (r *PluginRegistry) ResolveDepgraphs(ictx workflow.InvocationContext, dir string, opts *ecosystems.SCAPluginOptions) <-chan ecosystems.SCAResult {
@@ -79,12 +87,17 @@ func (r *PluginRegistry) ResolveDepgraphs(ictx workflow.InvocationContext, dir s
 	return resultsChan
 }
 
-func (r *PluginRegistry) register(plugin ecosystems.SCAPlugin, dependencies ...string) {
+func (r *PluginRegistry) register(plugin ecosystems.SCAPlugin, dependencies ...string) error {
 	r.entries = append(r.entries, pluginEntry{
 		plugin:       plugin,
 		dependencies: dependencies,
 	})
-	r.plugins = r.sortPlugins()
+	sorted := r.sortPlugins()
+	if sorted == nil {
+		return fmt.Errorf("circular dependency detected involving plugin: %s", plugin.GetName())
+	}
+	r.plugins = sorted
+	return nil
 }
 
 func (r *PluginRegistry) sortPlugins() []ecosystems.SCAPlugin {

--- a/pkg/ecosystems/orchestrator/registry_test.go
+++ b/pkg/ecosystems/orchestrator/registry_test.go
@@ -1,0 +1,258 @@
+package orchestrator
+
+import (
+	"context"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/rs/zerolog"
+	"github.com/snyk/go-application-framework/pkg/configuration"
+	gafmocks "github.com/snyk/go-application-framework/pkg/mocks"
+	"github.com/snyk/go-application-framework/pkg/workflow"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
+	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/logger"
+	"github.com/snyk/cli-extension-dep-graph/pkg/identity"
+)
+
+type mockPlugin struct {
+	name           string
+	processedFiles []string
+	results        []ecosystems.SCAResult
+}
+
+func (m mockPlugin) GetName() string {
+	return m.name
+}
+
+func (m mockPlugin) BuildDepGraphsFromDir(context.Context, logger.Logger, string, *ecosystems.SCAPluginOptions) (*ecosystems.PluginResult, error) {
+	return &ecosystems.PluginResult{
+		ProcessedFiles: m.processedFiles,
+		Results:        m.results,
+	}, nil
+}
+
+func TestPluginRegistry_OrderPreservedWithoutDependencies(t *testing.T) {
+	r := &PluginRegistry{
+		entries: make([]pluginEntry, 0),
+		plugins: make([]ecosystems.SCAPlugin, 0),
+	}
+
+	r.register(mockPlugin{name: "plugin-a"})
+	r.register(mockPlugin{name: "plugin-b"})
+	r.register(mockPlugin{name: "plugin-c"})
+
+	require.Len(t, r.plugins, 3)
+	assert.Equal(t, "plugin-a", r.plugins[0].GetName())
+	assert.Equal(t, "plugin-b", r.plugins[1].GetName())
+	assert.Equal(t, "plugin-c", r.plugins[2].GetName())
+}
+
+func TestPluginRegistry_DependenciesRespected(t *testing.T) {
+	r := &PluginRegistry{
+		entries: make([]pluginEntry, 0),
+		plugins: make([]ecosystems.SCAPlugin, 0),
+	}
+
+	r.register(mockPlugin{name: "plugin-c"}, "plugin-a")
+	r.register(mockPlugin{name: "plugin-b"}, "plugin-a")
+	r.register(mockPlugin{name: "plugin-a"})
+
+	require.Len(t, r.plugins, 3)
+	assert.Equal(t, "plugin-a", r.plugins[0].GetName())
+	assert.Equal(t, "plugin-c", r.plugins[1].GetName())
+	assert.Equal(t, "plugin-b", r.plugins[2].GetName())
+}
+
+func TestPluginRegistry_ChainedDependencies(t *testing.T) {
+	r := &PluginRegistry{
+		entries: make([]pluginEntry, 0),
+		plugins: make([]ecosystems.SCAPlugin, 0),
+	}
+
+	r.register(mockPlugin{name: "plugin-c"}, "plugin-b")
+	r.register(mockPlugin{name: "plugin-b"}, "plugin-a")
+	r.register(mockPlugin{name: "plugin-a"})
+
+	require.Len(t, r.plugins, 3)
+	assert.Equal(t, "plugin-a", r.plugins[0].GetName())
+	assert.Equal(t, "plugin-b", r.plugins[1].GetName())
+	assert.Equal(t, "plugin-c", r.plugins[2].GetName())
+}
+
+func TestPluginRegistry_DefaultRegistryOrder(t *testing.T) {
+	r := NewDefaultPluginRegistry()
+
+	require.Len(t, r.plugins, 4)
+	assert.Equal(t, "bun", r.plugins[0].GetName())
+	assert.Equal(t, "uv", r.plugins[1].GetName())
+	assert.Equal(t, "pip", r.plugins[2].GetName())
+	assert.Equal(t, "pipenv", r.plugins[3].GetName())
+}
+
+func TestPluginRegistry_CircularDependencyReturnsNil(t *testing.T) {
+	r := &PluginRegistry{
+		entries: make([]pluginEntry, 0),
+		plugins: make([]ecosystems.SCAPlugin, 0),
+	}
+
+	r.register(mockPlugin{name: "plugin-a"}, "plugin-b")
+	r.register(mockPlugin{name: "plugin-b"}, "plugin-a")
+
+	assert.Nil(t, r.plugins, "circular dependencies should result in nil plugins list")
+}
+
+func TestPluginRegistry_NonExistentDependencyIgnored(t *testing.T) {
+	r := &PluginRegistry{
+		entries: make([]pluginEntry, 0),
+		plugins: make([]ecosystems.SCAPlugin, 0),
+	}
+
+	r.register(mockPlugin{name: "plugin-a"})
+	r.register(mockPlugin{name: "plugin-b"}, "non-existent-plugin")
+
+	require.Len(t, r.plugins, 2)
+
+	pluginNames := make([]string, len(r.plugins))
+	for i, p := range r.plugins {
+		pluginNames[i] = p.GetName()
+	}
+
+	assert.Contains(t, pluginNames, "plugin-a")
+	assert.Contains(t, pluginNames, "plugin-b")
+}
+
+func TestPluginRegistry_DependencyAddedLater(t *testing.T) {
+	r := &PluginRegistry{
+		entries: make([]pluginEntry, 0),
+		plugins: make([]ecosystems.SCAPlugin, 0),
+	}
+
+	r.register(mockPlugin{name: "plugin-b"}, "plugin-a")
+	r.register(mockPlugin{name: "plugin-a"})
+
+	require.Len(t, r.plugins, 2)
+	assert.Equal(t, "plugin-a", r.plugins[0].GetName())
+	assert.Equal(t, "plugin-b", r.plugins[1].GetName())
+}
+
+func TestPluginRegistry_ResolveDepgraphs_AllProjectsMode(t *testing.T) {
+	ictx := setupMockInvocationContext(t)
+
+	r := &PluginRegistry{
+		entries: make([]pluginEntry, 0),
+		plugins: make([]ecosystems.SCAPlugin, 0),
+	}
+
+	r.register(mockPlugin{
+		name:           "plugin-a",
+		processedFiles: []string{"file-a.txt"},
+		results:        []ecosystems.SCAResult{{ProjectDescriptor: identity.ProjectDescriptor{Identity: identity.ProjectIdentity{ProjectType: "type-a"}}}},
+	})
+	r.register(mockPlugin{
+		name:           "plugin-b",
+		processedFiles: []string{"file-b.txt"},
+		results:        []ecosystems.SCAResult{{ProjectDescriptor: identity.ProjectDescriptor{Identity: identity.ProjectIdentity{ProjectType: "type-b"}}}},
+	})
+
+	opts := ecosystems.NewPluginOptions()
+	opts.Global.AllProjects = true
+
+	resultsChan := r.ResolveDepgraphs(ictx, "/test/dir", opts)
+
+	results := collectResults(resultsChan)
+
+	assert.Len(t, results, 2)
+}
+
+func TestPluginRegistry_ResolveDepgraphs_StopsAfterFirstResult(t *testing.T) {
+	ictx := setupMockInvocationContext(t)
+
+	r := &PluginRegistry{
+		entries: make([]pluginEntry, 0),
+		plugins: make([]ecosystems.SCAPlugin, 0),
+	}
+
+	r.register(mockPlugin{
+		name:           "plugin-a",
+		processedFiles: []string{"file-a.txt"},
+		results:        []ecosystems.SCAResult{{ProjectDescriptor: identity.ProjectDescriptor{Identity: identity.ProjectIdentity{ProjectType: "type-a"}}}},
+	})
+	r.register(mockPlugin{
+		name:           "plugin-b",
+		processedFiles: []string{"file-b.txt"},
+		results:        []ecosystems.SCAResult{{ProjectDescriptor: identity.ProjectDescriptor{Identity: identity.ProjectIdentity{ProjectType: "type-b"}}}},
+	})
+
+	opts := ecosystems.NewPluginOptions()
+	opts.Global.AllProjects = false
+
+	resultsChan := r.ResolveDepgraphs(ictx, "/test/dir", opts)
+
+	results := collectResults(resultsChan)
+
+	assert.Len(t, results, 1)
+	assert.Equal(t, "type-a", results[0].ProjectDescriptor.Identity.ProjectType)
+}
+
+func TestPluginRegistry_ResolveDepgraphs_ContinuesWhenNoResults(t *testing.T) {
+	ictx := setupMockInvocationContext(t)
+
+	r := &PluginRegistry{
+		entries: make([]pluginEntry, 0),
+		plugins: make([]ecosystems.SCAPlugin, 0),
+	}
+
+	r.register(mockPlugin{
+		name:           "plugin-a",
+		processedFiles: []string{},
+		results:        []ecosystems.SCAResult{},
+	})
+	r.register(mockPlugin{
+		name:           "plugin-b",
+		processedFiles: []string{"file-b.txt"},
+		results:        []ecosystems.SCAResult{{ProjectDescriptor: identity.ProjectDescriptor{Identity: identity.ProjectIdentity{ProjectType: "type-b"}}}},
+	})
+
+	opts := ecosystems.NewPluginOptions()
+	opts.Global.AllProjects = false
+
+	resultsChan := r.ResolveDepgraphs(ictx, "/test/dir", opts)
+
+	results := collectResults(resultsChan)
+
+	assert.Len(t, results, 1)
+	assert.Equal(t, "type-b", results[0].ProjectDescriptor.Identity.ProjectType)
+}
+
+func setupMockInvocationContext(t *testing.T) workflow.InvocationContext {
+	t.Helper()
+
+	ctrl := gomock.NewController(t)
+	ictx := gafmocks.NewMockInvocationContext(ctrl)
+	engine := gafmocks.NewMockEngine(ctrl)
+	cfg := configuration.New()
+	logger := zerolog.Nop()
+
+	ictx.EXPECT().GetConfiguration().Return(cfg).AnyTimes()
+	ictx.EXPECT().GetEngine().Return(engine).AnyTimes()
+	ictx.EXPECT().GetEnhancedLogger().Return(&logger).AnyTimes()
+	ictx.EXPECT().Context().Return(context.Background()).AnyTimes()
+
+	engine.EXPECT().
+		InvokeWithConfig(gomock.Any(), gomock.Any()).
+		Return([]workflow.Data{}, nil).
+		AnyTimes()
+
+	return ictx
+}
+
+func collectResults(resultsChan <-chan ecosystems.SCAResult) []ecosystems.SCAResult {
+	results := make([]ecosystems.SCAResult, 0)
+	for result := range resultsChan {
+		results = append(results, result)
+	}
+	return results
+}

--- a/pkg/ecosystems/orchestrator/registry_test.go
+++ b/pkg/ecosystems/orchestrator/registry_test.go
@@ -40,9 +40,9 @@ func TestPluginRegistry_OrderPreservedWithoutDependencies(t *testing.T) {
 		plugins: make([]ecosystems.SCAPlugin, 0),
 	}
 
-	r.register(mockPlugin{name: "plugin-a"})
-	r.register(mockPlugin{name: "plugin-b"})
-	r.register(mockPlugin{name: "plugin-c"})
+	require.NoError(t, r.register(mockPlugin{name: "plugin-a"}))
+	require.NoError(t, r.register(mockPlugin{name: "plugin-b"}))
+	require.NoError(t, r.register(mockPlugin{name: "plugin-c"}))
 
 	require.Len(t, r.plugins, 3)
 	assert.Equal(t, "plugin-a", r.plugins[0].GetName())
@@ -56,9 +56,12 @@ func TestPluginRegistry_DependenciesRespected(t *testing.T) {
 		plugins: make([]ecosystems.SCAPlugin, 0),
 	}
 
-	r.register(mockPlugin{name: "plugin-c"}, "plugin-a")
-	r.register(mockPlugin{name: "plugin-b"}, "plugin-a")
-	r.register(mockPlugin{name: "plugin-a"})
+	err := r.register(mockPlugin{name: "plugin-c"}, "plugin-a")
+	require.NoError(t, err)
+	err = r.register(mockPlugin{name: "plugin-b"}, "plugin-a")
+	require.NoError(t, err)
+	err = r.register(mockPlugin{name: "plugin-a"})
+	require.NoError(t, err)
 
 	require.Len(t, r.plugins, 3)
 	assert.Equal(t, "plugin-a", r.plugins[0].GetName())
@@ -72,9 +75,12 @@ func TestPluginRegistry_ChainedDependencies(t *testing.T) {
 		plugins: make([]ecosystems.SCAPlugin, 0),
 	}
 
-	r.register(mockPlugin{name: "plugin-c"}, "plugin-b")
-	r.register(mockPlugin{name: "plugin-b"}, "plugin-a")
-	r.register(mockPlugin{name: "plugin-a"})
+	err := r.register(mockPlugin{name: "plugin-c"}, "plugin-b")
+	require.NoError(t, err)
+	err = r.register(mockPlugin{name: "plugin-b"}, "plugin-a")
+	require.NoError(t, err)
+	err = r.register(mockPlugin{name: "plugin-a"})
+	require.NoError(t, err)
 
 	require.Len(t, r.plugins, 3)
 	assert.Equal(t, "plugin-a", r.plugins[0].GetName())
@@ -83,7 +89,8 @@ func TestPluginRegistry_ChainedDependencies(t *testing.T) {
 }
 
 func TestPluginRegistry_DefaultRegistryOrder(t *testing.T) {
-	r := NewDefaultPluginRegistry()
+	r, err := NewDefaultPluginRegistry()
+	require.NoError(t, err)
 
 	require.Len(t, r.plugins, 4)
 	assert.Equal(t, "bun", r.plugins[0].GetName())
@@ -92,16 +99,27 @@ func TestPluginRegistry_DefaultRegistryOrder(t *testing.T) {
 	assert.Equal(t, "pipenv", r.plugins[3].GetName())
 }
 
-func TestPluginRegistry_CircularDependencyReturnsNil(t *testing.T) {
+func TestPluginRegistry_DefaultRegistryHasNoCircularDependencies(t *testing.T) {
+	// This test ensures NewDefaultPluginRegistry doesn't error due to circular dependencies
+	r, err := NewDefaultPluginRegistry()
+	require.NoError(t, err, "NewDefaultPluginRegistry should not return error for valid dependency graph")
+	assert.NotNil(t, r)
+	assert.NotNil(t, r.plugins, "plugins should be successfully sorted without circular dependencies")
+	assert.Len(t, r.plugins, 4, "all 4 plugins should be registered")
+}
+
+func TestPluginRegistry_CircularDependencyReturnsError(t *testing.T) {
 	r := &PluginRegistry{
 		entries: make([]pluginEntry, 0),
 		plugins: make([]ecosystems.SCAPlugin, 0),
 	}
 
-	r.register(mockPlugin{name: "plugin-a"}, "plugin-b")
-	r.register(mockPlugin{name: "plugin-b"}, "plugin-a")
-
-	assert.Nil(t, r.plugins, "circular dependencies should result in nil plugins list")
+	err := r.register(mockPlugin{name: "plugin-a"}, "plugin-b")
+	require.NoError(t, err)
+	err = r.register(mockPlugin{name: "plugin-b"}, "plugin-a")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "circular dependency detected")
+	assert.Contains(t, err.Error(), "plugin-b")
 }
 
 func TestPluginRegistry_NonExistentDependencyIgnored(t *testing.T) {
@@ -110,8 +128,10 @@ func TestPluginRegistry_NonExistentDependencyIgnored(t *testing.T) {
 		plugins: make([]ecosystems.SCAPlugin, 0),
 	}
 
-	r.register(mockPlugin{name: "plugin-a"})
-	r.register(mockPlugin{name: "plugin-b"}, "non-existent-plugin")
+	err := r.register(mockPlugin{name: "plugin-a"})
+	require.NoError(t, err)
+	err = r.register(mockPlugin{name: "plugin-b"}, "non-existent-plugin")
+	require.NoError(t, err)
 
 	require.Len(t, r.plugins, 2)
 
@@ -130,12 +150,30 @@ func TestPluginRegistry_DependencyAddedLater(t *testing.T) {
 		plugins: make([]ecosystems.SCAPlugin, 0),
 	}
 
-	r.register(mockPlugin{name: "plugin-b"}, "plugin-a")
-	r.register(mockPlugin{name: "plugin-a"})
+	err := r.register(mockPlugin{name: "plugin-b"}, "plugin-a")
+	require.NoError(t, err)
+	err = r.register(mockPlugin{name: "plugin-a"})
+	require.NoError(t, err)
 
 	require.Len(t, r.plugins, 2)
 	assert.Equal(t, "plugin-a", r.plugins[0].GetName())
 	assert.Equal(t, "plugin-b", r.plugins[1].GetName())
+}
+
+func TestPluginRegistry_CircularDependencyError(t *testing.T) {
+	r := &PluginRegistry{
+		entries: make([]pluginEntry, 0),
+		plugins: make([]ecosystems.SCAPlugin, 0),
+	}
+
+	err := r.register(mockPlugin{name: "plugin-a"}, "plugin-b")
+	require.NoError(t, err)
+	err = r.register(mockPlugin{name: "plugin-b"}, "plugin-c")
+	require.NoError(t, err)
+	err = r.register(mockPlugin{name: "plugin-c"}, "plugin-a")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "circular dependency detected")
+	assert.Contains(t, err.Error(), "plugin-c")
 }
 
 func TestPluginRegistry_ResolveDepgraphs_AllProjectsMode(t *testing.T) {
@@ -146,16 +184,16 @@ func TestPluginRegistry_ResolveDepgraphs_AllProjectsMode(t *testing.T) {
 		plugins: make([]ecosystems.SCAPlugin, 0),
 	}
 
-	r.register(mockPlugin{
+	require.NoError(t, r.register(mockPlugin{
 		name:           "plugin-a",
 		processedFiles: []string{"file-a.txt"},
 		results:        []ecosystems.SCAResult{{ProjectDescriptor: identity.ProjectDescriptor{Identity: identity.ProjectIdentity{ProjectType: "type-a"}}}},
-	})
-	r.register(mockPlugin{
+	}))
+	require.NoError(t, r.register(mockPlugin{
 		name:           "plugin-b",
 		processedFiles: []string{"file-b.txt"},
 		results:        []ecosystems.SCAResult{{ProjectDescriptor: identity.ProjectDescriptor{Identity: identity.ProjectIdentity{ProjectType: "type-b"}}}},
-	})
+	}))
 
 	opts := ecosystems.NewPluginOptions()
 	opts.Global.AllProjects = true
@@ -175,16 +213,16 @@ func TestPluginRegistry_ResolveDepgraphs_StopsAfterFirstResult(t *testing.T) {
 		plugins: make([]ecosystems.SCAPlugin, 0),
 	}
 
-	r.register(mockPlugin{
+	require.NoError(t, r.register(mockPlugin{
 		name:           "plugin-a",
 		processedFiles: []string{"file-a.txt"},
 		results:        []ecosystems.SCAResult{{ProjectDescriptor: identity.ProjectDescriptor{Identity: identity.ProjectIdentity{ProjectType: "type-a"}}}},
-	})
-	r.register(mockPlugin{
+	}))
+	require.NoError(t, r.register(mockPlugin{
 		name:           "plugin-b",
 		processedFiles: []string{"file-b.txt"},
 		results:        []ecosystems.SCAResult{{ProjectDescriptor: identity.ProjectDescriptor{Identity: identity.ProjectIdentity{ProjectType: "type-b"}}}},
-	})
+	}))
 
 	opts := ecosystems.NewPluginOptions()
 	opts.Global.AllProjects = false
@@ -205,16 +243,16 @@ func TestPluginRegistry_ResolveDepgraphs_ContinuesWhenNoResults(t *testing.T) {
 		plugins: make([]ecosystems.SCAPlugin, 0),
 	}
 
-	r.register(mockPlugin{
+	require.NoError(t, r.register(mockPlugin{
 		name:           "plugin-a",
 		processedFiles: []string{},
 		results:        []ecosystems.SCAResult{},
-	})
-	r.register(mockPlugin{
+	}))
+	require.NoError(t, r.register(mockPlugin{
 		name:           "plugin-b",
 		processedFiles: []string{"file-b.txt"},
 		results:        []ecosystems.SCAResult{{ProjectDescriptor: identity.ProjectDescriptor{Identity: identity.ProjectIdentity{ProjectType: "type-b"}}}},
-	})
+	}))
 
 	opts := ecosystems.NewPluginOptions()
 	opts.Global.AllProjects = false

--- a/pkg/ecosystems/plugin_interface.go
+++ b/pkg/ecosystems/plugin_interface.go
@@ -26,4 +26,5 @@ type PluginResult struct {
 // from a directory containing project files.
 type SCAPlugin interface {
 	BuildDepGraphsFromDir(ctx context.Context, log logger.Logger, dir string, options *SCAPluginOptions) (*PluginResult, error)
+	GetName() string
 }

--- a/pkg/ecosystems/python/pip/plugin.go
+++ b/pkg/ecosystems/python/pip/plugin.go
@@ -21,12 +21,17 @@ import (
 )
 
 const (
+	PluginName            = "pip"
 	requirementsFile      = "requirements.txt"
 	maxConcurrentInstalls = 5
 	logFieldFile          = "file"
 )
 
 type Plugin struct{}
+
+func (p Plugin) GetName() string {
+	return PluginName
+}
 
 // Compile-time check to ensure Plugin implements SCAPlugin interface.
 var _ ecosystems.SCAPlugin = (*Plugin)(nil)

--- a/pkg/ecosystems/python/pipenv/plugin.go
+++ b/pkg/ecosystems/python/pipenv/plugin.go
@@ -22,6 +22,7 @@ import (
 )
 
 const (
+	PluginName            = "pipenv"
 	pipfileFile           = "Pipfile"
 	pipfileLockFile       = "Pipfile.lock"
 	maxConcurrentInstalls = 5
@@ -33,6 +34,10 @@ type Plugin struct{}
 
 // Compile-time check to ensure Plugin implements SCAPlugin interface.
 var _ ecosystems.SCAPlugin = (*Plugin)(nil)
+
+func (p Plugin) GetName() string {
+	return PluginName
+}
 
 // BuildDepGraphsFromDir discovers and builds dependency graphs for Pipenv projects.
 func (p Plugin) BuildDepGraphsFromDir(

--- a/pkg/ecosystems/python/uv/plugin.go
+++ b/pkg/ecosystems/python/uv/plugin.go
@@ -19,6 +19,8 @@ import (
 	"github.com/snyk/cli-extension-dep-graph/pkg/identity"
 )
 
+const PluginName = "uv"
+
 type Plugin struct {
 	client        Client
 	snykClient    *snykclient.SnykClient
@@ -31,6 +33,10 @@ func NewPlugin(client Client, snykClient *snykclient.SnykClient, remoteRepoURL s
 		snykClient:    snykClient,
 		remoteRepoURL: remoteRepoURL,
 	}
+}
+
+func (p Plugin) GetName() string {
+	return PluginName
 }
 
 func (p Plugin) BuildDepGraphsFromDir(


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [ ] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Add a new PluginRegistry to manage SCA plugin registration, dependency
resolution, and execution order. This replaces hardcoded plugin invocation
with a flexible, dependency-aware orchestration system.

Key features:
* Explicit dependency declaration at plugin registration time
* Topological sorting using Kahn's algorithm for correct execution order
* Circular dependency detection and validation
* Support for late-added dependencies
* Automatic processed file tracking and exclusion
* Configurable execution modes (single project vs all-projects)

