### PR TITLE
feat: add IsUvProject for uv project detection

### DIFF
--- a/internal/workflow/constants.go
+++ b/internal/workflow/constants.go
@@ -5,6 +5,9 @@ const (
 	ContentTypeJSONL       = "application/jsonl"
 	LegacyCLIWorkflowIDStr = "legacycli"
 	ContentLocationKey     = "Content-Location"
+
+	FeatureFlagUvCLI                         = "internal_snyk_cli_uv_enabled"
+	FeatureFlagUseUnifiedTestAPIForOSCliTest = "internal_snyk_cli_use_unified_test_api_for_os_cli_test"
 )
 
 var (

--- a/pkg/depgraph/callback.go
+++ b/pkg/depgraph/callback.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/snyk/cli-extension-dep-graph/internal/legacycli"
 	"github.com/snyk/cli-extension-dep-graph/internal/workflow"
+	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/python/uv"
 )
 
 type ResolutionHandlerFunc func(ctx gafworkflow.InvocationContext, config configuration.Configuration, logger *zerolog.Logger) ([]gafworkflow.Data, error)
@@ -17,9 +18,36 @@ func callback(ctx gafworkflow.InvocationContext, _ []gafworkflow.Data) ([]gafwor
 
 	logger.Print("DepGraph workflow start")
 
-	if config.GetBool(workflow.FlagUseSBOMResolution) {
+	if shouldUseOrchestratorResolution(config) {
+		return handleOrchestratorResolution(ctx, config, logger)
+	}
+
+	if shouldUseSBOMResolution(config, logger) {
 		return handleSBOMResolution(ctx, config, logger)
 	}
 
 	return legacycli.HandleLegacyResolution(ctx, config, logger) //nolint:wrapcheck // must return unwrapped so os-flows can detect and render ErrorCatalog.
+}
+
+func shouldUseSBOMResolution(config configuration.Configuration, logger *zerolog.Logger) bool {
+	if !uv.HasLockFile(
+		config.GetString(configuration.INPUT_DIRECTORY),
+		config.GetString(workflow.FlagFile),
+		config.GetBool(workflow.FlagAllProjects),
+		logger,
+	) {
+		return false
+	}
+
+	if !config.GetBool(workflow.FeatureFlagUvCLI) {
+		return false
+	}
+
+	logger.Info().Msg("uv.lock found and uv feature flag enabled, using SBOM resolution")
+
+	return true
+}
+
+func shouldUseOrchestratorResolution(config configuration.Configuration) bool {
+	return config.GetBool(workflow.FeatureFlagUseUnifiedTestAPIForOSCliTest)
 }

--- a/pkg/depgraph/callback.go
+++ b/pkg/depgraph/callback.go
@@ -30,21 +30,16 @@ func callback(ctx gafworkflow.InvocationContext, _ []gafworkflow.Data) ([]gafwor
 }
 
 func shouldUseSBOMResolution(config configuration.Configuration, logger *zerolog.Logger) bool {
-	if !uv.HasLockFile(
+	if !uv.IsUvProject(
 		config.GetString(configuration.INPUT_DIRECTORY),
 		config.GetString(workflow.FlagFile),
 		config.GetBool(workflow.FlagAllProjects),
-		logger,
+		config,
 	) {
 		return false
 	}
 
-	if !config.GetBool(workflow.FeatureFlagUvCLI) {
-		return false
-	}
-
 	logger.Info().Msg("uv.lock found and uv feature flag enabled, using SBOM resolution")
-
 	return true
 }
 

--- a/pkg/depgraph/callback_test.go
+++ b/pkg/depgraph/callback_test.go
@@ -43,22 +43,7 @@ func TestShouldUseSBOMResolution(t *testing.T) {
 	t.Parallel()
 	nopLogger := zerolog.Nop()
 
-	t.Run("returns false when uv feature flag is disabled", func(t *testing.T) {
-		t.Parallel()
-		config := configuration.New()
-		config.Set(workflow.FeatureFlagUvCLI, false)
-
-		assert.False(t, shouldUseSBOMResolution(config, &nopLogger))
-	})
-
-	t.Run("returns false when uv feature flag is not set", func(t *testing.T) {
-		t.Parallel()
-		config := configuration.New()
-
-		assert.False(t, shouldUseSBOMResolution(config, &nopLogger))
-	})
-
-	t.Run("returns false when uv feature flag is enabled but no uv.lock exists", func(t *testing.T) {
+	t.Run("returns false when no uv.lock exists even with FF enabled", func(t *testing.T) {
 		t.Parallel()
 		dir := t.TempDir()
 
@@ -69,7 +54,19 @@ func TestShouldUseSBOMResolution(t *testing.T) {
 		assert.False(t, shouldUseSBOMResolution(config, &nopLogger))
 	})
 
-	t.Run("returns true when uv feature flag is enabled and uv.lock exists", func(t *testing.T) {
+	t.Run("returns false when uv.lock exists but FF is disabled", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		createUvLockFile(t, dir)
+
+		config := configuration.New()
+		config.Set(workflow.FeatureFlagUvCLI, false)
+		config.Set(configuration.INPUT_DIRECTORY, dir)
+
+		assert.False(t, shouldUseSBOMResolution(config, &nopLogger))
+	})
+
+	t.Run("returns true when uv.lock exists and FF is enabled", func(t *testing.T) {
 		t.Parallel()
 		dir := t.TempDir()
 		createUvLockFile(t, dir)
@@ -81,7 +78,7 @@ func TestShouldUseSBOMResolution(t *testing.T) {
 		assert.True(t, shouldUseSBOMResolution(config, &nopLogger))
 	})
 
-	t.Run("returns true when uv feature flag is enabled and uv.lock is targeted via file flag", func(t *testing.T) {
+	t.Run("returns true when uv.lock is targeted via file flag", func(t *testing.T) {
 		t.Parallel()
 		dir := t.TempDir()
 		subdir := filepath.Join(dir, "sub")
@@ -95,7 +92,7 @@ func TestShouldUseSBOMResolution(t *testing.T) {
 		assert.True(t, shouldUseSBOMResolution(config, &nopLogger))
 	})
 
-	t.Run("returns false when uv feature flag is enabled and file flag targets a non-uv file", func(t *testing.T) {
+	t.Run("returns false when file flag targets a non-uv file", func(t *testing.T) {
 		t.Parallel()
 		dir := t.TempDir()
 

--- a/pkg/depgraph/callback_test.go
+++ b/pkg/depgraph/callback_test.go
@@ -1,0 +1,200 @@
+package depgraph
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/snyk/go-application-framework/pkg/configuration"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/snyk/cli-extension-dep-graph/internal/workflow"
+)
+
+func TestShouldUseOrchestratorResolution(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns true when unified test API feature flag is enabled", func(t *testing.T) {
+		t.Parallel()
+		config := configuration.New()
+		config.Set(workflow.FeatureFlagUseUnifiedTestAPIForOSCliTest, true)
+
+		assert.True(t, shouldUseOrchestratorResolution(config))
+	})
+
+	t.Run("returns false when unified test API feature flag is disabled", func(t *testing.T) {
+		t.Parallel()
+		config := configuration.New()
+		config.Set(workflow.FeatureFlagUseUnifiedTestAPIForOSCliTest, false)
+
+		assert.False(t, shouldUseOrchestratorResolution(config))
+	})
+
+	t.Run("returns false when unified test API feature flag is not set", func(t *testing.T) {
+		t.Parallel()
+		config := configuration.New()
+
+		assert.False(t, shouldUseOrchestratorResolution(config))
+	})
+}
+
+func TestShouldUseSBOMResolution(t *testing.T) {
+	t.Parallel()
+	nopLogger := zerolog.Nop()
+
+	t.Run("returns false when uv feature flag is disabled", func(t *testing.T) {
+		t.Parallel()
+		config := configuration.New()
+		config.Set(workflow.FeatureFlagUvCLI, false)
+
+		assert.False(t, shouldUseSBOMResolution(config, &nopLogger))
+	})
+
+	t.Run("returns false when uv feature flag is not set", func(t *testing.T) {
+		t.Parallel()
+		config := configuration.New()
+
+		assert.False(t, shouldUseSBOMResolution(config, &nopLogger))
+	})
+
+	t.Run("returns false when uv feature flag is enabled but no uv.lock exists", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+
+		config := configuration.New()
+		config.Set(workflow.FeatureFlagUvCLI, true)
+		config.Set(configuration.INPUT_DIRECTORY, dir)
+
+		assert.False(t, shouldUseSBOMResolution(config, &nopLogger))
+	})
+
+	t.Run("returns true when uv feature flag is enabled and uv.lock exists", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		createUvLockFile(t, dir)
+
+		config := configuration.New()
+		config.Set(workflow.FeatureFlagUvCLI, true)
+		config.Set(configuration.INPUT_DIRECTORY, dir)
+
+		assert.True(t, shouldUseSBOMResolution(config, &nopLogger))
+	})
+
+	t.Run("returns true when uv feature flag is enabled and uv.lock is targeted via file flag", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		subdir := filepath.Join(dir, "sub")
+		createUvLockFile(t, subdir)
+
+		config := configuration.New()
+		config.Set(workflow.FeatureFlagUvCLI, true)
+		config.Set(configuration.INPUT_DIRECTORY, dir)
+		config.Set(workflow.FlagFile, "sub/uv.lock")
+
+		assert.True(t, shouldUseSBOMResolution(config, &nopLogger))
+	})
+
+	t.Run("returns false when uv feature flag is enabled and file flag targets a non-uv file", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+
+		config := configuration.New()
+		config.Set(workflow.FeatureFlagUvCLI, true)
+		config.Set(configuration.INPUT_DIRECTORY, dir)
+		config.Set(workflow.FlagFile, "pom.xml")
+
+		assert.False(t, shouldUseSBOMResolution(config, &nopLogger))
+	})
+
+	t.Run("returns true with all-projects when uv.lock exists in subdirectory", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		createUvLockFile(t, filepath.Join(dir, "project1"))
+
+		config := configuration.New()
+		config.Set(workflow.FeatureFlagUvCLI, true)
+		config.Set(configuration.INPUT_DIRECTORY, dir)
+		config.Set(workflow.FlagAllProjects, true)
+
+		assert.True(t, shouldUseSBOMResolution(config, &nopLogger))
+	})
+
+	t.Run("returns false with all-projects when no uv.lock exists anywhere", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+
+		config := configuration.New()
+		config.Set(workflow.FeatureFlagUvCLI, true)
+		config.Set(configuration.INPUT_DIRECTORY, dir)
+		config.Set(workflow.FlagAllProjects, true)
+
+		assert.False(t, shouldUseSBOMResolution(config, &nopLogger))
+	})
+}
+
+func TestCallbackRouting(t *testing.T) {
+	t.Parallel()
+	nopLogger := zerolog.Nop()
+
+	t.Run("orchestrator takes priority over SBOM when both flags are set", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		createUvLockFile(t, dir)
+
+		config := configuration.New()
+		config.Set(workflow.FeatureFlagUseUnifiedTestAPIForOSCliTest, true)
+		config.Set(workflow.FeatureFlagUvCLI, true)
+		config.Set(configuration.INPUT_DIRECTORY, dir)
+
+		assert.True(t, shouldUseOrchestratorResolution(config),
+			"orchestrator should be selected")
+		assert.True(t, shouldUseSBOMResolution(config, &nopLogger),
+			"SBOM would also match, but orchestrator has priority")
+	})
+
+	t.Run("SBOM resolution selected when only uv flag is set with lockfile", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		createUvLockFile(t, dir)
+
+		config := configuration.New()
+		config.Set(workflow.FeatureFlagUvCLI, true)
+		config.Set(configuration.INPUT_DIRECTORY, dir)
+
+		assert.False(t, shouldUseOrchestratorResolution(config))
+		assert.True(t, shouldUseSBOMResolution(config, &nopLogger))
+	})
+
+	t.Run("legacy fallback when no feature flags are set", func(t *testing.T) {
+		t.Parallel()
+		config := configuration.New()
+
+		assert.False(t, shouldUseOrchestratorResolution(config))
+		assert.False(t, shouldUseSBOMResolution(config, &nopLogger))
+	})
+
+	t.Run("legacy fallback when uv flag is set but no lockfile exists", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+
+		config := configuration.New()
+		config.Set(workflow.FeatureFlagUvCLI, true)
+		config.Set(configuration.INPUT_DIRECTORY, dir)
+
+		assert.False(t, shouldUseOrchestratorResolution(config))
+		assert.False(t, shouldUseSBOMResolution(config, &nopLogger))
+	})
+}
+
+func createUvLockFile(t *testing.T, dir string) {
+	t.Helper()
+	err := os.MkdirAll(dir, 0o755)
+	if err != nil {
+		t.Fatalf("failed to create directory %s: %v", dir, err)
+	}
+	err = os.WriteFile(filepath.Join(dir, "uv.lock"), []byte("# test lockfile"), 0o600)
+	if err != nil {
+		t.Fatalf("failed to create uv.lock: %v", err)
+	}
+}

--- a/pkg/depgraph/orchestrator_resolution.go
+++ b/pkg/depgraph/orchestrator_resolution.go
@@ -1,0 +1,72 @@
+package depgraph
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/rs/zerolog"
+	"github.com/snyk/go-application-framework/pkg/configuration"
+	gafworkflow "github.com/snyk/go-application-framework/pkg/workflow"
+
+	"github.com/snyk/cli-extension-dep-graph/internal/workflow"
+	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
+	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/orchestrator"
+)
+
+func handleOrchestratorResolution(
+	ctx gafworkflow.InvocationContext,
+	config configuration.Configuration,
+	logger *zerolog.Logger,
+) ([]gafworkflow.Data, error) {
+	logger.Info().Msg("Retrieving dependencies from ecosystems orchestrator")
+
+	opts, err := ecosystems.NewPluginOptionsFromRawFlags(config.GetStringSlice(configuration.RAW_CMD_ARGS))
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse plugin options: %w", err)
+	}
+
+	inputDir := config.GetString(configuration.INPUT_DIRECTORY)
+	if inputDir == "" {
+		inputDir = "."
+	}
+
+	results, err := orchestrator.ResolveDepgraphs(ctx, inputDir, *opts)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve depgraphs through ecosystems orchestrator: %w", err)
+	}
+
+	var workflowData []gafworkflow.Data
+	for result := range results {
+		data, mapErr := orchestratorResultToWorkflowData(&result)
+		if mapErr != nil {
+			return nil, mapErr
+		}
+		workflowData = append(workflowData, data)
+	}
+
+	if len(workflowData) > 0 {
+		logger.Info().Msgf("Retrieved %d dependency graphs from ecosystems orchestrator", len(workflowData))
+	}
+
+	return workflowData, nil
+}
+
+func orchestratorResultToWorkflowData(result *ecosystems.SCAResult) (gafworkflow.Data, error) {
+	if result.Error != nil {
+		return nil, fmt.Errorf("failed to resolve depgraph for %s: %w",
+			result.ProjectDescriptor.GetTargetFile(), result.Error)
+	}
+
+	payload, err := json.Marshal(result.DepGraph)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal depgraph: %w", err)
+	}
+
+	data := gafworkflow.NewData(workflow.DataTypeID, workflow.ContentTypeJSON, payload)
+
+	targetFile := result.ProjectDescriptor.GetTargetFile()
+	data.SetMetaData(workflow.MetaKeyNormalisedTargetFile, targetFile)
+	data.SetMetaData(workflow.MetaKeyTargetFileFromPlugin, targetFile)
+
+	return data, nil
+}

--- a/pkg/depgraph/orchestrator_resolution_test.go
+++ b/pkg/depgraph/orchestrator_resolution_test.go
@@ -1,0 +1,95 @@
+package depgraph
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/snyk/dep-graph/go/pkg/depgraph"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/snyk/cli-extension-dep-graph/internal/workflow"
+	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
+	"github.com/snyk/cli-extension-dep-graph/pkg/identity"
+)
+
+func TestOrchestratorResultToWorkflowData_Success(t *testing.T) {
+	dg := &depgraph.DepGraph{
+		SchemaVersion: "1.2.0",
+		PkgManager:    depgraph.PkgManager{Name: "npm"},
+		Pkgs: []depgraph.Pkg{
+			{ID: "proj@1.0.0", Info: depgraph.PkgInfo{Name: "proj", Version: "1.0.0"}},
+		},
+		Graph: depgraph.Graph{RootNodeID: "root"},
+	}
+	targetFile := "package.json"
+
+	result := &ecosystems.SCAResult{
+		DepGraph: dg,
+		ProjectDescriptor: identity.ProjectDescriptor{
+			Identity: identity.ProjectIdentity{
+				TargetFile: &targetFile,
+			},
+		},
+	}
+
+	data, err := orchestratorResultToWorkflowData(result)
+
+	require.NoError(t, err)
+	require.NotNil(t, data)
+
+	payload, ok := data.GetPayload().([]byte)
+	require.True(t, ok)
+	assert.Contains(t, string(payload), "npm")
+
+	normalisedTargetFile, err := data.GetMetaData(workflow.MetaKeyNormalisedTargetFile)
+	require.NoError(t, err)
+	assert.Equal(t, "package.json", normalisedTargetFile)
+
+	targetFileFromPlugin, err := data.GetMetaData(workflow.MetaKeyTargetFileFromPlugin)
+	require.NoError(t, err)
+	assert.Equal(t, "package.json", targetFileFromPlugin)
+}
+
+func TestOrchestratorResultToWorkflowData_NilTargetFile(t *testing.T) {
+	dg := &depgraph.DepGraph{
+		SchemaVersion: "1.2.0",
+		PkgManager:    depgraph.PkgManager{Name: "maven"},
+	}
+
+	result := &ecosystems.SCAResult{
+		DepGraph: dg,
+		ProjectDescriptor: identity.ProjectDescriptor{
+			Identity: identity.ProjectIdentity{
+				TargetFile: nil,
+			},
+		},
+	}
+
+	data, err := orchestratorResultToWorkflowData(result)
+
+	require.NoError(t, err)
+	require.NotNil(t, data)
+
+	normalisedTargetFile, err := data.GetMetaData(workflow.MetaKeyNormalisedTargetFile)
+	require.NoError(t, err)
+	assert.Equal(t, "", normalisedTargetFile)
+}
+
+func TestOrchestratorResultToWorkflowData_ResultError(t *testing.T) {
+	targetFile := "pom.xml"
+	result := &ecosystems.SCAResult{
+		ProjectDescriptor: identity.ProjectDescriptor{
+			Identity: identity.ProjectIdentity{
+				TargetFile: &targetFile,
+			},
+		},
+		Error: errors.New("resolution failed"),
+	}
+
+	_, err := orchestratorResultToWorkflowData(result)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to resolve depgraph for pom.xml")
+	assert.ErrorContains(t, err, "resolution failed")
+}

--- a/pkg/depgraph/workflow.go
+++ b/pkg/depgraph/workflow.go
@@ -3,6 +3,7 @@ package depgraph
 import (
 	"fmt"
 
+	"github.com/snyk/go-application-framework/pkg/local_workflows/config_utils"
 	gafworkflow "github.com/snyk/go-application-framework/pkg/workflow"
 
 	"github.com/snyk/cli-extension-dep-graph/internal/workflow"
@@ -29,6 +30,9 @@ func Init(engine gafworkflow.Engine) error {
 	if err != nil {
 		return fmt.Errorf("failed to register workflow: %w", err)
 	}
+
+	config_utils.AddFeatureFlagToConfig(engine, workflow.FeatureFlagUvCLI, "enableUvCLI")
+	config_utils.AddFeatureFlagToConfig(engine, workflow.FeatureFlagUseUnifiedTestAPIForOSCliTest, "unified-test-api-os-cli")
 
 	return nil
 }

--- a/pkg/ecosystems/python/uv/detection.go
+++ b/pkg/ecosystems/python/uv/detection.go
@@ -1,0 +1,21 @@
+package uv
+
+import (
+	"github.com/snyk/go-application-framework/pkg/configuration"
+
+	"github.com/snyk/cli-extension-dep-graph/internal/workflow"
+)
+
+// IsUvProject reports whether the given directory should be treated as a uv
+// project. It performs a cheap filesystem check for uv lockfiles first, and
+// only if one is found does it check the enableUvCLI feature flag in the
+// configuration (which may trigger a network call on first access).
+//
+// Returns false when no uv lockfile is present or when the feature flag is
+// not enabled.
+func IsUvProject(dir, targetFile string, allProjects bool, config configuration.Configuration) bool {
+	if !HasLockFile(dir, targetFile, allProjects, nil) {
+		return false
+	}
+	return config.GetBool(workflow.FeatureFlagUvCLI)
+}

--- a/pkg/ecosystems/python/uv/detection_test.go
+++ b/pkg/ecosystems/python/uv/detection_test.go
@@ -1,0 +1,53 @@
+package uv_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/snyk/go-application-framework/pkg/configuration"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/python/uv"
+)
+
+const featureFlagUvCLI = "internal_snyk_cli_uv_enabled"
+
+func TestIsUvProject(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns true when lockfile exists and FF is enabled", func(t *testing.T) {
+		t.Parallel()
+		dir := createUvLock(t)
+		cfg := configuration.New()
+		cfg.Set(featureFlagUvCLI, true)
+
+		assert.True(t, uv.IsUvProject(dir, "", false, cfg))
+	})
+
+	t.Run("returns false when lockfile exists but FF is disabled", func(t *testing.T) {
+		t.Parallel()
+		dir := createUvLock(t)
+		cfg := configuration.New()
+		cfg.Set(featureFlagUvCLI, false)
+
+		assert.False(t, uv.IsUvProject(dir, "", false, cfg))
+	})
+
+	t.Run("returns false when no lockfile exists even with FF enabled", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		cfg := configuration.New()
+		cfg.Set(featureFlagUvCLI, true)
+
+		assert.False(t, uv.IsUvProject(dir, "", false, cfg))
+	})
+}
+
+func createUvLock(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "uv.lock"), []byte("# test"), 0o600))
+	return dir
+}

--- a/pkg/ecosystems/python/uv/lockfile.go
+++ b/pkg/ecosystems/python/uv/lockfile.go
@@ -1,0 +1,103 @@
+//nolint:goconst // Some repeat strings for logging labels. Silencing the linter in favor of repetition.
+package uv
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"github.com/rs/zerolog"
+)
+
+// ExcludedLockFileDirs is a list of directories that are excluded from the uv.lock file search.
+var ExcludedLockFileDirs = map[string]bool{
+	"node_modules": true,
+	".build":       true,
+}
+
+// HasLockFile checks if the specified directory contains a uv.lock file or the target file if provided.
+// If allProjects is true, the function will check if the directory contains a uv.lock file recursively.
+// Otherwise, it will only check if the directory contains a uv.lock file.
+func HasLockFile(dir, targetFile string, allProjects bool, logger *zerolog.Logger) bool {
+	if allProjects {
+		return HasLockFileRecursive(dir, logger)
+	}
+	return HasLockFileSingle(dir, targetFile, logger)
+}
+
+// HasLockFileSingle checks if the specified directory contains a uv.lock file.
+// If targetFile is provided and is a uv.lock file (by name), it will be checked;
+// otherwise, the function looks for uv.lock in the directory.
+func HasLockFileSingle(dir, targetFile string, logger *zerolog.Logger) bool {
+	var uvLockPath string
+	if targetFile != "" && filepath.Base(targetFile) == LockFileName {
+		if filepath.IsAbs(targetFile) {
+			uvLockPath = targetFile
+		} else {
+			uvLockPath = filepath.Join(dir, targetFile)
+		}
+	} else {
+		uvLockPath = filepath.Join(dir, LockFileName)
+	}
+
+	_, err := os.Stat(uvLockPath)
+	if err == nil {
+		return true
+	}
+
+	if !errors.Is(err, os.ErrNotExist) && logger != nil {
+		logger.Debug().
+			Err(err).
+			Str("path", uvLockPath).
+			Msg("Error checking for uv.lock file")
+	}
+
+	return false
+}
+
+// HasLockFileRecursive checks if any directory within dir (including dir itself)
+// contains a uv.lock file, skipping directories in ExcludedLockFileDirs.
+func HasLockFileRecursive(dir string, logger *zerolog.Logger) bool {
+	found := false
+	fpErr := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			if logger != nil {
+				logger.Debug().
+					Err(err).
+					Str("path", path).
+					Msg("Error accessing path during uv.lock search")
+			}
+			return nil
+		}
+
+		if d.IsDir() {
+			dirName := d.Name()
+			if ExcludedLockFileDirs[dirName] {
+				if logger != nil {
+					logger.Debug().
+						Str("path", path).
+						Msg("Skipping excluded directory during uv.lock search")
+				}
+				return fs.SkipDir
+			}
+			return nil
+		}
+
+		if d.Name() == LockFileName {
+			found = true
+			return fs.SkipAll
+		}
+
+		return nil
+	})
+
+	if fpErr != nil && logger != nil {
+		logger.Debug().
+			Err(fpErr).
+			Str("path", dir).
+			Msg("Error checking for uv.lock file")
+	}
+
+	return found
+}

--- a/pkg/ecosystems/python/uv/lockfile_test.go
+++ b/pkg/ecosystems/python/uv/lockfile_test.go
@@ -1,0 +1,193 @@
+package uv_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/python/uv"
+)
+
+func TestHasLockFile(t *testing.T) {
+	t.Parallel()
+	nopLogger := zerolog.Nop()
+
+	t.Run("does not find uv.lock file when all-projects is false and uv.lock exists in subfolder", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		createLockFile(t, tmpDir, "project1")
+
+		result := uv.HasLockFile(tmpDir, "", false, &nopLogger)
+		assert.False(t, result)
+	})
+
+	t.Run("finds uv.lock file when all-projects is true and uv.lock exists in subfolder", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		createLockFile(t, tmpDir, "project1")
+
+		result := uv.HasLockFile(tmpDir, "", true, &nopLogger)
+		assert.True(t, result)
+	})
+}
+
+func TestHasLockFileSingle(t *testing.T) {
+	t.Parallel()
+	nopLogger := zerolog.Nop()
+
+	t.Run("returns true when uv.lock exists", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		createLockFile(t, tmpDir)
+
+		result := uv.HasLockFileSingle(tmpDir, "", &nopLogger)
+		assert.True(t, result)
+	})
+
+	t.Run("returns true when uv.lock exists with target file", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		createLockFile(t, tmpDir)
+
+		result := uv.HasLockFileSingle(tmpDir, "uv.lock", &nopLogger)
+		assert.True(t, result)
+	})
+
+	t.Run("returns true when uv.lock exists with target file in subdirectory", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		createLockFile(t, tmpDir, "subdir")
+
+		result := uv.HasLockFileSingle(tmpDir, "subdir/uv.lock", &nopLogger)
+		assert.True(t, result)
+	})
+
+	t.Run("returns true when uv.lock exists with absolute target path", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		createLockFile(t, tmpDir, "subdir")
+		absolutePath := filepath.Join(tmpDir, "subdir", uv.LockFileName)
+
+		result := uv.HasLockFileSingle(tmpDir, absolutePath, &nopLogger)
+		assert.True(t, result)
+	})
+
+	t.Run("returns false when uv.lock does not exist", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+
+		result := uv.HasLockFileSingle(dir, "", &nopLogger)
+		assert.False(t, result)
+	})
+
+	t.Run("returns false when directory does not exist", func(t *testing.T) {
+		t.Parallel()
+		dir := filepath.Join(t.TempDir(), "nonexistent")
+
+		result := uv.HasLockFileSingle(dir, "", &nopLogger)
+		assert.False(t, result)
+	})
+
+	t.Run("returns false when target file is not uv.lock even if it exists", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		otherFile := filepath.Join(tmpDir, "pom.xml")
+		err := os.WriteFile(otherFile, []byte("<project></project>"), 0o600)
+		require.NoError(t, err)
+
+		result := uv.HasLockFileSingle(tmpDir, "pom.xml", &nopLogger)
+		assert.False(t, result)
+	})
+
+	t.Run("works with nil logger", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		createLockFile(t, dir)
+
+		result := uv.HasLockFileSingle(dir, "", nil)
+		assert.True(t, result)
+	})
+}
+
+func TestHasLockFileRecursive(t *testing.T) {
+	t.Parallel()
+	nopLogger := zerolog.Nop()
+
+	t.Run("returns true when uv.lock exists", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		createLockFile(t, tmpDir)
+
+		result := uv.HasLockFileRecursive(tmpDir, &nopLogger)
+		assert.True(t, result)
+	})
+
+	t.Run("returns true when uv.lock exists in subdirectory", func(t *testing.T) {
+		t.Parallel()
+		tmpDir := t.TempDir()
+		createLockFile(t, tmpDir, "subdir")
+
+		result := uv.HasLockFileRecursive(tmpDir, &nopLogger)
+		assert.True(t, result)
+	})
+
+	t.Run("returns false when uv.lock exists in excluded subdirectory", func(t *testing.T) {
+		t.Parallel()
+		tmpDir := t.TempDir()
+		createLockFile(t, tmpDir, "node_modules")
+		createLockFile(t, tmpDir, "subdir", "node_modules")
+		createLockFile(t, tmpDir, ".build")
+
+		result := uv.HasLockFileRecursive(tmpDir, &nopLogger)
+		assert.False(t, result)
+	})
+
+	t.Run("returns false when uv.lock does not exist", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+
+		result := uv.HasLockFileRecursive(dir, &nopLogger)
+		assert.False(t, result)
+	})
+
+	t.Run("returns false when directory does not exist", func(t *testing.T) {
+		t.Parallel()
+		dir := filepath.Join(t.TempDir(), "nonexistent")
+
+		result := uv.HasLockFileRecursive(dir, &nopLogger)
+		assert.False(t, result)
+	})
+
+	t.Run("works with nil logger", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		createLockFile(t, dir)
+
+		result := uv.HasLockFileRecursive(dir, nil)
+		assert.True(t, result)
+	})
+}
+
+func createLockFile(t *testing.T, rootDir string, subFolders ...string) {
+	t.Helper()
+
+	lockDir := filepath.Join(append([]string{rootDir}, subFolders...)...)
+	err := os.MkdirAll(lockDir, 0o755)
+	require.NoError(t, err)
+
+	lockPath := filepath.Join(lockDir, uv.LockFileName)
+	err = os.WriteFile(lockPath, []byte("# test"), 0o600)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
### What this does

Exposes the uv lofile detection and FF check, so we can consume this in cli-extension-os-flows and don't have to leave the low-level, uv-specific code there. Addendum to #165.
