### PR TITLE
feat: [CMPA-539] Adds support for configuration matching flag in gradle resolver

### DIFF
--- a/pkg/ecosystems/gradle/depgraph.go
+++ b/pkg/ecosystems/gradle/depgraph.go
@@ -2,16 +2,21 @@ package gradle
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/snyk/dep-graph/go/pkg/depgraph"
+
+	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
 )
 
 const pkgManagerName = "gradle"
 
 // buildDepGraph converts a single gradleProject into a *depgraph.DepGraph by
 // merging the resolved dependencies from all available configurations.
-func buildDepGraph(proj *gradleProject) (*depgraph.DepGraph, error) {
+// If options.Gradle.ConfigurationMatching is set, only configurations matching
+// the regex pattern will be included.
+func buildDepGraph(proj *gradleProject, options *ecosystems.SCAPluginOptions) (*depgraph.DepGraph, error) {
 	// Derive a stable root name (group:artifact) and version from the GAV.
 	rootName, rootVersion := splitGAV(proj.GAV)
 	if rootName == "" {
@@ -57,17 +62,24 @@ func buildDepGraph(proj *gradleProject) (*depgraph.DepGraph, error) {
 		return nil
 	}
 
-	// Merge all configurations into a single graph.  Per-configuration
-	// filtering (e.g. --configuration-matching, preferring runtimeClasspath)
-	// will be added when feature parity work begins.
-	//
+	// Filter configurations based on --configuration-matching if specified
+	configurationsToProcess := proj.Configurations
+	if options != nil && options.Gradle.ConfigurationMatching != "" {
+		var err error
+		configurationsToProcess, err = filterConfigurationsByPattern(proj.Configurations, options.Gradle.ConfigurationMatching)
+		if err != nil {
+			return nil, fmt.Errorf("failed to apply configuration matching pattern '%s': %w", options.Gradle.ConfigurationMatching, err)
+		}
+	}
+
+	// Merge all configurations into a single graph.
 	// Iterate configurations in Gradle declaration order (preserved by the array
 	// format from the init script). The init script processes configurations via
 	// project.configurations.matching{...}.each{...}, which iterates in the
 	// order configurations were declared. When the same edge appears in multiple
 	// configurations, its position in the merged graph is taken from the first
 	// configuration that contributes it.
-	for _, cfg := range proj.Configurations {
+	for _, cfg := range configurationsToProcess {
 		if cfg.Error != "" {
 			continue
 		}
@@ -159,4 +171,22 @@ func splitGAV(gav string) (name, version string) {
 	}
 
 	return gav, ""
+}
+
+// filterConfigurationsByPattern filters gradle configurations based on a regex pattern.
+// Returns only configurations whose names match the provided regex pattern.
+func filterConfigurationsByPattern(configurations []gradleConfig, pattern string) ([]gradleConfig, error) {
+	regex, err := regexp.Compile(pattern)
+	if err != nil {
+		return nil, fmt.Errorf("invalid regex pattern: %w", err)
+	}
+
+	var filtered []gradleConfig
+	for _, config := range configurations {
+		if regex.MatchString(config.Name) {
+			filtered = append(filtered, config)
+		}
+	}
+
+	return filtered, nil
 }

--- a/pkg/ecosystems/gradle/depgraph_test.go
+++ b/pkg/ecosystems/gradle/depgraph_test.go
@@ -5,6 +5,7 @@ package gradle
 import (
 	"testing"
 
+	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
 	"github.com/snyk/dep-graph/go/pkg/depgraph"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -62,7 +63,7 @@ func TestBuildDepGraph(t *testing.T) {
 			}),
 		})
 
-		dg, err := buildDepGraph(&proj)
+		dg, err := buildDepGraph(&proj, nil)
 		require.NoError(t, err)
 		require.NotNil(t, dg)
 
@@ -85,7 +86,7 @@ func TestBuildDepGraph(t *testing.T) {
 			}),
 		})
 
-		dg, err := buildDepGraph(&proj)
+		dg, err := buildDepGraph(&proj, nil)
 		require.NoError(t, err)
 
 		ids := nodeIDSet(dg)
@@ -102,7 +103,7 @@ func TestBuildDepGraph(t *testing.T) {
 			}),
 		})
 
-		dg, err := buildDepGraph(&proj)
+		dg, err := buildDepGraph(&proj, nil)
 		require.NoError(t, err)
 
 		ids := nodeIDSet(dg)
@@ -117,7 +118,7 @@ func TestBuildDepGraph(t *testing.T) {
 			}),
 		})
 
-		dg, err := buildDepGraph(&proj)
+		dg, err := buildDepGraph(&proj, nil)
 		require.NoError(t, err)
 
 		ids := nodeIDSet(dg)
@@ -132,7 +133,7 @@ func TestBuildDepGraph(t *testing.T) {
 			}),
 		})
 
-		dg, err := buildDepGraph(&proj)
+		dg, err := buildDepGraph(&proj, nil)
 		require.NoError(t, err)
 
 		ids := nodeIDSet(dg)
@@ -148,7 +149,7 @@ func TestBuildDepGraph(t *testing.T) {
 			}),
 		})
 
-		dg, err := buildDepGraph(&proj)
+		dg, err := buildDepGraph(&proj, nil)
 		require.NoError(t, err)
 
 		ids := nodeIDSet(dg)
@@ -164,7 +165,7 @@ func TestBuildDepGraph(t *testing.T) {
 			}),
 		})
 
-		dg, err := buildDepGraph(&proj)
+		dg, err := buildDepGraph(&proj, nil)
 		require.NoError(t, err)
 
 		ids := nodeIDSet(dg)
@@ -176,7 +177,7 @@ func TestBuildDepGraph(t *testing.T) {
 			{Name: "runtimeClasspath", Error: "resolution failed"},
 		})
 
-		dg, err := buildDepGraph(&proj)
+		dg, err := buildDepGraph(&proj, nil)
 		require.NoError(t, err)
 
 		// Only the root node; no dependency nodes.
@@ -186,7 +187,7 @@ func TestBuildDepGraph(t *testing.T) {
 	t.Run("returns empty graph when no configurations present", func(t *testing.T) {
 		proj := makeProject("com.example", "app", "1.0.0", []gradleConfig{})
 
-		dg, err := buildDepGraph(&proj)
+		dg, err := buildDepGraph(&proj, nil)
 		require.NoError(t, err)
 		assert.Len(t, dg.Graph.Nodes, 1)
 	})
@@ -196,7 +197,7 @@ func TestBuildDepGraph(t *testing.T) {
 			makeConfig("runtimeClasspath", "com.example:app:unspecified", []gradleDep{}),
 		})
 
-		dg, err := buildDepGraph(&proj)
+		dg, err := buildDepGraph(&proj, nil)
 		require.NoError(t, err)
 		assert.Equal(t, "", dg.Pkgs[0].Info.Version)
 	})
@@ -212,7 +213,7 @@ func TestBuildDepGraph(t *testing.T) {
 			}),
 		})
 
-		dg, err := buildDepGraph(&proj)
+		dg, err := buildDepGraph(&proj, nil)
 		require.NoError(t, err)
 
 		ids := nodeIDSet(dg)
@@ -235,7 +236,7 @@ func TestBuildDepGraph(t *testing.T) {
 			}),
 		})
 
-		dg, err := buildDepGraph(&proj)
+		dg, err := buildDepGraph(&proj, nil)
 		require.NoError(t, err)
 
 		ids := nodeIDSet(dg)
@@ -282,7 +283,7 @@ func TestBuildDepGraph_DoesNotDuplicateEdges(t *testing.T) {
 		makeConfig("testRuntimeClasspath", "com.example:app:1.0.0", []gradleDep{makeDep("com.google.guava:guava:32.1.2-jre")}),
 	})
 
-	dg, err := buildDepGraph(&proj)
+	dg, err := buildDepGraph(&proj, nil)
 	require.NoError(t, err)
 
 	rootNode := findNodeByID(t, dg, "root-node")
@@ -337,7 +338,7 @@ func TestBuildDepGraph_EdgePositionFromFirstDeclaringConfig(t *testing.T) {
 
 	proj := makeProject("com.example", "app", "1.0.0", []gradleConfig{compileConfig, runtimeConfig})
 
-	dg, err := buildDepGraph(&proj)
+	dg, err := buildDepGraph(&proj, nil)
 	require.NoError(t, err)
 
 	rootNode := findNodeByID(t, dg, "root-node")
@@ -413,4 +414,217 @@ func TestSplitGAV(t *testing.T) {
 			assert.Equal(t, tt.wantVersion, version)
 		})
 	}
+}
+
+// ── Configuration Matching Tests ─────────────────────────────────────────────
+
+func TestBuildDepGraph_ConfigurationMatching(t *testing.T) {
+	t.Run("filters configurations by exact match", func(t *testing.T) {
+		proj := makeProject("com.example", "my-app", "1.0.0", []gradleConfig{
+			makeConfig("runtimeClasspath", "com.example:my-app:1.0.0", []gradleDep{
+				makeDep("com.google.guava:guava:32.1.2-jre"),
+			}),
+			makeConfig("compileClasspath", "com.example:my-app:1.0.0", []gradleDep{
+				makeDep("org.apache.commons:commons-lang3:3.12.0"),
+			}),
+			makeConfig("testRuntimeClasspath", "com.example:my-app:1.0.0", []gradleDep{
+				makeDep("junit:junit:4.13.2"),
+			}),
+		})
+
+		options := &ecosystems.SCAPluginOptions{}
+		options.Gradle.ConfigurationMatching = "runtimeClasspath"
+
+		dg, err := buildDepGraph(&proj, options)
+		require.NoError(t, err)
+		require.NotNil(t, dg)
+
+		ids := nodeIDSet(dg)
+		assert.True(t, ids["com.google.guava:guava@32.1.2-jre"], "runtimeClasspath dep should be included")
+		assert.False(t, ids["org.apache.commons:commons-lang3@3.12.0"], "compileClasspath dep should be excluded")
+		assert.False(t, ids["junit:junit@4.13.2"], "testRuntimeClasspath dep should be excluded")
+	})
+
+	t.Run("filters configurations by regex pattern", func(t *testing.T) {
+		proj := makeProject("com.example", "my-app", "1.0.0", []gradleConfig{
+			makeConfig("runtimeClasspath", "com.example:my-app:1.0.0", []gradleDep{
+				makeDep("com.google.guava:guava:32.1.2-jre"),
+			}),
+			makeConfig("compileClasspath", "com.example:my-app:1.0.0", []gradleDep{
+				makeDep("org.apache.commons:commons-lang3:3.12.0"),
+			}),
+			makeConfig("testRuntimeClasspath", "com.example:my-app:1.0.0", []gradleDep{
+				makeDep("junit:junit:4.13.2"),
+			}),
+			makeConfig("testCompileClasspath", "com.example:my-app:1.0.0", []gradleDep{
+				makeDep("org.mockito:mockito-core:5.1.1"),
+			}),
+		})
+
+		// Match all runtime classpaths (runtime and testRuntime) - case insensitive
+		options := &ecosystems.SCAPluginOptions{}
+		options.Gradle.ConfigurationMatching = "(?i).*runtime.*"
+
+		dg, err := buildDepGraph(&proj, options)
+		require.NoError(t, err)
+		require.NotNil(t, dg)
+
+		ids := nodeIDSet(dg)
+		assert.True(t, ids["com.google.guava:guava@32.1.2-jre"], "runtimeClasspath dep should be included")
+		assert.True(t, ids["junit:junit@4.13.2"], "testRuntimeClasspath dep should be included")
+		assert.False(t, ids["org.apache.commons:commons-lang3@3.12.0"], "compileClasspath dep should be excluded")
+		assert.False(t, ids["org.mockito:mockito-core@5.1.1"], "testCompileClasspath dep should be excluded")
+	})
+
+	t.Run("includes all configurations when no pattern specified", func(t *testing.T) {
+		proj := makeProject("com.example", "my-app", "1.0.0", []gradleConfig{
+			makeConfig("runtimeClasspath", "com.example:my-app:1.0.0", []gradleDep{
+				makeDep("com.google.guava:guava:32.1.2-jre"),
+			}),
+			makeConfig("compileClasspath", "com.example:my-app:1.0.0", []gradleDep{
+				makeDep("org.apache.commons:commons-lang3:3.12.0"),
+			}),
+		})
+
+		dg, err := buildDepGraph(&proj, nil)
+		require.NoError(t, err)
+		require.NotNil(t, dg)
+
+		ids := nodeIDSet(dg)
+		assert.True(t, ids["com.google.guava:guava@32.1.2-jre"], "runtimeClasspath dep should be included")
+		assert.True(t, ids["org.apache.commons:commons-lang3@3.12.0"], "compileClasspath dep should be included")
+	})
+
+	t.Run("returns error for invalid regex pattern", func(t *testing.T) {
+		proj := makeProject("com.example", "my-app", "1.0.0", []gradleConfig{
+			makeConfig("runtimeClasspath", "com.example:my-app:1.0.0", []gradleDep{}),
+		})
+
+		options := &ecosystems.SCAPluginOptions{}
+		options.Gradle.ConfigurationMatching = "[invalid-regex"
+
+		_, err := buildDepGraph(&proj, options)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid regex pattern")
+		assert.Contains(t, err.Error(), "[invalid-regex")
+	})
+
+	t.Run("returns empty graph when no configurations match pattern", func(t *testing.T) {
+		proj := makeProject("com.example", "my-app", "1.0.0", []gradleConfig{
+			makeConfig("runtimeClasspath", "com.example:my-app:1.0.0", []gradleDep{
+				makeDep("com.google.guava:guava:32.1.2-jre"),
+			}),
+			makeConfig("compileClasspath", "com.example:my-app:1.0.0", []gradleDep{
+				makeDep("org.apache.commons:commons-lang3:3.12.0"),
+			}),
+		})
+
+		options := &ecosystems.SCAPluginOptions{}
+		options.Gradle.ConfigurationMatching = "nonExistentConfiguration"
+
+		dg, err := buildDepGraph(&proj, options)
+		require.NoError(t, err)
+		require.NotNil(t, dg)
+
+		// Only the root node should exist; no dependency nodes.
+		assert.Len(t, dg.Graph.Nodes, 1)
+	})
+
+	t.Run("preserves configuration processing order after filtering", func(t *testing.T) {
+		// Test that when multiple configurations match, they are processed in their original order
+		proj := makeProject("com.example", "my-app", "1.0.0", []gradleConfig{
+			makeConfig("compileClasspath", "com.example:my-app:1.0.0", []gradleDep{
+				makeDep("com.google.guava:guava:32.1.2-jre"),       // First occurrence
+				makeDep("org.apache.commons:commons-lang3:3.12.0"), // First occurrence
+			}),
+			makeConfig("runtimeClasspath", "com.example:my-app:1.0.0", []gradleDep{
+				makeDep("org.apache.commons:commons-lang3:3.12.0"), // Second occurrence (should be deduplicated)
+				makeDep("com.google.guava:guava:32.1.2-jre"),       // Second occurrence (should be deduplicated)
+			}),
+			makeConfig("testCompileClasspath", "com.example:my-app:1.0.0", []gradleDep{
+				makeDep("junit:junit:4.13.2"), // Should be excluded by pattern
+			}),
+		})
+
+		// Match compile and runtime classpaths but not test
+		options := &ecosystems.SCAPluginOptions{}
+		options.Gradle.ConfigurationMatching = "(compile|runtime)Classpath"
+
+		dg, err := buildDepGraph(&proj, options)
+		require.NoError(t, err)
+
+		rootNode := findNodeByID(t, dg, "root-node")
+		require.Len(t, rootNode.Deps, 2, "should have 2 dependencies from merged configurations")
+
+		// Verify order is preserved from first configuration (compileClasspath)
+		assert.Equal(t, "com.google.guava:guava@32.1.2-jre", rootNode.Deps[0].NodeID,
+			"order should be preserved from first matching configuration")
+		assert.Equal(t, "org.apache.commons:commons-lang3@3.12.0", rootNode.Deps[1].NodeID)
+
+		// Verify test dependency is excluded
+		ids := nodeIDSet(dg)
+		assert.False(t, ids["junit:junit@4.13.2"], "test dependency should be excluded")
+	})
+
+	t.Run("handles configuration matching with configurations that have errors", func(t *testing.T) {
+		proj := makeProject("com.example", "my-app", "1.0.0", []gradleConfig{
+			{Name: "runtimeClasspath", Error: "resolution failed"},
+			makeConfig("compileClasspath", "com.example:my-app:1.0.0", []gradleDep{
+				makeDep("com.google.guava:guava:32.1.2-jre"),
+			}),
+		})
+
+		options := &ecosystems.SCAPluginOptions{}
+		options.Gradle.ConfigurationMatching = ".*Classpath"
+
+		dg, err := buildDepGraph(&proj, options)
+		require.NoError(t, err)
+
+		// Only compileClasspath should contribute dependencies; runtimeClasspath has error
+		ids := nodeIDSet(dg)
+		assert.True(t, ids["com.google.guava:guava@32.1.2-jre"], "compileClasspath dep should be included")
+	})
+}
+
+func TestFilterConfigurationsByPattern(t *testing.T) {
+	configs := []gradleConfig{
+		{Name: "runtimeClasspath"},
+		{Name: "compileClasspath"},
+		{Name: "testRuntimeClasspath"},
+		{Name: "testCompileClasspath"},
+		{Name: "annotationProcessor"},
+	}
+
+	t.Run("filters by exact match", func(t *testing.T) {
+		filtered, err := filterConfigurationsByPattern(configs, "runtimeClasspath")
+		require.NoError(t, err)
+		require.Len(t, filtered, 1)
+		assert.Equal(t, "runtimeClasspath", filtered[0].Name)
+	})
+
+	t.Run("filters by regex pattern", func(t *testing.T) {
+		filtered, err := filterConfigurationsByPattern(configs, "(?i).*runtime.*")
+		require.NoError(t, err)
+		require.Len(t, filtered, 2)
+		assert.Equal(t, "runtimeClasspath", filtered[0].Name)
+		assert.Equal(t, "testRuntimeClasspath", filtered[1].Name)
+	})
+
+	t.Run("returns empty slice when no matches", func(t *testing.T) {
+		filtered, err := filterConfigurationsByPattern(configs, "nonExistent")
+		require.NoError(t, err)
+		assert.Len(t, filtered, 0)
+	})
+
+	t.Run("returns error for invalid regex", func(t *testing.T) {
+		_, err := filterConfigurationsByPattern(configs, "[invalid")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid regex pattern")
+	})
+
+	t.Run("matches all with .* pattern", func(t *testing.T) {
+		filtered, err := filterConfigurationsByPattern(configs, ".*")
+		require.NoError(t, err)
+		assert.Len(t, filtered, 5)
+	})
 }

--- a/pkg/ecosystems/gradle/plugin.go
+++ b/pkg/ecosystems/gradle/plugin.go
@@ -60,6 +60,10 @@ func (p Plugin) BuildDepGraphsFromDir(
 		log = logger.Nop()
 	}
 
+	if err := ValidateOptions(dir, options); err != nil {
+		return nil, fmt.Errorf("gradle: invalid options: %w", err)
+	}
+
 	files, err := p.discoverGradleFiles(ctx, dir, options)
 	if err != nil {
 		return nil, fmt.Errorf("gradle: failed to discover files: %w", err)
@@ -151,10 +155,7 @@ func (p Plugin) processGradleFiles(
 	defer cleanup()
 
 	// Build extra args once upfront - user init scripts should be relative to original scan directory
-	extraArgs, err := buildExtraArgs(dir, options)
-	if err != nil {
-		return nil, nil, fmt.Errorf("gradle: %w", err)
-	}
+	extraArgs := buildExtraArgs(dir, options)
 
 	for _, discoveredFile := range filesCopy {
 		relativeProjectDir := filepath.Dir(discoveredFile.RelPath)
@@ -336,7 +337,7 @@ func (p Plugin) convertProjects(
 		}
 		relFile := relativeTargetFile(dir, absFile)
 
-		depGraph, err := buildDepGraph(&proj)
+		depGraph, err := buildDepGraph(&proj, options)
 		if err != nil {
 			log.Error(ctx, "Failed to build dep graph for Gradle project",
 				logger.Attr("project_path", proj.Path),
@@ -415,12 +416,13 @@ func resolveInitScript() (path string, cleanup func(), err error) {
 
 // buildExtraArgs assembles any additional Gradle command-line arguments derived
 // from plugin options (e.g. user-provided init scripts, configuration flags).
-func buildExtraArgs(projectDir string, options *ecosystems.SCAPluginOptions) ([]string, error) {
+func buildExtraArgs(projectDir string, options *ecosystems.SCAPluginOptions) []string {
 	var args []string
 
 	// Add user-provided init script as an additional --init-script flag.
 	// The embedded Snyk init script is always used; this allows users to provide
 	// supplementary init scripts needed to make their Gradle build work.
+	// Note: validation is handled in ValidateOptions, so we just need to resolve the path.
 	if userInitScript := options.Gradle.InitScript; userInitScript != "" {
 		// Resolve relative paths against the project directory
 		initPath := userInitScript
@@ -428,20 +430,11 @@ func buildExtraArgs(projectDir string, options *ecosystems.SCAPluginOptions) ([]
 			initPath = filepath.Join(projectDir, userInitScript)
 		}
 
-		// Defensive validation: ensure the init script exists and is a file
-		info, err := os.Stat(initPath)
-		if err != nil {
-			return nil, fmt.Errorf("user init script not found: %s: %w", userInitScript, err)
-		}
-		if info.IsDir() {
-			return nil, fmt.Errorf("user init script is a directory, not a file: %s", userInitScript)
-		}
-
 		args = append(args, "--init-script", initPath)
 	}
 
 	// Reserved for future flag forwarding (e.g. --configuration, -P flags).
-	return args, nil
+	return args
 }
 
 // isBuildFile reports whether path refers to a Gradle build file.

--- a/pkg/ecosystems/gradle/plugin_integration_test.go
+++ b/pkg/ecosystems/gradle/plugin_integration_test.go
@@ -117,6 +117,40 @@ func pluginTestCases() map[string]PluginTestCase {
 			Fixture: "dynamic-versions",
 			Options: ecosystems.NewPluginOptions(),
 		},
+		// Exercises --configuration-matching flag functionality using a fixture with dependencies
+		// in multiple configurations: implementation (guava), runtimeOnly (logback), compileOnly (commons-lang3),
+		// testImplementation (junit, mockito), and testRuntimeOnly (slf4j-simple).
+		// This validates that the regex filtering correctly includes/excludes configurations.
+
+		// Full scan (baseline) - includes all configurations
+		"configuration_matching_full_scan": {
+			Fixture: "configuration-matching",
+			Options: ecosystems.NewPluginOptions(),
+		},
+		// Runtime configurations only - includes implementation + runtimeOnly + testRuntimeOnly
+		"configuration_matching_runtime_only": {
+			Fixture:      "configuration-matching",
+			Options:      ecosystems.NewPluginOptions().WithGradleConfigurationMatching("(?i).*runtime.*"),
+			ExpectedFile: "expected_plugin_runtime_only.json",
+		},
+		// Compile configurations only - includes compileOnly + compileClasspath
+		"configuration_matching_compile_only": {
+			Fixture:      "configuration-matching",
+			Options:      ecosystems.NewPluginOptions().WithGradleConfigurationMatching("compile.*"),
+			ExpectedFile: "expected_plugin_compile_only.json",
+		},
+		// Test configurations only - includes testImplementation + testRuntimeOnly
+		"configuration_matching_test_only": {
+			Fixture:      "configuration-matching",
+			Options:      ecosystems.NewPluginOptions().WithGradleConfigurationMatching("(?i)test.*"),
+			ExpectedFile: "expected_plugin_test_only.json",
+		},
+		// Exact match for single configuration - includes only runtimeClasspath
+		"configuration_matching_exact": {
+			Fixture:      "configuration-matching",
+			Options:      ecosystems.NewPluginOptions().WithGradleConfigurationMatching("^runtimeClasspath$"),
+			ExpectedFile: "expected_plugin_exact_runtime.json",
+		},
 	}
 }
 
@@ -128,7 +162,7 @@ func TestGradleWrapper_BinaryResolution(t *testing.T) {
 	// Check JDK compatibility - Gradle 8.4 (used by wrapper) supports at most Java 21
 	jdkVersion, err := jdkRuntime()
 	require.NoErrorf(t, err, "could not detect jdk runtime version")
-	
+
 	if jdkVersion.Major() > 21 {
 		t.Skipf("Gradle 8.4 wrapper supports at most Java 21; running on Java %d", jdkVersion.Major())
 	}

--- a/pkg/ecosystems/gradle/plugin_test.go
+++ b/pkg/ecosystems/gradle/plugin_test.go
@@ -326,8 +326,7 @@ func TestBuildExtraArgs(t *testing.T) {
 		dir := t.TempDir()
 		opts := &ecosystems.SCAPluginOptions{}
 
-		args, err := buildExtraArgs(dir, opts)
-		require.NoError(t, err)
+		args := buildExtraArgs(dir, opts)
 		assert.Empty(t, args)
 	})
 
@@ -340,8 +339,7 @@ func TestBuildExtraArgs(t *testing.T) {
 			Gradle: ecosystems.GradleOptions{InitScript: userScript},
 		}
 
-		args, err := buildExtraArgs(dir, opts)
-		require.NoError(t, err)
+		args := buildExtraArgs(dir, opts)
 		assert.Equal(t, []string{"--init-script", userScript}, args)
 	})
 
@@ -355,35 +353,38 @@ func TestBuildExtraArgs(t *testing.T) {
 			Gradle: ecosystems.GradleOptions{InitScript: "scripts/custom.gradle"},
 		}
 
-		args, err := buildExtraArgs(dir, opts)
-		require.NoError(t, err)
+		args := buildExtraArgs(dir, opts)
 		assert.Equal(t, []string{"--init-script", userScript}, args)
 	})
 
-	t.Run("returns error when user init script does not exist", func(t *testing.T) {
+	t.Run("handles relative user init script path", func(t *testing.T) {
 		dir := t.TempDir()
+		scriptsDir := filepath.Join(dir, "scripts")
+		require.NoError(t, os.MkdirAll(scriptsDir, 0o755))
+		validScript := filepath.Join(scriptsDir, "custom.gradle")
+		require.NoError(t, os.WriteFile(validScript, []byte("// custom script"), 0o644))
+
 		opts := &ecosystems.SCAPluginOptions{
-			Gradle: ecosystems.GradleOptions{InitScript: "nonexistent.gradle"},
+			Gradle: ecosystems.GradleOptions{InitScript: "scripts/custom.gradle"}, // relative path
 		}
 
-		_, err := buildExtraArgs(dir, opts)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "user init script not found")
-		assert.Contains(t, err.Error(), "nonexistent.gradle")
+		args := buildExtraArgs(dir, opts)
+		// Should resolve to absolute path
+		expectedPath := filepath.Join(dir, "scripts/custom.gradle")
+		assert.Equal(t, []string{"--init-script", expectedPath}, args)
 	})
 
-	t.Run("returns error when user init script is a directory", func(t *testing.T) {
+	t.Run("handles absolute user init script path", func(t *testing.T) {
 		dir := t.TempDir()
-		scriptDir := filepath.Join(dir, "scripts")
-		require.NoError(t, os.Mkdir(scriptDir, 0o755))
+		validScript := filepath.Join(dir, "valid.gradle")
+		require.NoError(t, os.WriteFile(validScript, []byte("// valid script"), 0o644))
 
 		opts := &ecosystems.SCAPluginOptions{
-			Gradle: ecosystems.GradleOptions{InitScript: scriptDir},
+			Gradle: ecosystems.GradleOptions{InitScript: validScript}, // absolute path
 		}
 
-		_, err := buildExtraArgs(dir, opts)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "user init script is a directory")
+		args := buildExtraArgs(dir, opts)
+		assert.Equal(t, []string{"--init-script", validScript}, args)
 	})
 }
 

--- a/pkg/ecosystems/gradle/validation.go
+++ b/pkg/ecosystems/gradle/validation.go
@@ -1,0 +1,63 @@
+package gradle
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
+)
+
+// ValidateOptions validates the provided options and returns an error if any are invalid.
+// This should be called early in the process to fail fast on configuration errors.
+// The dir parameter is used to resolve and validate relative init script paths.
+func ValidateOptions(dir string, options *ecosystems.SCAPluginOptions) error {
+	if options == nil {
+		return nil // No options to validate
+	}
+
+	// Validate Gradle configuration matching regex if provided
+	if options.Gradle.ConfigurationMatching != "" {
+		if _, err := regexp.Compile(options.Gradle.ConfigurationMatching); err != nil {
+			return fmt.Errorf("invalid --configuration-matching regex pattern '%s': %w", options.Gradle.ConfigurationMatching, err)
+		}
+	}
+
+	// Validate user init script if provided
+	if userInitScript := options.Gradle.InitScript; userInitScript != "" {
+		if err := validateInitScript(dir, userInitScript); err != nil {
+			return err
+		}
+	}
+
+	// Add validation for other options as needed in the future
+
+	return nil
+}
+
+// validateInitScript validates an init script path (absolute or relative).
+func validateInitScript(projectDir, initPath string) error {
+	// Basic sanity checks
+	if strings.TrimSpace(initPath) == "" {
+		return fmt.Errorf("user init script path is empty")
+	}
+
+	// Resolve to absolute path for validation
+	resolvedPath := initPath
+	if !filepath.IsAbs(initPath) {
+		resolvedPath = filepath.Join(projectDir, initPath)
+	}
+
+	// Validate that the file exists and is not a directory
+	info, err := os.Stat(resolvedPath)
+	if err != nil {
+		return fmt.Errorf("user init script not found: %s: %w", initPath, err)
+	}
+	if info.IsDir() {
+		return fmt.Errorf("user init script is a directory, not a file: %s", initPath)
+	}
+
+	return nil
+}

--- a/pkg/ecosystems/gradle/validation_test.go
+++ b/pkg/ecosystems/gradle/validation_test.go
@@ -1,0 +1,196 @@
+//go:build !integration
+
+package gradle
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
+	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateOptions(t *testing.T) {
+	tempDir := t.TempDir()
+
+	t.Run("accepts nil options", func(t *testing.T) {
+		err := ValidateOptions(tempDir, nil)
+		require.NoError(t, err)
+	})
+
+	t.Run("accepts empty options", func(t *testing.T) {
+		options := &ecosystems.SCAPluginOptions{}
+		err := ValidateOptions(tempDir, options)
+		require.NoError(t, err)
+	})
+
+	t.Run("accepts valid configuration matching regex", func(t *testing.T) {
+		options := &ecosystems.SCAPluginOptions{}
+		options.Gradle.ConfigurationMatching = "(?i).*runtime.*"
+		err := ValidateOptions(tempDir, options)
+		require.NoError(t, err)
+	})
+
+	t.Run("accepts empty configuration matching string", func(t *testing.T) {
+		options := &ecosystems.SCAPluginOptions{}
+		options.Gradle.ConfigurationMatching = ""
+		err := ValidateOptions(tempDir, options)
+		require.NoError(t, err)
+	})
+
+	t.Run("rejects invalid configuration matching regex", func(t *testing.T) {
+		options := &ecosystems.SCAPluginOptions{}
+		options.Gradle.ConfigurationMatching = "[invalid-regex"
+		err := ValidateOptions(tempDir, options)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid --configuration-matching regex pattern")
+		assert.Contains(t, err.Error(), "[invalid-regex")
+	})
+
+	t.Run("validates complex regex patterns", func(t *testing.T) {
+		testCases := []struct {
+			name    string
+			pattern string
+			valid   bool
+		}{
+			{"exact match", "^runtimeClasspath$", true},
+			{"case insensitive", "(?i).*runtime.*", true},
+			{"alternation", "(compile|runtime)Classpath", true},
+			{"word boundaries", "\\bcompile\\b", true},
+			{"unclosed bracket", "[invalid", false},
+			{"unclosed paren", "(unclosed", false},
+			{"invalid escape", "\\k", false},
+			{"empty pattern is valid", "", true},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				options := &ecosystems.SCAPluginOptions{}
+				options.Gradle.ConfigurationMatching = tc.pattern
+				err := ValidateOptions(tempDir, options)
+				if tc.valid {
+					require.NoError(t, err, "pattern %q should be valid", tc.pattern)
+				} else {
+					require.Error(t, err, "pattern %q should be invalid", tc.pattern)
+					assert.Contains(t, err.Error(), "invalid --configuration-matching regex pattern")
+				}
+			})
+		}
+	})
+
+	t.Run("validates absolute init script paths", func(t *testing.T) {
+		dir := t.TempDir()
+
+		// Test with existing file
+		validScript := filepath.Join(dir, "valid.gradle")
+		require.NoError(t, os.WriteFile(validScript, []byte("// valid script"), 0o644))
+
+		options := &ecosystems.SCAPluginOptions{}
+		options.Gradle.InitScript = validScript
+		err := ValidateOptions(dir, options)
+		require.NoError(t, err)
+
+		// Test with non-existent file
+		options.Gradle.InitScript = filepath.Join(dir, "nonexistent.gradle")
+		err = ValidateOptions(dir, options)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "user init script not found")
+
+		// Test with directory instead of file
+		scriptDir := filepath.Join(dir, "scriptdir")
+		require.NoError(t, os.Mkdir(scriptDir, 0o755))
+		options.Gradle.InitScript = scriptDir
+		err = ValidateOptions(dir, options)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "user init script is a directory")
+	})
+
+	t.Run("validates relative init script paths", func(t *testing.T) {
+		dir := t.TempDir()
+
+		// Create a valid relative script
+		scriptsDir := filepath.Join(dir, "scripts")
+		require.NoError(t, os.MkdirAll(scriptsDir, 0o755))
+		validScript := filepath.Join(scriptsDir, "custom.gradle")
+		require.NoError(t, os.WriteFile(validScript, []byte("// custom script"), 0o644))
+
+		// Test with valid relative path
+		options := &ecosystems.SCAPluginOptions{}
+		options.Gradle.InitScript = "scripts/custom.gradle"
+		err := ValidateOptions(dir, options)
+		require.NoError(t, err)
+
+		// Test with non-existent relative path
+		options.Gradle.InitScript = "scripts/nonexistent.gradle"
+		err = ValidateOptions(dir, options)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "user init script not found")
+
+		// Test with empty path
+		options.Gradle.InitScript = "   "
+		err = ValidateOptions(dir, options)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "user init script path is empty")
+
+		// Test with relative path that is a directory
+		options.Gradle.InitScript = "scripts"
+		err = ValidateOptions(dir, options)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "user init script is a directory")
+
+		// Test that file extension doesn't matter
+		customScript := filepath.Join(scriptsDir, "custom-init.txt")
+		require.NoError(t, os.WriteFile(customScript, []byte("// custom init"), 0o644))
+		options.Gradle.InitScript = "scripts/custom-init.txt"
+		err = ValidateOptions(dir, options)
+		require.NoError(t, err)
+	})
+}
+
+// Integration test to ensure BuildDepGraphsFromDir fails fast with invalid options
+func TestValidateOptions_Integration_BuildDepGraphsFromDir(t *testing.T) {
+	t.Run("BuildDepGraphsFromDir fails fast with invalid regex", func(t *testing.T) {
+		dir := t.TempDir()
+		buildFile := filepath.Join(dir, "build.gradle")
+		require.NoError(t, os.WriteFile(buildFile, []byte(""), 0o644))
+
+		options := &ecosystems.SCAPluginOptions{}
+		options.Gradle.ConfigurationMatching = "[invalid-regex"
+
+		ctx := context.Background()
+		log := logger.Nop()
+		plugin := Plugin{}
+
+		// This should fail fast during validation, before any file discovery or Gradle execution
+		result, err := plugin.BuildDepGraphsFromDir(ctx, log, dir, options)
+		require.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "gradle: invalid options:")
+		assert.Contains(t, err.Error(), "invalid --configuration-matching regex pattern")
+		assert.Contains(t, err.Error(), "[invalid-regex")
+	})
+
+	t.Run("BuildDepGraphsFromDir fails fast with invalid init script", func(t *testing.T) {
+		dir := t.TempDir()
+		buildFile := filepath.Join(dir, "build.gradle")
+		require.NoError(t, os.WriteFile(buildFile, []byte(""), 0o644))
+
+		options := &ecosystems.SCAPluginOptions{}
+		options.Gradle.InitScript = "/nonexistent/init.gradle"
+
+		ctx := context.Background()
+		log := logger.Nop()
+		plugin := Plugin{}
+
+		// This should fail fast during validation, before any file discovery
+		result, err := plugin.BuildDepGraphsFromDir(ctx, log, dir, options)
+		require.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "gradle: invalid options:")
+		assert.Contains(t, err.Error(), "user init script not found")
+	})
+}

--- a/pkg/ecosystems/testdata/fixtures/gradle/configuration-matching/README.md
+++ b/pkg/ecosystems/testdata/fixtures/gradle/configuration-matching/README.md
@@ -1,0 +1,21 @@
+# Configuration Matching Test Fixture
+
+This fixture tests the `--configuration-matching` flag functionality by using a Gradle project with dependencies spread across multiple configurations:
+
+## Dependencies by Configuration
+
+- **implementation**: `com.google.guava:guava:30.1.1-jre` (appears in runtime classpaths)
+- **runtimeOnly**: `ch.qos.logback:logback-classic:1.2.12` (runtime classpaths only)
+- **compileOnly**: `org.apache.commons:commons-lang3:3.14.0` (compile classpaths only) 
+- **testImplementation**: `junit:junit:4.13.2`, `org.mockito:mockito-core:4.11.0` (test classpaths)
+- **testRuntimeOnly**: `org.slf4j:slf4j-simple:1.7.36` (test runtime classpaths only)
+
+## Test Cases
+
+- **Full scan**: All dependencies from all configurations
+- **Runtime only** (`(?i).*runtime.*`): implementation + runtimeOnly + testRuntimeOnly dependencies
+- **Compile only** (`compile.*`): compileOnly + compileClasspath dependencies  
+- **Test only** (`(?i)test.*`): testImplementation + testRuntimeOnly dependencies
+- **Exact match** (`^runtimeClasspath$`): Only dependencies from the exact runtimeClasspath configuration
+
+This validates that the regex filtering correctly includes/excludes configurations and their dependencies.

--- a/pkg/ecosystems/testdata/fixtures/gradle/configuration-matching/build.gradle
+++ b/pkg/ecosystems/testdata/fixtures/gradle/configuration-matching/build.gradle
@@ -1,0 +1,24 @@
+plugins {
+    id 'java'
+}
+
+group = 'com.snyk.fixtures'
+version = '1.0.0'
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    // Runtime dependencies
+    implementation 'com.google.guava:guava:30.1.1-jre'
+    runtimeOnly 'ch.qos.logback:logback-classic:1.2.12'
+    
+    // Compile dependencies  
+    compileOnly 'org.apache.commons:commons-lang3:3.14.0'
+    
+    // Test dependencies
+    testImplementation 'junit:junit:4.13.2'
+    testImplementation 'org.mockito:mockito-core:4.11.0'
+    testRuntimeOnly 'org.slf4j:slf4j-simple:1.7.36'
+}

--- a/pkg/ecosystems/testdata/fixtures/gradle/configuration-matching/expected_plugin.json
+++ b/pkg/ecosystems/testdata/fixtures/gradle/configuration-matching/expected_plugin.json
@@ -1,0 +1,340 @@
+[
+  {
+    "depGraph": {
+      "schemaVersion": "1.3.0",
+      "pkgManager": {
+        "name": "gradle"
+      },
+      "pkgs": [
+        {
+          "id": "com.snyk.fixtures:configuration-matching-app@1.0.0",
+          "info": {
+            "name": "com.snyk.fixtures:configuration-matching-app",
+            "version": "1.0.0"
+          }
+        },
+        {
+          "id": "org.apache.commons:commons-lang3@3.14.0",
+          "info": {
+            "name": "org.apache.commons:commons-lang3",
+            "version": "3.14.0"
+          }
+        },
+        {
+          "id": "com.google.guava:guava@30.1.1-jre",
+          "info": {
+            "name": "com.google.guava:guava",
+            "version": "30.1.1-jre"
+          }
+        },
+        {
+          "id": "com.google.guava:failureaccess@1.0.1",
+          "info": {
+            "name": "com.google.guava:failureaccess",
+            "version": "1.0.1"
+          }
+        },
+        {
+          "id": "com.google.guava:listenablefuture@9999.0-empty-to-avoid-conflict-with-guava",
+          "info": {
+            "name": "com.google.guava:listenablefuture",
+            "version": "9999.0-empty-to-avoid-conflict-with-guava"
+          }
+        },
+        {
+          "id": "com.google.code.findbugs:jsr305@3.0.2",
+          "info": {
+            "name": "com.google.code.findbugs:jsr305",
+            "version": "3.0.2"
+          }
+        },
+        {
+          "id": "org.checkerframework:checker-qual@3.8.0",
+          "info": {
+            "name": "org.checkerframework:checker-qual",
+            "version": "3.8.0"
+          }
+        },
+        {
+          "id": "com.google.errorprone:error_prone_annotations@2.5.1",
+          "info": {
+            "name": "com.google.errorprone:error_prone_annotations",
+            "version": "2.5.1"
+          }
+        },
+        {
+          "id": "com.google.j2objc:j2objc-annotations@1.3",
+          "info": {
+            "name": "com.google.j2objc:j2objc-annotations",
+            "version": "1.3"
+          }
+        },
+        {
+          "id": "ch.qos.logback:logback-classic@1.2.12",
+          "info": {
+            "name": "ch.qos.logback:logback-classic",
+            "version": "1.2.12"
+          }
+        },
+        {
+          "id": "ch.qos.logback:logback-core@1.2.12",
+          "info": {
+            "name": "ch.qos.logback:logback-core",
+            "version": "1.2.12"
+          }
+        },
+        {
+          "id": "org.slf4j:slf4j-api@1.7.32",
+          "info": {
+            "name": "org.slf4j:slf4j-api",
+            "version": "1.7.32"
+          }
+        },
+        {
+          "id": "junit:junit@4.13.2",
+          "info": {
+            "name": "junit:junit",
+            "version": "4.13.2"
+          }
+        },
+        {
+          "id": "org.hamcrest:hamcrest-core@1.3",
+          "info": {
+            "name": "org.hamcrest:hamcrest-core",
+            "version": "1.3"
+          }
+        },
+        {
+          "id": "org.mockito:mockito-core@4.11.0",
+          "info": {
+            "name": "org.mockito:mockito-core",
+            "version": "4.11.0"
+          }
+        },
+        {
+          "id": "net.bytebuddy:byte-buddy@1.12.19",
+          "info": {
+            "name": "net.bytebuddy:byte-buddy",
+            "version": "1.12.19"
+          }
+        },
+        {
+          "id": "net.bytebuddy:byte-buddy-agent@1.12.19",
+          "info": {
+            "name": "net.bytebuddy:byte-buddy-agent",
+            "version": "1.12.19"
+          }
+        },
+        {
+          "id": "org.slf4j:slf4j-api@1.7.36",
+          "info": {
+            "name": "org.slf4j:slf4j-api",
+            "version": "1.7.36"
+          }
+        },
+        {
+          "id": "org.objenesis:objenesis@3.3",
+          "info": {
+            "name": "org.objenesis:objenesis",
+            "version": "3.3"
+          }
+        },
+        {
+          "id": "org.slf4j:slf4j-simple@1.7.36",
+          "info": {
+            "name": "org.slf4j:slf4j-simple",
+            "version": "1.7.36"
+          }
+        }
+      ],
+      "graph": {
+        "rootNodeId": "root-node",
+        "nodes": [
+          {
+            "nodeId": "root-node",
+            "pkgId": "com.snyk.fixtures:configuration-matching-app@1.0.0",
+            "deps": [
+              {
+                "nodeId": "org.apache.commons:commons-lang3@3.14.0"
+              },
+              {
+                "nodeId": "com.google.guava:guava@30.1.1-jre"
+              },
+              {
+                "nodeId": "ch.qos.logback:logback-classic@1.2.12"
+              },
+              {
+                "nodeId": "junit:junit@4.13.2"
+              },
+              {
+                "nodeId": "org.mockito:mockito-core@4.11.0"
+              },
+              {
+                "nodeId": "org.slf4j:slf4j-simple@1.7.36"
+              }
+            ]
+          },
+          {
+            "nodeId": "org.apache.commons:commons-lang3@3.14.0",
+            "pkgId": "org.apache.commons:commons-lang3@3.14.0",
+            "deps": []
+          },
+          {
+            "nodeId": "com.google.guava:guava@30.1.1-jre",
+            "pkgId": "com.google.guava:guava@30.1.1-jre",
+            "deps": [
+              {
+                "nodeId": "com.google.guava:failureaccess@1.0.1"
+              },
+              {
+                "nodeId": "com.google.guava:listenablefuture@9999.0-empty-to-avoid-conflict-with-guava"
+              },
+              {
+                "nodeId": "com.google.code.findbugs:jsr305@3.0.2"
+              },
+              {
+                "nodeId": "org.checkerframework:checker-qual@3.8.0"
+              },
+              {
+                "nodeId": "com.google.errorprone:error_prone_annotations@2.5.1"
+              },
+              {
+                "nodeId": "com.google.j2objc:j2objc-annotations@1.3"
+              }
+            ]
+          },
+          {
+            "nodeId": "com.google.guava:failureaccess@1.0.1",
+            "pkgId": "com.google.guava:failureaccess@1.0.1",
+            "deps": []
+          },
+          {
+            "nodeId": "com.google.guava:listenablefuture@9999.0-empty-to-avoid-conflict-with-guava",
+            "pkgId": "com.google.guava:listenablefuture@9999.0-empty-to-avoid-conflict-with-guava",
+            "deps": []
+          },
+          {
+            "nodeId": "com.google.code.findbugs:jsr305@3.0.2",
+            "pkgId": "com.google.code.findbugs:jsr305@3.0.2",
+            "deps": []
+          },
+          {
+            "nodeId": "org.checkerframework:checker-qual@3.8.0",
+            "pkgId": "org.checkerframework:checker-qual@3.8.0",
+            "deps": []
+          },
+          {
+            "nodeId": "com.google.errorprone:error_prone_annotations@2.5.1",
+            "pkgId": "com.google.errorprone:error_prone_annotations@2.5.1",
+            "deps": []
+          },
+          {
+            "nodeId": "com.google.j2objc:j2objc-annotations@1.3",
+            "pkgId": "com.google.j2objc:j2objc-annotations@1.3",
+            "deps": []
+          },
+          {
+            "nodeId": "ch.qos.logback:logback-classic@1.2.12",
+            "pkgId": "ch.qos.logback:logback-classic@1.2.12",
+            "deps": [
+              {
+                "nodeId": "ch.qos.logback:logback-core@1.2.12"
+              },
+              {
+                "nodeId": "org.slf4j:slf4j-api@1.7.32"
+              },
+              {
+                "nodeId": "org.slf4j:slf4j-api@1.7.36"
+              }
+            ]
+          },
+          {
+            "nodeId": "ch.qos.logback:logback-core@1.2.12",
+            "pkgId": "ch.qos.logback:logback-core@1.2.12",
+            "deps": []
+          },
+          {
+            "nodeId": "org.slf4j:slf4j-api@1.7.32",
+            "pkgId": "org.slf4j:slf4j-api@1.7.32",
+            "deps": []
+          },
+          {
+            "nodeId": "junit:junit@4.13.2",
+            "pkgId": "junit:junit@4.13.2",
+            "deps": [
+              {
+                "nodeId": "org.hamcrest:hamcrest-core@1.3"
+              }
+            ]
+          },
+          {
+            "nodeId": "org.hamcrest:hamcrest-core@1.3",
+            "pkgId": "org.hamcrest:hamcrest-core@1.3",
+            "deps": []
+          },
+          {
+            "nodeId": "org.mockito:mockito-core@4.11.0",
+            "pkgId": "org.mockito:mockito-core@4.11.0",
+            "deps": [
+              {
+                "nodeId": "net.bytebuddy:byte-buddy@1.12.19"
+              },
+              {
+                "nodeId": "net.bytebuddy:byte-buddy-agent@1.12.19"
+              },
+              {
+                "nodeId": "org.objenesis:objenesis@3.3"
+              }
+            ]
+          },
+          {
+            "nodeId": "net.bytebuddy:byte-buddy@1.12.19",
+            "pkgId": "net.bytebuddy:byte-buddy@1.12.19",
+            "deps": []
+          },
+          {
+            "nodeId": "net.bytebuddy:byte-buddy-agent@1.12.19",
+            "pkgId": "net.bytebuddy:byte-buddy-agent@1.12.19",
+            "deps": []
+          },
+          {
+            "nodeId": "org.slf4j:slf4j-api@1.7.36",
+            "pkgId": "org.slf4j:slf4j-api@1.7.36",
+            "deps": []
+          },
+          {
+            "nodeId": "org.objenesis:objenesis@3.3",
+            "pkgId": "org.objenesis:objenesis@3.3",
+            "deps": []
+          },
+          {
+            "nodeId": "org.slf4j:slf4j-simple@1.7.36",
+            "pkgId": "org.slf4j:slf4j-simple@1.7.36",
+            "deps": [
+              {
+                "nodeId": "org.slf4j:slf4j-api@1.7.36:pruned"
+              }
+            ]
+          },
+          {
+            "nodeId": "org.slf4j:slf4j-api@1.7.36:pruned",
+            "pkgId": "org.slf4j:slf4j-api@1.7.36",
+            "info": {
+              "labels": {
+                "pruned": "true"
+              }
+            },
+            "deps": []
+          }
+        ]
+      }
+    },
+    "projectDescriptor": {
+      "identity": {
+        "type": "gradle",
+        "targetFile": "build.gradle",
+        "rootComponentName": "com.snyk.fixtures:configuration-matching-app"
+      }
+    }
+  }
+]

--- a/pkg/ecosystems/testdata/fixtures/gradle/configuration-matching/expected_plugin_compile_only.json
+++ b/pkg/ecosystems/testdata/fixtures/gradle/configuration-matching/expected_plugin_compile_only.json
@@ -1,0 +1,158 @@
+[
+  {
+    "depGraph": {
+      "schemaVersion": "1.3.0",
+      "pkgManager": {
+        "name": "gradle"
+      },
+      "pkgs": [
+        {
+          "id": "com.snyk.fixtures:configuration-matching-app@1.0.0",
+          "info": {
+            "name": "com.snyk.fixtures:configuration-matching-app",
+            "version": "1.0.0"
+          }
+        },
+        {
+          "id": "org.apache.commons:commons-lang3@3.14.0",
+          "info": {
+            "name": "org.apache.commons:commons-lang3",
+            "version": "3.14.0"
+          }
+        },
+        {
+          "id": "com.google.guava:guava@30.1.1-jre",
+          "info": {
+            "name": "com.google.guava:guava",
+            "version": "30.1.1-jre"
+          }
+        },
+        {
+          "id": "com.google.guava:failureaccess@1.0.1",
+          "info": {
+            "name": "com.google.guava:failureaccess",
+            "version": "1.0.1"
+          }
+        },
+        {
+          "id": "com.google.guava:listenablefuture@9999.0-empty-to-avoid-conflict-with-guava",
+          "info": {
+            "name": "com.google.guava:listenablefuture",
+            "version": "9999.0-empty-to-avoid-conflict-with-guava"
+          }
+        },
+        {
+          "id": "com.google.code.findbugs:jsr305@3.0.2",
+          "info": {
+            "name": "com.google.code.findbugs:jsr305",
+            "version": "3.0.2"
+          }
+        },
+        {
+          "id": "org.checkerframework:checker-qual@3.8.0",
+          "info": {
+            "name": "org.checkerframework:checker-qual",
+            "version": "3.8.0"
+          }
+        },
+        {
+          "id": "com.google.errorprone:error_prone_annotations@2.5.1",
+          "info": {
+            "name": "com.google.errorprone:error_prone_annotations",
+            "version": "2.5.1"
+          }
+        },
+        {
+          "id": "com.google.j2objc:j2objc-annotations@1.3",
+          "info": {
+            "name": "com.google.j2objc:j2objc-annotations",
+            "version": "1.3"
+          }
+        }
+      ],
+      "graph": {
+        "rootNodeId": "root-node",
+        "nodes": [
+          {
+            "nodeId": "root-node",
+            "pkgId": "com.snyk.fixtures:configuration-matching-app@1.0.0",
+            "deps": [
+              {
+                "nodeId": "org.apache.commons:commons-lang3@3.14.0"
+              },
+              {
+                "nodeId": "com.google.guava:guava@30.1.1-jre"
+              }
+            ]
+          },
+          {
+            "nodeId": "org.apache.commons:commons-lang3@3.14.0",
+            "pkgId": "org.apache.commons:commons-lang3@3.14.0",
+            "deps": []
+          },
+          {
+            "nodeId": "com.google.guava:guava@30.1.1-jre",
+            "pkgId": "com.google.guava:guava@30.1.1-jre",
+            "deps": [
+              {
+                "nodeId": "com.google.guava:failureaccess@1.0.1"
+              },
+              {
+                "nodeId": "com.google.guava:listenablefuture@9999.0-empty-to-avoid-conflict-with-guava"
+              },
+              {
+                "nodeId": "com.google.code.findbugs:jsr305@3.0.2"
+              },
+              {
+                "nodeId": "org.checkerframework:checker-qual@3.8.0"
+              },
+              {
+                "nodeId": "com.google.errorprone:error_prone_annotations@2.5.1"
+              },
+              {
+                "nodeId": "com.google.j2objc:j2objc-annotations@1.3"
+              }
+            ]
+          },
+          {
+            "nodeId": "com.google.guava:failureaccess@1.0.1",
+            "pkgId": "com.google.guava:failureaccess@1.0.1",
+            "deps": []
+          },
+          {
+            "nodeId": "com.google.guava:listenablefuture@9999.0-empty-to-avoid-conflict-with-guava",
+            "pkgId": "com.google.guava:listenablefuture@9999.0-empty-to-avoid-conflict-with-guava",
+            "deps": []
+          },
+          {
+            "nodeId": "com.google.code.findbugs:jsr305@3.0.2",
+            "pkgId": "com.google.code.findbugs:jsr305@3.0.2",
+            "deps": []
+          },
+          {
+            "nodeId": "org.checkerframework:checker-qual@3.8.0",
+            "pkgId": "org.checkerframework:checker-qual@3.8.0",
+            "deps": []
+          },
+          {
+            "nodeId": "com.google.errorprone:error_prone_annotations@2.5.1",
+            "pkgId": "com.google.errorprone:error_prone_annotations@2.5.1",
+            "deps": []
+          },
+          {
+            "nodeId": "com.google.j2objc:j2objc-annotations@1.3",
+            "pkgId": "com.google.j2objc:j2objc-annotations@1.3",
+            "deps": []
+          }
+        ]
+      }
+    },
+    "projectDescriptor": {
+      "identity": {
+        "type": "gradle",
+        "targetFile": "build.gradle",
+        "rootComponentName": "com.snyk.fixtures:configuration-matching-app"
+      }
+    }
+  }
+]

--- a/pkg/ecosystems/testdata/fixtures/gradle/configuration-matching/expected_plugin_exact_runtime.json
+++ b/pkg/ecosystems/testdata/fixtures/gradle/configuration-matching/expected_plugin_exact_runtime.json
@@ -1,0 +1,189 @@
+[
+  {
+    "depGraph": {
+      "schemaVersion": "1.3.0",
+      "pkgManager": {
+        "name": "gradle"
+      },
+      "pkgs": [
+        {
+          "id": "com.snyk.fixtures:configuration-matching-app@1.0.0",
+          "info": {
+            "name": "com.snyk.fixtures:configuration-matching-app",
+            "version": "1.0.0"
+          }
+        },
+        {
+          "id": "com.google.guava:guava@30.1.1-jre",
+          "info": {
+            "name": "com.google.guava:guava",
+            "version": "30.1.1-jre"
+          }
+        },
+        {
+          "id": "com.google.guava:failureaccess@1.0.1",
+          "info": {
+            "name": "com.google.guava:failureaccess",
+            "version": "1.0.1"
+          }
+        },
+        {
+          "id": "com.google.guava:listenablefuture@9999.0-empty-to-avoid-conflict-with-guava",
+          "info": {
+            "name": "com.google.guava:listenablefuture",
+            "version": "9999.0-empty-to-avoid-conflict-with-guava"
+          }
+        },
+        {
+          "id": "com.google.code.findbugs:jsr305@3.0.2",
+          "info": {
+            "name": "com.google.code.findbugs:jsr305",
+            "version": "3.0.2"
+          }
+        },
+        {
+          "id": "org.checkerframework:checker-qual@3.8.0",
+          "info": {
+            "name": "org.checkerframework:checker-qual",
+            "version": "3.8.0"
+          }
+        },
+        {
+          "id": "com.google.errorprone:error_prone_annotations@2.5.1",
+          "info": {
+            "name": "com.google.errorprone:error_prone_annotations",
+            "version": "2.5.1"
+          }
+        },
+        {
+          "id": "com.google.j2objc:j2objc-annotations@1.3",
+          "info": {
+            "name": "com.google.j2objc:j2objc-annotations",
+            "version": "1.3"
+          }
+        },
+        {
+          "id": "ch.qos.logback:logback-classic@1.2.12",
+          "info": {
+            "name": "ch.qos.logback:logback-classic",
+            "version": "1.2.12"
+          }
+        },
+        {
+          "id": "ch.qos.logback:logback-core@1.2.12",
+          "info": {
+            "name": "ch.qos.logback:logback-core",
+            "version": "1.2.12"
+          }
+        },
+        {
+          "id": "org.slf4j:slf4j-api@1.7.32",
+          "info": {
+            "name": "org.slf4j:slf4j-api",
+            "version": "1.7.32"
+          }
+        }
+      ],
+      "graph": {
+        "rootNodeId": "root-node",
+        "nodes": [
+          {
+            "nodeId": "root-node",
+            "pkgId": "com.snyk.fixtures:configuration-matching-app@1.0.0",
+            "deps": [
+              {
+                "nodeId": "com.google.guava:guava@30.1.1-jre"
+              },
+              {
+                "nodeId": "ch.qos.logback:logback-classic@1.2.12"
+              }
+            ]
+          },
+          {
+            "nodeId": "com.google.guava:guava@30.1.1-jre",
+            "pkgId": "com.google.guava:guava@30.1.1-jre",
+            "deps": [
+              {
+                "nodeId": "com.google.guava:failureaccess@1.0.1"
+              },
+              {
+                "nodeId": "com.google.guava:listenablefuture@9999.0-empty-to-avoid-conflict-with-guava"
+              },
+              {
+                "nodeId": "com.google.code.findbugs:jsr305@3.0.2"
+              },
+              {
+                "nodeId": "org.checkerframework:checker-qual@3.8.0"
+              },
+              {
+                "nodeId": "com.google.errorprone:error_prone_annotations@2.5.1"
+              },
+              {
+                "nodeId": "com.google.j2objc:j2objc-annotations@1.3"
+              }
+            ]
+          },
+          {
+            "nodeId": "com.google.guava:failureaccess@1.0.1",
+            "pkgId": "com.google.guava:failureaccess@1.0.1",
+            "deps": []
+          },
+          {
+            "nodeId": "com.google.guava:listenablefuture@9999.0-empty-to-avoid-conflict-with-guava",
+            "pkgId": "com.google.guava:listenablefuture@9999.0-empty-to-avoid-conflict-with-guava",
+            "deps": []
+          },
+          {
+            "nodeId": "com.google.code.findbugs:jsr305@3.0.2",
+            "pkgId": "com.google.code.findbugs:jsr305@3.0.2",
+            "deps": []
+          },
+          {
+            "nodeId": "org.checkerframework:checker-qual@3.8.0",
+            "pkgId": "org.checkerframework:checker-qual@3.8.0",
+            "deps": []
+          },
+          {
+            "nodeId": "com.google.errorprone:error_prone_annotations@2.5.1",
+            "pkgId": "com.google.errorprone:error_prone_annotations@2.5.1",
+            "deps": []
+          },
+          {
+            "nodeId": "com.google.j2objc:j2objc-annotations@1.3",
+            "pkgId": "com.google.j2objc:j2objc-annotations@1.3",
+            "deps": []
+          },
+          {
+            "nodeId": "ch.qos.logback:logback-classic@1.2.12",
+            "pkgId": "ch.qos.logback:logback-classic@1.2.12",
+            "deps": [
+              {
+                "nodeId": "ch.qos.logback:logback-core@1.2.12"
+              },
+              {
+                "nodeId": "org.slf4j:slf4j-api@1.7.32"
+              }
+            ]
+          },
+          {
+            "nodeId": "ch.qos.logback:logback-core@1.2.12",
+            "pkgId": "ch.qos.logback:logback-core@1.2.12",
+            "deps": []
+          },
+          {
+            "nodeId": "org.slf4j:slf4j-api@1.7.32",
+            "pkgId": "org.slf4j:slf4j-api@1.7.32",
+            "deps": []
+          }
+        ]
+      }
+    },
+    "projectDescriptor": {
+      "identity": {
+        "type": "gradle",
+        "targetFile": "build.gradle",
+        "rootComponentName": "com.snyk.fixtures:configuration-matching-app"
+      }
+    }
+  }
+]

--- a/pkg/ecosystems/testdata/fixtures/gradle/configuration-matching/expected_plugin_runtime_only.json
+++ b/pkg/ecosystems/testdata/fixtures/gradle/configuration-matching/expected_plugin_runtime_only.json
@@ -1,0 +1,325 @@
+[
+  {
+    "depGraph": {
+      "schemaVersion": "1.3.0",
+      "pkgManager": {
+        "name": "gradle"
+      },
+      "pkgs": [
+        {
+          "id": "com.snyk.fixtures:configuration-matching-app@1.0.0",
+          "info": {
+            "name": "com.snyk.fixtures:configuration-matching-app",
+            "version": "1.0.0"
+          }
+        },
+        {
+          "id": "com.google.guava:guava@30.1.1-jre",
+          "info": {
+            "name": "com.google.guava:guava",
+            "version": "30.1.1-jre"
+          }
+        },
+        {
+          "id": "com.google.guava:failureaccess@1.0.1",
+          "info": {
+            "name": "com.google.guava:failureaccess",
+            "version": "1.0.1"
+          }
+        },
+        {
+          "id": "com.google.guava:listenablefuture@9999.0-empty-to-avoid-conflict-with-guava",
+          "info": {
+            "name": "com.google.guava:listenablefuture",
+            "version": "9999.0-empty-to-avoid-conflict-with-guava"
+          }
+        },
+        {
+          "id": "com.google.code.findbugs:jsr305@3.0.2",
+          "info": {
+            "name": "com.google.code.findbugs:jsr305",
+            "version": "3.0.2"
+          }
+        },
+        {
+          "id": "org.checkerframework:checker-qual@3.8.0",
+          "info": {
+            "name": "org.checkerframework:checker-qual",
+            "version": "3.8.0"
+          }
+        },
+        {
+          "id": "com.google.errorprone:error_prone_annotations@2.5.1",
+          "info": {
+            "name": "com.google.errorprone:error_prone_annotations",
+            "version": "2.5.1"
+          }
+        },
+        {
+          "id": "com.google.j2objc:j2objc-annotations@1.3",
+          "info": {
+            "name": "com.google.j2objc:j2objc-annotations",
+            "version": "1.3"
+          }
+        },
+        {
+          "id": "ch.qos.logback:logback-classic@1.2.12",
+          "info": {
+            "name": "ch.qos.logback:logback-classic",
+            "version": "1.2.12"
+          }
+        },
+        {
+          "id": "ch.qos.logback:logback-core@1.2.12",
+          "info": {
+            "name": "ch.qos.logback:logback-core",
+            "version": "1.2.12"
+          }
+        },
+        {
+          "id": "org.slf4j:slf4j-api@1.7.32",
+          "info": {
+            "name": "org.slf4j:slf4j-api",
+            "version": "1.7.32"
+          }
+        },
+        {
+          "id": "org.slf4j:slf4j-api@1.7.36",
+          "info": {
+            "name": "org.slf4j:slf4j-api",
+            "version": "1.7.36"
+          }
+        },
+        {
+          "id": "junit:junit@4.13.2",
+          "info": {
+            "name": "junit:junit",
+            "version": "4.13.2"
+          }
+        },
+        {
+          "id": "org.hamcrest:hamcrest-core@1.3",
+          "info": {
+            "name": "org.hamcrest:hamcrest-core",
+            "version": "1.3"
+          }
+        },
+        {
+          "id": "org.mockito:mockito-core@4.11.0",
+          "info": {
+            "name": "org.mockito:mockito-core",
+            "version": "4.11.0"
+          }
+        },
+        {
+          "id": "net.bytebuddy:byte-buddy@1.12.19",
+          "info": {
+            "name": "net.bytebuddy:byte-buddy",
+            "version": "1.12.19"
+          }
+        },
+        {
+          "id": "net.bytebuddy:byte-buddy-agent@1.12.19",
+          "info": {
+            "name": "net.bytebuddy:byte-buddy-agent",
+            "version": "1.12.19"
+          }
+        },
+        {
+          "id": "org.objenesis:objenesis@3.3",
+          "info": {
+            "name": "org.objenesis:objenesis",
+            "version": "3.3"
+          }
+        },
+        {
+          "id": "org.slf4j:slf4j-simple@1.7.36",
+          "info": {
+            "name": "org.slf4j:slf4j-simple",
+            "version": "1.7.36"
+          }
+        }
+      ],
+      "graph": {
+        "rootNodeId": "root-node",
+        "nodes": [
+          {
+            "nodeId": "root-node",
+            "pkgId": "com.snyk.fixtures:configuration-matching-app@1.0.0",
+            "deps": [
+              {
+                "nodeId": "com.google.guava:guava@30.1.1-jre"
+              },
+              {
+                "nodeId": "ch.qos.logback:logback-classic@1.2.12"
+              },
+              {
+                "nodeId": "junit:junit@4.13.2"
+              },
+              {
+                "nodeId": "org.mockito:mockito-core@4.11.0"
+              },
+              {
+                "nodeId": "org.slf4j:slf4j-simple@1.7.36"
+              }
+            ]
+          },
+          {
+            "nodeId": "com.google.guava:guava@30.1.1-jre",
+            "pkgId": "com.google.guava:guava@30.1.1-jre",
+            "deps": [
+              {
+                "nodeId": "com.google.guava:failureaccess@1.0.1"
+              },
+              {
+                "nodeId": "com.google.guava:listenablefuture@9999.0-empty-to-avoid-conflict-with-guava"
+              },
+              {
+                "nodeId": "com.google.code.findbugs:jsr305@3.0.2"
+              },
+              {
+                "nodeId": "org.checkerframework:checker-qual@3.8.0"
+              },
+              {
+                "nodeId": "com.google.errorprone:error_prone_annotations@2.5.1"
+              },
+              {
+                "nodeId": "com.google.j2objc:j2objc-annotations@1.3"
+              }
+            ]
+          },
+          {
+            "nodeId": "com.google.guava:failureaccess@1.0.1",
+            "pkgId": "com.google.guava:failureaccess@1.0.1",
+            "deps": []
+          },
+          {
+            "nodeId": "com.google.guava:listenablefuture@9999.0-empty-to-avoid-conflict-with-guava",
+            "pkgId": "com.google.guava:listenablefuture@9999.0-empty-to-avoid-conflict-with-guava",
+            "deps": []
+          },
+          {
+            "nodeId": "com.google.code.findbugs:jsr305@3.0.2",
+            "pkgId": "com.google.code.findbugs:jsr305@3.0.2",
+            "deps": []
+          },
+          {
+            "nodeId": "org.checkerframework:checker-qual@3.8.0",
+            "pkgId": "org.checkerframework:checker-qual@3.8.0",
+            "deps": []
+          },
+          {
+            "nodeId": "com.google.errorprone:error_prone_annotations@2.5.1",
+            "pkgId": "com.google.errorprone:error_prone_annotations@2.5.1",
+            "deps": []
+          },
+          {
+            "nodeId": "com.google.j2objc:j2objc-annotations@1.3",
+            "pkgId": "com.google.j2objc:j2objc-annotations@1.3",
+            "deps": []
+          },
+          {
+            "nodeId": "ch.qos.logback:logback-classic@1.2.12",
+            "pkgId": "ch.qos.logback:logback-classic@1.2.12",
+            "deps": [
+              {
+                "nodeId": "ch.qos.logback:logback-core@1.2.12"
+              },
+              {
+                "nodeId": "org.slf4j:slf4j-api@1.7.32"
+              },
+              {
+                "nodeId": "org.slf4j:slf4j-api@1.7.36"
+              }
+            ]
+          },
+          {
+            "nodeId": "ch.qos.logback:logback-core@1.2.12",
+            "pkgId": "ch.qos.logback:logback-core@1.2.12",
+            "deps": []
+          },
+          {
+            "nodeId": "org.slf4j:slf4j-api@1.7.32",
+            "pkgId": "org.slf4j:slf4j-api@1.7.32",
+            "deps": []
+          },
+          {
+            "nodeId": "org.slf4j:slf4j-api@1.7.36",
+            "pkgId": "org.slf4j:slf4j-api@1.7.36",
+            "deps": []
+          },
+          {
+            "nodeId": "junit:junit@4.13.2",
+            "pkgId": "junit:junit@4.13.2",
+            "deps": [
+              {
+                "nodeId": "org.hamcrest:hamcrest-core@1.3"
+              }
+            ]
+          },
+          {
+            "nodeId": "org.hamcrest:hamcrest-core@1.3",
+            "pkgId": "org.hamcrest:hamcrest-core@1.3",
+            "deps": []
+          },
+          {
+            "nodeId": "org.mockito:mockito-core@4.11.0",
+            "pkgId": "org.mockito:mockito-core@4.11.0",
+            "deps": [
+              {
+                "nodeId": "net.bytebuddy:byte-buddy@1.12.19"
+              },
+              {
+                "nodeId": "net.bytebuddy:byte-buddy-agent@1.12.19"
+              },
+              {
+                "nodeId": "org.objenesis:objenesis@3.3"
+              }
+            ]
+          },
+          {
+            "nodeId": "net.bytebuddy:byte-buddy@1.12.19",
+            "pkgId": "net.bytebuddy:byte-buddy@1.12.19",
+            "deps": []
+          },
+          {
+            "nodeId": "net.bytebuddy:byte-buddy-agent@1.12.19",
+            "pkgId": "net.bytebuddy:byte-buddy-agent@1.12.19",
+            "deps": []
+          },
+          {
+            "nodeId": "org.objenesis:objenesis@3.3",
+            "pkgId": "org.objenesis:objenesis@3.3",
+            "deps": []
+          },
+          {
+            "nodeId": "org.slf4j:slf4j-simple@1.7.36",
+            "pkgId": "org.slf4j:slf4j-simple@1.7.36",
+            "deps": [
+              {
+                "nodeId": "org.slf4j:slf4j-api@1.7.36:pruned"
+              }
+            ]
+          },
+          {
+            "nodeId": "org.slf4j:slf4j-api@1.7.36:pruned",
+            "pkgId": "org.slf4j:slf4j-api@1.7.36",
+            "info": {
+              "labels": {
+                "pruned": "true"
+              }
+            },
+            "deps": []
+          }
+        ]
+      }
+    },
+    "projectDescriptor": {
+      "identity": {
+        "type": "gradle",
+        "targetFile": "build.gradle",
+        "rootComponentName": "com.snyk.fixtures:configuration-matching-app"
+      }
+    }
+  }
+]

--- a/pkg/ecosystems/testdata/fixtures/gradle/configuration-matching/expected_plugin_test_only.json
+++ b/pkg/ecosystems/testdata/fixtures/gradle/configuration-matching/expected_plugin_test_only.json
@@ -1,0 +1,310 @@
+[
+  {
+    "depGraph": {
+      "schemaVersion": "1.3.0",
+      "pkgManager": {
+        "name": "gradle"
+      },
+      "pkgs": [
+        {
+          "id": "com.snyk.fixtures:configuration-matching-app@1.0.0",
+          "info": {
+            "name": "com.snyk.fixtures:configuration-matching-app",
+            "version": "1.0.0"
+          }
+        },
+        {
+          "id": "com.google.guava:guava@30.1.1-jre",
+          "info": {
+            "name": "com.google.guava:guava",
+            "version": "30.1.1-jre"
+          }
+        },
+        {
+          "id": "com.google.guava:failureaccess@1.0.1",
+          "info": {
+            "name": "com.google.guava:failureaccess",
+            "version": "1.0.1"
+          }
+        },
+        {
+          "id": "com.google.guava:listenablefuture@9999.0-empty-to-avoid-conflict-with-guava",
+          "info": {
+            "name": "com.google.guava:listenablefuture",
+            "version": "9999.0-empty-to-avoid-conflict-with-guava"
+          }
+        },
+        {
+          "id": "com.google.code.findbugs:jsr305@3.0.2",
+          "info": {
+            "name": "com.google.code.findbugs:jsr305",
+            "version": "3.0.2"
+          }
+        },
+        {
+          "id": "org.checkerframework:checker-qual@3.8.0",
+          "info": {
+            "name": "org.checkerframework:checker-qual",
+            "version": "3.8.0"
+          }
+        },
+        {
+          "id": "com.google.errorprone:error_prone_annotations@2.5.1",
+          "info": {
+            "name": "com.google.errorprone:error_prone_annotations",
+            "version": "2.5.1"
+          }
+        },
+        {
+          "id": "com.google.j2objc:j2objc-annotations@1.3",
+          "info": {
+            "name": "com.google.j2objc:j2objc-annotations",
+            "version": "1.3"
+          }
+        },
+        {
+          "id": "junit:junit@4.13.2",
+          "info": {
+            "name": "junit:junit",
+            "version": "4.13.2"
+          }
+        },
+        {
+          "id": "org.hamcrest:hamcrest-core@1.3",
+          "info": {
+            "name": "org.hamcrest:hamcrest-core",
+            "version": "1.3"
+          }
+        },
+        {
+          "id": "org.mockito:mockito-core@4.11.0",
+          "info": {
+            "name": "org.mockito:mockito-core",
+            "version": "4.11.0"
+          }
+        },
+        {
+          "id": "net.bytebuddy:byte-buddy@1.12.19",
+          "info": {
+            "name": "net.bytebuddy:byte-buddy",
+            "version": "1.12.19"
+          }
+        },
+        {
+          "id": "net.bytebuddy:byte-buddy-agent@1.12.19",
+          "info": {
+            "name": "net.bytebuddy:byte-buddy-agent",
+            "version": "1.12.19"
+          }
+        },
+        {
+          "id": "ch.qos.logback:logback-classic@1.2.12",
+          "info": {
+            "name": "ch.qos.logback:logback-classic",
+            "version": "1.2.12"
+          }
+        },
+        {
+          "id": "ch.qos.logback:logback-core@1.2.12",
+          "info": {
+            "name": "ch.qos.logback:logback-core",
+            "version": "1.2.12"
+          }
+        },
+        {
+          "id": "org.slf4j:slf4j-api@1.7.36",
+          "info": {
+            "name": "org.slf4j:slf4j-api",
+            "version": "1.7.36"
+          }
+        },
+        {
+          "id": "org.objenesis:objenesis@3.3",
+          "info": {
+            "name": "org.objenesis:objenesis",
+            "version": "3.3"
+          }
+        },
+        {
+          "id": "org.slf4j:slf4j-simple@1.7.36",
+          "info": {
+            "name": "org.slf4j:slf4j-simple",
+            "version": "1.7.36"
+          }
+        }
+      ],
+      "graph": {
+        "rootNodeId": "root-node",
+        "nodes": [
+          {
+            "nodeId": "root-node",
+            "pkgId": "com.snyk.fixtures:configuration-matching-app@1.0.0",
+            "deps": [
+              {
+                "nodeId": "com.google.guava:guava@30.1.1-jre"
+              },
+              {
+                "nodeId": "junit:junit@4.13.2"
+              },
+              {
+                "nodeId": "org.mockito:mockito-core@4.11.0"
+              },
+              {
+                "nodeId": "ch.qos.logback:logback-classic@1.2.12"
+              },
+              {
+                "nodeId": "org.slf4j:slf4j-simple@1.7.36"
+              }
+            ]
+          },
+          {
+            "nodeId": "com.google.guava:guava@30.1.1-jre",
+            "pkgId": "com.google.guava:guava@30.1.1-jre",
+            "deps": [
+              {
+                "nodeId": "com.google.guava:failureaccess@1.0.1"
+              },
+              {
+                "nodeId": "com.google.guava:listenablefuture@9999.0-empty-to-avoid-conflict-with-guava"
+              },
+              {
+                "nodeId": "com.google.code.findbugs:jsr305@3.0.2"
+              },
+              {
+                "nodeId": "org.checkerframework:checker-qual@3.8.0"
+              },
+              {
+                "nodeId": "com.google.errorprone:error_prone_annotations@2.5.1"
+              },
+              {
+                "nodeId": "com.google.j2objc:j2objc-annotations@1.3"
+              }
+            ]
+          },
+          {
+            "nodeId": "com.google.guava:failureaccess@1.0.1",
+            "pkgId": "com.google.guava:failureaccess@1.0.1",
+            "deps": []
+          },
+          {
+            "nodeId": "com.google.guava:listenablefuture@9999.0-empty-to-avoid-conflict-with-guava",
+            "pkgId": "com.google.guava:listenablefuture@9999.0-empty-to-avoid-conflict-with-guava",
+            "deps": []
+          },
+          {
+            "nodeId": "com.google.code.findbugs:jsr305@3.0.2",
+            "pkgId": "com.google.code.findbugs:jsr305@3.0.2",
+            "deps": []
+          },
+          {
+            "nodeId": "org.checkerframework:checker-qual@3.8.0",
+            "pkgId": "org.checkerframework:checker-qual@3.8.0",
+            "deps": []
+          },
+          {
+            "nodeId": "com.google.errorprone:error_prone_annotations@2.5.1",
+            "pkgId": "com.google.errorprone:error_prone_annotations@2.5.1",
+            "deps": []
+          },
+          {
+            "nodeId": "com.google.j2objc:j2objc-annotations@1.3",
+            "pkgId": "com.google.j2objc:j2objc-annotations@1.3",
+            "deps": []
+          },
+          {
+            "nodeId": "junit:junit@4.13.2",
+            "pkgId": "junit:junit@4.13.2",
+            "deps": [
+              {
+                "nodeId": "org.hamcrest:hamcrest-core@1.3"
+              }
+            ]
+          },
+          {
+            "nodeId": "org.hamcrest:hamcrest-core@1.3",
+            "pkgId": "org.hamcrest:hamcrest-core@1.3",
+            "deps": []
+          },
+          {
+            "nodeId": "org.mockito:mockito-core@4.11.0",
+            "pkgId": "org.mockito:mockito-core@4.11.0",
+            "deps": [
+              {
+                "nodeId": "net.bytebuddy:byte-buddy@1.12.19"
+              },
+              {
+                "nodeId": "net.bytebuddy:byte-buddy-agent@1.12.19"
+              },
+              {
+                "nodeId": "org.objenesis:objenesis@3.3"
+              }
+            ]
+          },
+          {
+            "nodeId": "net.bytebuddy:byte-buddy@1.12.19",
+            "pkgId": "net.bytebuddy:byte-buddy@1.12.19",
+            "deps": []
+          },
+          {
+            "nodeId": "net.bytebuddy:byte-buddy-agent@1.12.19",
+            "pkgId": "net.bytebuddy:byte-buddy-agent@1.12.19",
+            "deps": []
+          },
+          {
+            "nodeId": "ch.qos.logback:logback-classic@1.2.12",
+            "pkgId": "ch.qos.logback:logback-classic@1.2.12",
+            "deps": [
+              {
+                "nodeId": "ch.qos.logback:logback-core@1.2.12"
+              },
+              {
+                "nodeId": "org.slf4j:slf4j-api@1.7.36"
+              }
+            ]
+          },
+          {
+            "nodeId": "ch.qos.logback:logback-core@1.2.12",
+            "pkgId": "ch.qos.logback:logback-core@1.2.12",
+            "deps": []
+          },
+          {
+            "nodeId": "org.slf4j:slf4j-api@1.7.36",
+            "pkgId": "org.slf4j:slf4j-api@1.7.36",
+            "deps": []
+          },
+          {
+            "nodeId": "org.objenesis:objenesis@3.3",
+            "pkgId": "org.objenesis:objenesis@3.3",
+            "deps": []
+          },
+          {
+            "nodeId": "org.slf4j:slf4j-simple@1.7.36",
+            "pkgId": "org.slf4j:slf4j-simple@1.7.36",
+            "deps": [
+              {
+                "nodeId": "org.slf4j:slf4j-api@1.7.36:pruned"
+              }
+            ]
+          },
+          {
+            "nodeId": "org.slf4j:slf4j-api@1.7.36:pruned",
+            "pkgId": "org.slf4j:slf4j-api@1.7.36",
+            "info": {
+              "labels": {
+                "pruned": "true"
+              }
+            },
+            "deps": []
+          }
+        ]
+      }
+    },
+    "projectDescriptor": {
+      "identity": {
+        "type": "gradle",
+        "targetFile": "build.gradle",
+        "rootComponentName": "com.snyk.fixtures:configuration-matching-app"
+      }
+    }
+  }
+]

--- a/pkg/ecosystems/testdata/fixtures/gradle/configuration-matching/settings.gradle
+++ b/pkg/ecosystems/testdata/fixtures/gradle/configuration-matching/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'configuration-matching-app'


### PR DESCRIPTION

- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### Summary

Implements the `--configuration-matching` flag to filter Gradle configurations using regex patterns. This allows users to limit dependency resolution to specific configurations (e.g., runtime-only, test-only, or exact matches).

### Implementation Approach

- **Go-side filtering**: Filters configurations after Gradle resolution but before dependency graph construction
- **Fail-fast validation**: Options are validated immediately upon plugin invocation, before any file discovery or Gradle execution
- **Regex support**: Full regex pattern support with clear error messages for invalid patterns

### Key Features

- Filter configurations by regex pattern (e.g., `(?i).*runtime.*` for all runtime configurations)
- Exact matching support (e.g., `^runtimeClasspath$`)
