### PR TITLE
feat(conversion): export SBOMConverter interface from pkg/conversion

### DIFF
--- a/internal/remoteconv/extract_test.go
+++ b/internal/remoteconv/extract_test.go
@@ -1,4 +1,4 @@
-package conversion
+package remoteconv
 
 import (
 	"testing"

--- a/internal/remoteconv/remote_converter.go
+++ b/internal/remoteconv/remote_converter.go
@@ -1,4 +1,4 @@
-package conversion
+package remoteconv
 
 import (
 	"context"
@@ -8,6 +8,7 @@ import (
 	"github.com/snyk/dep-graph/go/pkg/depgraph"
 
 	"github.com/snyk/cli-extension-dep-graph/internal/snykclient"
+	"github.com/snyk/cli-extension-dep-graph/pkg/conversion"
 	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/logger"
 )
 
@@ -27,8 +28,8 @@ func NewRemoteSBOMConverter(client *snykclient.SnykClient, log logger.Logger) *R
 func (c *RemoteSBOMConverter) ConvertSBOM(
 	ctx context.Context,
 	sbom io.Reader,
-	options ConvertSBOMOptions,
-) ([]*depgraph.DepGraph, []Warning, error) {
+	options conversion.ConvertSBOMOptions,
+) ([]*depgraph.DepGraph, []conversion.Warning, error) {
 	scans, snykWarnings, err := c.client.SBOMConvert(ctx, c.log, sbom, options.RemoteRepoURL, options.ForceSingleGraph)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to convert SBOM: %w", err)
@@ -43,16 +44,16 @@ func (c *RemoteSBOMConverter) ConvertSBOM(
 	return depGraphs, warnings, nil
 }
 
-func translateWarnings(warnings []*snykclient.ConversionWarning) []Warning {
+func translateWarnings(warnings []*snykclient.ConversionWarning) []conversion.Warning {
 	if len(warnings) == 0 {
 		return nil
 	}
-	out := make([]Warning, 0, len(warnings))
+	out := make([]conversion.Warning, 0, len(warnings))
 	for _, w := range warnings {
 		if w == nil {
 			continue
 		}
-		out = append(out, Warning{
+		out = append(out, conversion.Warning{
 			Type:   w.Type,
 			BOMRef: w.BOMRef,
 			Msg:    w.Msg,
@@ -75,5 +76,5 @@ func extractDepGraphsFromScans(scans []*snykclient.ScanResult) ([]*depgraph.DepG
 	return depGraphs, nil
 }
 
-// Compile-time check that RemoteSBOMConverter satisfies SBOMConverter.
-var _ SBOMConverter = (*RemoteSBOMConverter)(nil)
+// Compile-time check that RemoteSBOMConverter satisfies the public SBOMConverter interface.
+var _ conversion.SBOMConverter = (*RemoteSBOMConverter)(nil)

--- a/internal/remoteconv/remote_converter_test.go
+++ b/internal/remoteconv/remote_converter_test.go
@@ -1,4 +1,4 @@
-package conversion
+package remoteconv
 
 import (
 	"bytes"
@@ -12,6 +12,7 @@ import (
 
 	"github.com/snyk/cli-extension-dep-graph/internal/mocks"
 	"github.com/snyk/cli-extension-dep-graph/internal/snykclient"
+	"github.com/snyk/cli-extension-dep-graph/pkg/conversion"
 	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/logger"
 )
 
@@ -62,7 +63,7 @@ func TestRemoteSBOMConverter_ConvertSBOM_Success(t *testing.T) {
 	depGraphs, warnings, err := converter.ConvertSBOM(
 		context.Background(),
 		bytes.NewReader([]byte(`{"test": "sbom"}`)),
-		ConvertSBOMOptions{},
+		conversion.ConvertSBOMOptions{},
 	)
 
 	require.NoError(t, err)
@@ -79,13 +80,13 @@ func TestRemoteSBOMConverter_ConvertSBOM_TranslatesWarnings(t *testing.T) {
 	_, warnings, err := converter.ConvertSBOM(
 		context.Background(),
 		bytes.NewReader([]byte(`{"test": "sbom"}`)),
-		ConvertSBOMOptions{},
+		conversion.ConvertSBOMOptions{},
 	)
 
 	require.NoError(t, err)
 	require.Len(t, warnings, 2)
-	assert.Equal(t, Warning{Type: "UnsupportedComponent", BOMRef: "ref-1", Msg: "first warning"}, warnings[0])
-	assert.Equal(t, Warning{Type: "MissingPurl", BOMRef: "ref-2", Msg: "second warning"}, warnings[1])
+	assert.Equal(t, conversion.Warning{Type: "UnsupportedComponent", BOMRef: "ref-1", Msg: "first warning"}, warnings[0])
+	assert.Equal(t, conversion.Warning{Type: "MissingPurl", BOMRef: "ref-2", Msg: "second warning"}, warnings[1])
 }
 
 func TestRemoteSBOMConverter_ConvertSBOM_ForwardsRemoteRepoURL(t *testing.T) {
@@ -99,7 +100,7 @@ func TestRemoteSBOMConverter_ConvertSBOM_ForwardsRemoteRepoURL(t *testing.T) {
 	_, _, err := converter.ConvertSBOM(
 		context.Background(),
 		bytes.NewReader([]byte(`{"test": "sbom"}`)),
-		ConvertSBOMOptions{RemoteRepoURL: "https://example.com/repo"},
+		conversion.ConvertSBOMOptions{RemoteRepoURL: "https://example.com/repo"},
 	)
 
 	require.NoError(t, err)
@@ -128,7 +129,7 @@ func TestRemoteSBOMConverter_ConvertSBOM_ForwardsForceSingleGraph(t *testing.T) 
 			_, _, err := converter.ConvertSBOM(
 				context.Background(),
 				bytes.NewReader([]byte(`{"test": "sbom"}`)),
-				ConvertSBOMOptions{ForceSingleGraph: tt.forceSingleGraph},
+				conversion.ConvertSBOMOptions{ForceSingleGraph: tt.forceSingleGraph},
 			)
 
 			require.NoError(t, err)
@@ -149,7 +150,7 @@ func TestRemoteSBOMConverter_ConvertSBOM_PropagatesError(t *testing.T) {
 	depGraphs, warnings, err := converter.ConvertSBOM(
 		context.Background(),
 		bytes.NewReader([]byte(`{"test": "sbom"}`)),
-		ConvertSBOMOptions{},
+		conversion.ConvertSBOMOptions{},
 	)
 
 	require.Error(t, err)
@@ -166,7 +167,7 @@ func TestRemoteSBOMConverter_ConvertSBOM_EmptyResultsReturnsEmptySlice(t *testin
 	depGraphs, warnings, err := converter.ConvertSBOM(
 		context.Background(),
 		bytes.NewReader([]byte(`{"test": "sbom"}`)),
-		ConvertSBOMOptions{},
+		conversion.ConvertSBOMOptions{},
 	)
 
 	require.NoError(t, err)

--- a/pkg/conversion/converter.go
+++ b/pkg/conversion/converter.go
@@ -1,3 +1,6 @@
+// Package conversion defines the public SBOM-to-depgraph conversion interface
+// and supporting types. Consumers implement this interface to inject their own
+// conversion strategy into ecosystem plugins.
 package conversion
 
 import (

--- a/pkg/depgraph/sbom_resolution.go
+++ b/pkg/depgraph/sbom_resolution.go
@@ -15,7 +15,7 @@ import (
 	"github.com/snyk/go-application-framework/pkg/configuration"
 	"github.com/snyk/go-application-framework/pkg/workflow"
 
-	"github.com/snyk/cli-extension-dep-graph/internal/conversion"
+	"github.com/snyk/cli-extension-dep-graph/internal/remoteconv"
 	"github.com/snyk/cli-extension-dep-graph/internal/snykclient"
 	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
 	ecosystemslogger "github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/logger"
@@ -41,7 +41,7 @@ func handleSBOMResolution(
 		orgID,
 	)
 
-	converter := conversion.NewRemoteSBOMConverter(snykClient, ecosystemslogger.NewFromZerolog(logger))
+	converter := remoteconv.NewRemoteSBOMConverter(snykClient, ecosystemslogger.NewFromZerolog(logger))
 
 	return handleSBOMResolutionDI(
 		ctx,

--- a/pkg/ecosystems/python/uv/mock_converter_test.go
+++ b/pkg/ecosystems/python/uv/mock_converter_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/snyk/dep-graph/go/pkg/depgraph"
 
-	"github.com/snyk/cli-extension-dep-graph/internal/conversion"
+	"github.com/snyk/cli-extension-dep-graph/pkg/conversion"
 )
 
 // MockSBOMConverter is a test double for conversion.SBOMConverter. It records

--- a/pkg/ecosystems/python/uv/plugin.go
+++ b/pkg/ecosystems/python/uv/plugin.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/snyk/error-catalog-golang-public/opensource/ecosystems"
 
-	"github.com/snyk/cli-extension-dep-graph/internal/conversion"
+	"github.com/snyk/cli-extension-dep-graph/pkg/conversion"
 	scaecosystems "github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
 	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/discovery"
 	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/logger"


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written (if applicable) [ℹ︎](https://github.com/snyk/general/wiki/Documentation) - n/a
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

`SBOMConverter`, `ConvertSBOMOptions`, and `Warning` were introduced under `internal/conversion` in #161. However, because `internal/` is private to this Go module, external consumers cannot reference the types and so cannot implement the interface. This PR moves them to a new `pkg/conversion` package.