### PR TITLE
feat: Adds `ResolverMetadata` to SCAResult containing optional details about resolver execution

### DIFF
--- a/pkg/ecosystems/README.md
+++ b/pkg/ecosystems/README.md
@@ -34,9 +34,10 @@ The `SCAResult.DepGraph` field uses the standard Snyk dependency graph format fr
 import "github.com/snyk/dep-graph/go/pkg/depgraph"
 
 type SCAResult struct {
-    DepGraph *depgraph.DepGraph `json:"depGraph,omitempty"`
-    Metadata Metadata           `json:"metadata"`
-    Error    error              `json:"error,omitempty"`
+    DepGraph          *depgraph.DepGraph         `json:"depGraph,omitempty"`
+    ProjectDescriptor identity.ProjectDescriptor `json:"projectDescriptor"`
+    ResolverMetadata  *ResolverMetadata          `json:"meta,omitempty"`
+    Error             error                      `json:"error,omitempty"`
 }
 ```
 
@@ -133,23 +134,76 @@ depGraph := builder.Build()
 
 ```go
 type SCAResult struct {
-    DepGraph *depgraph.DepGraph `json:"depGraph,omitempty"`
-    Metadata Metadata           `json:"metadata"`
-    Error    error              `json:"error,omitempty"`
+    DepGraph          *depgraph.DepGraph         `json:"depGraph,omitempty"`
+    ProjectDescriptor identity.ProjectDescriptor `json:"projectDescriptor"`
+    ResolverMetadata  *ResolverMetadata          `json:"meta,omitempty"`
+    Error             error                      `json:"error,omitempty"`
 }
 ```
 
 Each result contains:
 - **DepGraph**: The complete dependency graph using Snyk's standard format
-- **Metadata**: Context about the analysis (target file, runtime environment)
+- **ProjectDescriptor**: Project identity information (type, target file, runtime)
+- **ResolverMetadata**: Information about the resolver/plugin that performed the analysis
 - **Error**: Any error encountered during analysis (optional)
 
-### Metadata
+### ProjectDescriptor
 
 ```go
-type Metadata struct {
-    TargetFile string `json:"targetFile"`  // Path to the manifest file (e.g., "requirements.txt")
-    Runtime    string `json:"runtime"`     // Runtime environment (e.g., "python@3.11.0")
+type ProjectDescriptor struct {
+    Identity ProjectIdentity `json:"identity"`
+}
+
+type ProjectIdentity struct {
+    ProjectType       string  `json:"type,omitempty"`           // Project type (e.g., "npm", "maven", "pip")
+    TargetFile        *string `json:"targetFile,omitempty"`     // Manifest/build file path
+    TargetRuntime     *string `json:"targetRuntime,omitempty"`  // Runtime environment
+    RootComponentName string  `json:"rootComponentName,omitempty"` // Root component name
+}
+```
+
+The `ProjectDescriptor` contains project identity information that uniquely identifies what was analyzed. This includes the project type (ecosystem), the specific manifest file, and runtime details.
+
+### ResolverMetadata
+
+```go
+type ResolverMetadata struct {
+    PluginName       string            `json:"pluginName"`       // Name of the plugin/resolver
+    VersionBuildInfo map[string]string `json:"versionBuildInfo"` // Version and build information
+}
+```
+
+**Standard keys** are available in the `metadata` package:
+
+```go
+import "github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/metadata"
+
+// Available keys:
+const (
+    // Gradle ecosystem
+    metadata.GradleVersion  = "gradleVersion"
+    metadata.JavaVersion    = "javaVersion" 
+    
+    // Python ecosystem
+    metadata.PythonVersion  = "pythonVersion"
+    
+    // General build info
+    metadata.BuildTimestamp = "buildTimestamp"
+)
+```
+
+**Example usage:**
+
+```go
+import "github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/metadata"
+
+resolverMetadata := ResolverMetadata{
+    PluginName: "gradle",
+    VersionBuildInfo: map[string]string{
+        metadata.GradleVersion:  "8.5",
+        metadata.JavaVersion:    "17.0.1", 
+        metadata.BuildTimestamp: "2024-01-01T12:00:00Z",
+    },
 }
 ```
 
@@ -186,12 +240,10 @@ func main() {
     
     for _, scaResult := range result.Results {
         if scaResult.Error != nil {
-            fmt.Printf("Error analyzing %s: %v\n", scaResult.Metadata.TargetFile, scaResult.Error)
+            fmt.Printf("Error analyzing with %s: %v\n", scaResult.ResolverMetadata.PluginName, scaResult.Error)
             continue
         }
-        
-        fmt.Printf("Target: %s\n", scaResult.Metadata.TargetFile)
-        fmt.Printf("Runtime: %s\n", scaResult.Metadata.Runtime)
+
         fmt.Printf("Package Manager: %s\n", scaResult.DepGraph.PkgManager.Name)
         fmt.Printf("Total Packages: %d\n", len(scaResult.DepGraph.Pkgs))
     }
@@ -214,7 +266,7 @@ result, err := plugin.BuildDepGraphsFromDir(ctx, logger.Nop(), "/path/to/monorep
 for _, result := range result.Results {
     if result.Error != nil {
         // Individual file failed, but others may have succeeded
-        log.Printf("Failed to analyze %s: %v", result.Metadata.TargetFile, result.Error)
+        log.Printf("Failed to analyze with %s: %v", result.ResolverMetadata.PluginName, result.Error)
         continue
     }
     

--- a/pkg/ecosystems/gradle/plugin.go
+++ b/pkg/ecosystems/gradle/plugin.go
@@ -12,6 +12,7 @@ import (
 	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
 	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/discovery"
 	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/logger"
+	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/metadata"
 	"github.com/snyk/cli-extension-dep-graph/pkg/identity"
 )
 
@@ -295,6 +296,15 @@ func (p Plugin) convertProjects(
 		}
 	}
 
+	resolverMetadata := ecosystems.ResolverMetadata{
+		PluginName: PluginName,
+		VersionBuildInfo: map[string]string{
+			metadata.GradleVersion:  parsed.Metadata.GradleVersion,
+			metadata.JavaVersion:    parsed.Metadata.JavaVersion,
+			metadata.BuildTimestamp: parsed.Metadata.GeneratedAt,
+		},
+	}
+
 	// Iterate projects in Gradle evaluation order (preserved by the array format).
 	// The init script outputs projects via root.allprojects.each, which visits
 	// in evaluation order: root first, then subprojects in settings.gradle
@@ -338,7 +348,8 @@ func (p Plugin) convertProjects(
 						TargetFile:  &relFile,
 					},
 				},
-				Error: err,
+				Error:            err,
+				ResolverMetadata: &resolverMetadata,
 			})
 
 			continue
@@ -361,6 +372,7 @@ func (p Plugin) convertProjects(
 					RootComponentName: rootName,
 				},
 			},
+			ResolverMetadata: &resolverMetadata,
 		})
 		processedFiles = append(processedFiles, relFile)
 	}

--- a/pkg/ecosystems/gradle/plugin_test.go
+++ b/pkg/ecosystems/gradle/plugin_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
 	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/logger"
+	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/metadata"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -499,6 +500,14 @@ func TestTargetFileFiltering_MockedOutput(t *testing.T) {
 		assert.Len(t, allResults, 3, "Without target file, should return all projects")
 		assert.Len(t, allFiles, 3)
 
+		// Validate ResolverMetadata for all results
+		for i, result := range allResults {
+			assert.NotNil(t, result.ResolverMetadata, "allResults[%d] ResolverMetadata should not be nil", i)
+			assert.Equal(t, "gradle", result.ResolverMetadata.PluginName, "allResults[%d] PluginName should be 'gradle'", i)
+			assert.Contains(t, result.ResolverMetadata.VersionBuildInfo, metadata.GradleVersion, "allResults[%d] should contain gradleVersion", i)
+			assert.Contains(t, result.ResolverMetadata.VersionBuildInfo, metadata.JavaVersion, "allResults[%d] should contain javaVersion", i)
+		}
+
 		// Extract project names for verification
 		allProjectNames := make([]string, len(allResults))
 		for i, result := range allResults {
@@ -524,6 +533,12 @@ func TestTargetFileFiltering_MockedOutput(t *testing.T) {
 		result := targetedResults[0]
 		assert.NotNil(t, result.DepGraph)
 		assert.Equal(t, "com.example:app", result.DepGraph.GetRootPkg().Info.Name)
+
+		// Validate ResolverMetadata
+		assert.NotNil(t, result.ResolverMetadata)
+		assert.Equal(t, "gradle", result.ResolverMetadata.PluginName)
+		assert.Contains(t, result.ResolverMetadata.VersionBuildInfo, metadata.GradleVersion)
+		assert.Contains(t, result.ResolverMetadata.VersionBuildInfo, metadata.JavaVersion)
 
 		// Verify it has the expected dependency (slf4j-api from the mock)
 		depGraph := result.DepGraph
@@ -565,6 +580,12 @@ func TestTargetFileFiltering_MockedOutput(t *testing.T) {
 		result := results[0]
 		assert.NotNil(t, result.DepGraph)
 		assert.Equal(t, "com.example:lib", result.DepGraph.GetRootPkg().Info.Name)
+
+		// Validate ResolverMetadata
+		assert.NotNil(t, result.ResolverMetadata)
+		assert.Equal(t, "gradle", result.ResolverMetadata.PluginName)
+		assert.Contains(t, result.ResolverMetadata.VersionBuildInfo, metadata.GradleVersion)
+		assert.Contains(t, result.ResolverMetadata.VersionBuildInfo, metadata.JavaVersion)
 
 		// Verify it has the expected dependency (guava from the mock)
 		depGraph := result.DepGraph

--- a/pkg/ecosystems/javascript/bun/executor.go
+++ b/pkg/ecosystems/javascript/bun/executor.go
@@ -45,7 +45,7 @@ var _ bunWhyRunner = (*bunCmdExecutor)(nil)
 // The caller must close the returned ReadCloser when done (or on error) to
 // ensure the background goroutine and subprocess are released promptly.
 func (e *bunCmdExecutor) Run(ctx context.Context, dir string) (io.ReadCloser, error) {
-	resolved, err := exec.LookPath("bun")
+	resolved, err := exec.LookPath("bun") //nolint:goconst // executable name
 	if err != nil {
 		return nil, errBunNotFound //nolint:wrapcheck // sentinel error, intentionally returned unwrapped
 	}

--- a/pkg/ecosystems/javascript/bun/plugin.go
+++ b/pkg/ecosystems/javascript/bun/plugin.go
@@ -153,6 +153,10 @@ func (p Plugin) buildResults(
 					TargetFile:  &tf,
 				},
 			},
+			ResolverMetadata: &ecosystems.ResolverMetadata{
+				PluginName:       PluginName,
+				VersionBuildInfo: map[string]string{},
+			},
 		}
 	}
 

--- a/pkg/ecosystems/javascript/bun/plugin_test.go
+++ b/pkg/ecosystems/javascript/bun/plugin_test.go
@@ -71,6 +71,10 @@ func TestPlugin_Simple(t *testing.T) {
 	assert.Equal(t, "my-app", scaResult.DepGraph.GetRootPkg().Info.Name)
 	assert.Equal(t, "package.json", scaResult.ProjectDescriptor.GetTargetFile())
 
+	// Validate ResolverMetadata
+	assert.NotNil(t, scaResult.ResolverMetadata)
+	assert.Equal(t, "bun", scaResult.ResolverMetadata.PluginName)
+
 	pkgIDs := make(map[string]bool)
 	for _, p := range scaResult.DepGraph.Pkgs {
 		pkgIDs[p.ID] = true
@@ -99,6 +103,10 @@ func TestPlugin_Workspace_MultipleDepGraphs(t *testing.T) {
 	for _, r := range result.Results {
 		require.NoError(t, r.Error)
 		require.NotNil(t, r.DepGraph)
+
+		// Validate ResolverMetadata
+		assert.NotNil(t, r.ResolverMetadata)
+		assert.Equal(t, "bun", r.ResolverMetadata.PluginName)
 	}
 
 	rootResult := testFindResultByRoot(t, result.Results, "my-workspace")
@@ -298,6 +306,10 @@ func TestPlugin_AllProjects_WorkspacesWithSubpackages(t *testing.T) {
 	for i, r := range result.Results {
 		require.NoError(t, r.Error, "result[%d] must not carry an error", i)
 		require.NotNil(t, r.DepGraph, "result[%d] must have a dep graph", i)
+
+		// Validate ResolverMetadata
+		assert.NotNil(t, r.ResolverMetadata, "result[%d] ResolverMetadata should not be nil", i)
+		assert.Equal(t, "bun", r.ResolverMetadata.PluginName, "result[%d] PluginName should be 'bun'", i)
 	}
 
 	wantTargetFiles := []string{

--- a/pkg/ecosystems/metadata/keys.go
+++ b/pkg/ecosystems/metadata/keys.go
@@ -1,0 +1,14 @@
+package metadata
+
+// Standard keys for ResolverMetadata.VersionBuildInfo.
+const (
+	// JVM ecosystem.
+	GradleVersion = "gradleVersion"
+	JavaVersion   = "javaVersion"
+
+	// Python ecosystem.
+	PythonVersion = "pythonVersion"
+
+	// General build info.
+	BuildTimestamp = "buildTimestamp"
+)

--- a/pkg/ecosystems/plugin_interface.go
+++ b/pkg/ecosystems/plugin_interface.go
@@ -9,11 +9,17 @@ import (
 	"github.com/snyk/cli-extension-dep-graph/pkg/identity"
 )
 
+type ResolverMetadata struct {
+	PluginName       string            `json:"pluginName,omitempty"`
+	VersionBuildInfo map[string]string `json:"versionBuildInfo,omitempty"`
+}
+
 // SCAResult represents the result of a Software Composition Analysis (SCA),
 // containing the dependency graph and associated project descriptor.
 type SCAResult struct {
 	DepGraph          *depgraph.DepGraph         `json:"depGraph,omitempty"`
 	ProjectDescriptor identity.ProjectDescriptor `json:"projectDescriptor"`
+	ResolverMetadata  *ResolverMetadata          `json:"meta,omitempty"`
 	Error             error                      `json:"error,omitempty"`
 }
 

--- a/pkg/ecosystems/python/pip/plugin.go
+++ b/pkg/ecosystems/python/pip/plugin.go
@@ -17,6 +17,7 @@ import (
 	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
 	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/discovery"
 	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/logger"
+	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/metadata"
 	"github.com/snyk/cli-extension-dep-graph/pkg/identity"
 )
 
@@ -216,6 +217,12 @@ func (p Plugin) buildDepGraphFromFile(
 				ProjectType:       "pip",
 				TargetFile:        &file.RelPath,
 				RootComponentName: rootName,
+			},
+		},
+		ResolverMetadata: &ecosystems.ResolverMetadata{
+			PluginName: PluginName,
+			VersionBuildInfo: map[string]string{
+				metadata.PythonVersion: pythonVersion,
 			},
 		},
 	}, nil

--- a/pkg/ecosystems/python/pip/plugin_integration_test.go
+++ b/pkg/ecosystems/python/pip/plugin_integration_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
 	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/logger"
+	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/metadata"
 )
 
 // PluginTestCase defines a test case for the plugin
@@ -242,12 +243,30 @@ func assertResultsMatchExpected(t *testing.T, actual, expected []ecosystems.SCAR
 		return sortExpected[i].DepGraph.GetRootPkg().Info.Name < sortExpected[j].DepGraph.GetRootPkg().Info.Name
 	})
 
+	// Validate and sync ResolverMetadata before comparison
+	for i := range sortActual {
+		// Validate ResolverMetadata is properly populated
+		require.NotNil(t, sortActual[i].ResolverMetadata, "[%s] ResolverMetadata should not be nil", fixtureName)
+		assert.Equal(t, "pip", sortActual[i].ResolverMetadata.PluginName, "[%s] PluginName should be 'pip'", fixtureName)
+
+		// Validate pythonVersion is present (should be non-empty if available)
+		if pythonVersion, exists := sortActual[i].ResolverMetadata.VersionBuildInfo[metadata.PythonVersion]; exists {
+			assert.NotEmpty(t, pythonVersion, "[%s] pythonVersion should not be empty if present", fixtureName)
+		}
+
+		// Null out ResolverMetadata for comparison (not part of golden files)
+		sortActual[i].ResolverMetadata = nil
+	}
+
 	// Sync fields that vary between pip and pipenv or by environment (allows sharing fixtures)
 	for i := range sortExpected {
 		sortExpected[i].ProjectDescriptor.Identity.TargetRuntime = sortActual[i].ProjectDescriptor.Identity.TargetRuntime
 		sortExpected[i].ProjectDescriptor.Identity.TargetFile = sortActual[i].ProjectDescriptor.Identity.TargetFile
 		sortActual[i].ProjectDescriptor.Identity.ProjectType = "" // Clear type since fixtures are shared
-		sortActual[i].Error = nil                                 // Error field isn't in expected JSON
+
+		// Ensure expected ResolverMetadata is also nil for comparison
+		sortExpected[i].ResolverMetadata = nil
+		sortActual[i].Error = nil // Error field isn't in expected JSON
 	}
 
 	// Compare by JSON representation to ignore internal unexported fields in depgraph.DepGraph

--- a/pkg/ecosystems/python/pipenv/plugin.go
+++ b/pkg/ecosystems/python/pipenv/plugin.go
@@ -17,6 +17,7 @@ import (
 	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
 	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/discovery"
 	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/logger"
+	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/metadata"
 	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/python/pip"
 	"github.com/snyk/cli-extension-dep-graph/pkg/identity"
 )
@@ -224,6 +225,12 @@ func (p Plugin) buildDepGraphFromPipfile(
 				ProjectType:       "pip",
 				TargetFile:        &file.RelPath,
 				RootComponentName: rootName,
+			},
+		},
+		ResolverMetadata: &ecosystems.ResolverMetadata{
+			PluginName: PluginName,
+			VersionBuildInfo: map[string]string{
+				metadata.PythonVersion: pythonVersion,
 			},
 		},
 	}, nil

--- a/pkg/ecosystems/python/pipenv/plugin_integration_test.go
+++ b/pkg/ecosystems/python/pipenv/plugin_integration_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
 	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/logger"
+	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/metadata"
 	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/python/pip"
 )
 
@@ -217,6 +218,21 @@ func assertResultsMatchExpected(t *testing.T, actual, expected []ecosystems.SCAR
 		return getFirstDirectDep(sortExpected[i]) < getFirstDirectDep(sortExpected[j])
 	})
 
+	// Validate and sync ResolverMetadata before comparison
+	for i := range sortActual {
+		// Validate ResolverMetadata is properly populated
+		require.NotNil(t, sortActual[i].ResolverMetadata, "[%s] ResolverMetadata should not be nil", fixtureName)
+		assert.Equal(t, "pipenv", sortActual[i].ResolverMetadata.PluginName, "[%s] PluginName should be 'pipenv'", fixtureName)
+
+		// Validate pythonVersion is present (should be non-empty if available)
+		if pythonVersion, exists := sortActual[i].ResolverMetadata.VersionBuildInfo[metadata.PythonVersion]; exists {
+			assert.NotEmpty(t, pythonVersion, "[%s] pythonVersion should not be empty if present", fixtureName)
+		}
+
+		// Null out ResolverMetadata for comparison (not part of golden files)
+		sortActual[i].ResolverMetadata = nil
+	}
+
 	// Sync fields that vary between pip and pipenv (allows sharing fixtures)
 	for i := range sortExpected {
 		sortExpected[i].ProjectDescriptor.Identity.TargetRuntime = sortActual[i].ProjectDescriptor.Identity.TargetRuntime
@@ -226,6 +242,9 @@ func assertResultsMatchExpected(t *testing.T, actual, expected []ecosystems.SCAR
 			sortExpected[i].DepGraph.PkgManager = sortActual[i].DepGraph.PkgManager
 		}
 		sortActual[i].Error = nil // Error field isn't in expected JSON
+
+		// Ensure expected ResolverMetadata is also nil for comparison
+		sortExpected[i].ResolverMetadata = nil
 	}
 
 	// Compare by JSON representation to ignore internal unexported fields in depgraph.DepGraph

--- a/pkg/ecosystems/python/uv/plugin.go
+++ b/pkg/ecosystems/python/uv/plugin.go
@@ -177,6 +177,10 @@ func (p Plugin) buildResults(
 					RootComponentName: rootName,
 				},
 			},
+			ResolverMetadata: &scaecosystems.ResolverMetadata{
+				PluginName:       PluginName,
+				VersionBuildInfo: map[string]string{},
+			},
 		}
 		result.Results = append(result.Results, res)
 	}


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [ ] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Adds a `ResolverMetadata` struct to the `SCAResult`. This maps to the legacy plugin `meta` field and contains details about the resolver that may be useful for debugging/tracking/metrics:
- Name
- Underlying versions
- etc.
