### PR TITLE
feat: improve gradle plugin [CMPA-474]

### DIFF
--- a/pkg/ecosystems/gradle/README.md
+++ b/pkg/ecosystems/gradle/README.md
@@ -4,7 +4,7 @@
 
 This package implements a Gradle dependency graph resolver for the Snyk CLI ecosystem. It extracts complete dependency trees from Gradle projects using Gradle's native ResolutionResult API, producing dependency graphs that can be analysed for vulnerabilities and licence compliance.
 
-The resolver works by injecting a custom init script (`snyk-deps-init.gradle`) into Gradle builds, which programmatically walks the resolved dependency graph for each project and configuration, outputting structured JSON data that is then converted into Snyk's internal dependency graph format.
+The resolver works by injecting a custom init script (`snyk-deps-init.gradle`) into Gradle builds, which programmatically walks the resolved dependency graph for each project and configuration, outputting newline-delimited JSON (NDJSON) that is then converted into Snyk's internal dependency graph format.
 
 ## Design Decisions & Known Issues
 
@@ -111,16 +111,17 @@ This approach leverages Gradle's native multi-module handling whilst providing t
 
 ### Memory Optimisation
 
-The init script uses streaming JSON output to handle large projects efficiently:
-- Dependencies are written incrementally rather than accumulated in memory
-- Minimal data retention during graph traversal
+The init script uses NDJSON output to handle large projects efficiently:
+- Each subproject's dependencies are resolved and written by an isolated per-project task (`snykDependencyGraphProject`), then aggregated by the root `snykDependencyGraph` task
+- One JSON object per line — no in-memory accumulation of the full document
 - Suitable for projects with thousands of dependencies
 
 ### Execution Isolation
 
 Gradle execution uses several flags for predictable, isolated behaviour:
 - `--no-daemon`: Prevents state leakage between invocations
-- `--no-parallel`: Currently used but undesirable; planned improvements should remove this limitation to allow parallel execution for better performance, with particular benefits expected for `TargetFile` invocation scenarios
+
+Parallel project execution is safe because each `snykDependencyGraphProject` task writes to its own output file — there is no shared mutable state between subproject tasks. Projects that opt in to parallel execution via `org.gradle.parallel=true` in their `gradle.properties` will have that setting respected.
 
 `GRADLE_OPTS` configuration is left for invoking system to handle, following standard Gradle conventions rather than prescriptive memory tuning.
 

--- a/pkg/ecosystems/gradle/executor.go
+++ b/pkg/ecosystems/gradle/executor.go
@@ -13,12 +13,12 @@ import (
 
 const (
 	// snykDepsMarker is the prefix the init script prints on the line that
-	// contains the absolute path to the generated JSON output file.
-	snykDepsMarker = "SNYK_DEPS_JSON "
+	// contains the absolute path to the generated NDJSON output file.
+	snykDepsMarker = "SNYK_DEPS_NDJSON "
 )
 
 // runInitScript runs `gradle :snykDependencyGraph` with the embedded init script
-// and returns a ReadCloser for the generated JSON file.
+// and returns a ReadCloser for the generated NDJSON file.
 //
 // Always uses `:snykDependencyGraph` to run the task on the root project since
 // the task only exists at the root level.
@@ -26,12 +26,11 @@ const (
 // Fixed flags applied on every invocation:
 //
 //	--no-daemon          avoid background daemon processes
-//	--no-parallel        required for correctness on certain multi-project builds
 //	--console=plain      suppress progress animations that pollute output
 //	-Dorg.gradle.welcome=never       suppress "Welcome to Gradle" banner
 //
-// The returned ReadCloser must be closed by the caller. The JSON output is written
-// to <projectDir>/build/reports/snyk-dependency-graph.json with a fixed name, so it
+// The returned ReadCloser must be closed by the caller. The NDJSON output is written
+// to <projectDir>/build/reports/snyk-dependency-graph.ndjson with a fixed name, so it
 // is overwritten on each invocation rather than accumulating. It lives in Gradle's
 // build directory and is cleaned by `gradle clean` along with other build artifacts.
 // Preserved between runs as a debugging aid.
@@ -39,7 +38,6 @@ func runInitScript(ctx context.Context, projectDir, gradleBinary, initScriptPath
 	args := append([]string{
 		"--init-script", initScriptPath,
 		"--no-daemon",
-		"--no-parallel",
 		"--console=plain",
 		"-Dorg.gradle.welcome=never",
 		":snykDependencyGraph",
@@ -89,7 +87,7 @@ func runInitScript(ctx context.Context, projectDir, gradleBinary, initScriptPath
 }
 
 // parseSnykDepsMarkerFromStream scans Gradle's stdout stream for the line emitted by
-// the init script: "SNYK_DEPS_JSON /absolute/path/to/file.json".
+// the init script: "SNYK_DEPS_NDJSON /absolute/path/to/file.ndjson".
 // Returns the file path when found, empty string if not found, or an error if multiple
 // marker lines are detected (which could indicate tampering or malicious behavior).
 func parseSnykDepsMarkerFromStream(stdout io.Reader) (string, error) {
@@ -104,7 +102,7 @@ func parseSnykDepsMarkerFromStream(stdout io.Reader) (string, error) {
 		if strings.HasPrefix(line, snykDepsMarker) {
 			markerCount++
 			if markerCount > 1 {
-				return "", fmt.Errorf("multiple SNYK_DEPS_JSON marker lines detected, possible tampering attempt")
+				return "", fmt.Errorf("multiple SNYK_DEPS_NDJSON marker lines detected, possible tampering attempt")
 			}
 			foundPath = strings.TrimSpace(strings.TrimPrefix(line, snykDepsMarker))
 		}

--- a/pkg/ecosystems/gradle/executor_test.go
+++ b/pkg/ecosystems/gradle/executor_test.go
@@ -14,26 +14,26 @@ import (
 
 func TestParseSnykDepsMarkerFromStream(t *testing.T) {
 	t.Run("extracts path from marker line", func(t *testing.T) {
-		output := "some gradle output\nSNYK_DEPS_JSON /tmp/snyk-deps-12345.json\nmore output\n"
+		output := "some gradle output\nSNYK_DEPS_NDJSON /tmp/snyk-deps-12345.ndjson\nmore output\n"
 		result, err := parseSnykDepsMarkerFromStream(strings.NewReader(output))
 		require.NoError(t, err)
-		assert.Equal(t, "/tmp/snyk-deps-12345.json", result)
+		assert.Equal(t, "/tmp/snyk-deps-12345.ndjson", result)
 	})
 
 	t.Run("handles Windows-style path", func(t *testing.T) {
-		output := "SNYK_DEPS_JSON C:\\build\\reports\\snyk-dependency-graph.json\n"
+		output := "SNYK_DEPS_NDJSON C:\\build\\reports\\snyk-dependency-graph.ndjson\n"
 		result, err := parseSnykDepsMarkerFromStream(strings.NewReader(output))
 		require.NoError(t, err)
-		assert.Equal(t, `C:\build\reports\snyk-dependency-graph.json`, result)
+		assert.Equal(t, `C:\build\reports\snyk-dependency-graph.ndjson`, result)
 	})
 
 	t.Run("ignores leading and trailing whitespace on marker line", func(t *testing.T) {
 		// TrimSpace is applied to each line, so both leading and trailing
 		// whitespace are stripped before the prefix check and extraction.
-		output := "  SNYK_DEPS_JSON /tmp/file.json  \n"
+		output := "  SNYK_DEPS_NDJSON /tmp/file.ndjson  \n"
 		result, err := parseSnykDepsMarkerFromStream(strings.NewReader(output))
 		require.NoError(t, err)
-		assert.Equal(t, "/tmp/file.json", result)
+		assert.Equal(t, "/tmp/file.ndjson", result)
 	})
 
 	t.Run("returns empty string when marker is absent", func(t *testing.T) {
@@ -50,19 +50,19 @@ func TestParseSnykDepsMarkerFromStream(t *testing.T) {
 	})
 
 	t.Run("returns error when multiple marker lines detected", func(t *testing.T) {
-		output := "SNYK_DEPS_JSON /first.json\nSNYK_DEPS_JSON /second.json\n"
+		output := "SNYK_DEPS_NDJSON /first.ndjson\nSNYK_DEPS_NDJSON /second.ndjson\n"
 		result, err := parseSnykDepsMarkerFromStream(strings.NewReader(output))
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "multiple SNYK_DEPS_JSON marker lines detected")
+		assert.Contains(t, err.Error(), "multiple SNYK_DEPS_NDJSON marker lines detected")
 		assert.Contains(t, err.Error(), "possible tampering attempt")
 		assert.Empty(t, result)
 	})
 
 	t.Run("returns error even when multiple markers are separated by other output", func(t *testing.T) {
-		output := "Task :snykDependencyGraph\nSNYK_DEPS_JSON /first.json\nBUILD SUCCESSFUL\nSNYK_DEPS_JSON /second.json\nDone\n"
+		output := "Task :snykDependencyGraph\nSNYK_DEPS_NDJSON /first.ndjson\nBUILD SUCCESSFUL\nSNYK_DEPS_NDJSON /second.ndjson\nDone\n"
 		result, err := parseSnykDepsMarkerFromStream(strings.NewReader(output))
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "multiple SNYK_DEPS_JSON marker lines detected")
+		assert.Contains(t, err.Error(), "multiple SNYK_DEPS_NDJSON marker lines detected")
 		assert.Empty(t, result)
 	})
 }

--- a/pkg/ecosystems/gradle/init/snyk-deps-init.gradle
+++ b/pkg/ecosystems/gradle/init/snyk-deps-init.gradle
@@ -1,62 +1,69 @@
 // Snyk Dependency Extraction Init Script
 // Usage: gradle --init-script snyk-deps-init.gradle snykDependencyGraph
 //
-// Produces: build/reports/snyk-dependency-graph.json
+// Produces: build/reports/snyk-dependency-graph.ndjson
+//   Line 1:    metadata JSON object
+//   Lines 2+:  one project JSON object per line (newline-delimited JSON)
 //
 // Uses Gradle's ResolutionResult API (Gradle 4.4+) to programmatically
 // walk the resolved dependency graph per-project, per-configuration.
-// Output is clean JSON written directly to file — no stdout parsing needed.
 //
 // Compatibility: Gradle 5.0+ (uses fully qualified groovy.json.JsonOutput to avoid init script classloading issues)
-// Configuration Cache: Not compatible (streaming for memory efficiency on large projects)
+// Configuration Cache: Not compatible
 // Build Files: Auto-detects build.gradle and build.gradle.kts
-// Memory: Optimized for large projects (streaming JSON, minimal data retention)
 
 gradle.projectsEvaluated { g ->
     def root = g.rootProject
 
+    // One task per project, each writing to its own output file.
+    // Isolation makes parallel execution safe; snykDependencyGraph depends on all of these.
+    def perProjectTasks = root.allprojects.collect { proj ->
+        // Resolved at configuration time so outputs.file() can register it for up-to-date checking.
+        def outputFile = resolveReportsFile(proj, "snyk-project.ndjson")
+
+        proj.task('snykDependencyGraphProject') {
+            group = 'reporting'
+            description = "Snyk: resolve dependency graph for ${proj.path}"
+            outputs.file(outputFile)
+            try {
+                notCompatibleWithConfigurationCache("Snyk dependency resolution")
+            } catch (Exception ignored) {
+                // Older Gradle versions don't have this method
+            }
+            doLast {
+                outputFile.parentFile.mkdirs()
+                outputFile.text = groovy.json.JsonOutput.toJson(buildProjectEntry(proj))
+            }
+        }
+    }
+
+    def aggregateOutputFile = resolveReportsFile(root, "snyk-dependency-graph.ndjson")
+
     root.task('snykDependencyGraph') {
         group = 'reporting'
-        description = 'Generate machine-readable dependency graph JSON for all projects'
-
-        // Not configuration cache compatible due to streaming approach for memory efficiency
+        description = 'Snyk: aggregate dependency graph for all projects'
+        dependsOn perProjectTasks
+        // No outputs.file declared: this task must always run to print the SNYK_DEPS_NDJSON marker.
         try {
-            notCompatibleWithConfigurationCache("Streaming dependency resolution for large projects")
+            notCompatibleWithConfigurationCache("Snyk dependency resolution")
         } catch (Exception ignored) {
             // Older Gradle versions don't have this method
         }
-
         doLast {
-            // Compatible with Gradle 6-9: try new API first, fallback to deprecated API
-            def outputDir
-            try {
-                outputDir = root.layout.buildDirectory.dir("reports").get().asFile
-            } catch (Exception e) {
-                outputDir = file("${root.buildDir}/reports")
-            }
-            outputDir.mkdirs()
-            def outputFile = file("${outputDir}/snyk-dependency-graph.json")
-
-            // Stream JSON output to avoid memory accumulation for large projects
-            outputFile.withWriter('UTF-8') { writer ->
-                writer.print('{"metadata":')
-                writer.print(groovy.json.JsonOutput.toJson(buildMetadata(root)))
-                writer.print(',"projects":[')
-                def first = true
-                root.allprojects.each { proj ->
-                    def projEntry = buildProjectEntry(proj)
-                    if (projEntry != null) {
-                        if (!first) {
-                            writer.print(',')
-                        }
-                        writer.print(groovy.json.JsonOutput.toJson(projEntry))
-                        first = false
-                        projEntry = null  // Release memory immediately
+            aggregateOutputFile.parentFile.mkdirs()
+            aggregateOutputFile.withWriter('UTF-8') { writer ->
+                // Line 1: metadata
+                writer.println(groovy.json.JsonOutput.toJson(buildMetadata(root)))
+                // One line per project, read from each per-project task output then clean up
+                perProjectTasks.each { task ->
+                    def projectFile = task.outputs.files.singleFile
+                    if (projectFile.exists()) {
+                        writer.println(projectFile.text.trim())
+                        projectFile.delete()
                     }
                 }
-                writer.print(']}')
             }
-            println "SNYK_DEPS_JSON ${outputFile.absolutePath}"
+            println "SNYK_DEPS_NDJSON ${aggregateOutputFile.absolutePath}"
         }
     }
 }
@@ -231,4 +238,14 @@ def componentId(component) {
     }
     // Fallback for project components
     return component.id.toString()
+}
+
+// Returns <proj.buildDir>/reports/<fileName>. Uses layout API (Gradle 6+);
+// falls back to the deprecated buildDir property for Gradle 5.
+def resolveReportsFile(project, String fileName) {
+    try {
+        return new File(project.layout.buildDirectory.dir("reports").get().asFile, fileName)
+    } catch (Exception e) {
+        return new File(project.buildDir, "reports/${fileName}")
+    }
 }

--- a/pkg/ecosystems/gradle/parser.go
+++ b/pkg/ecosystems/gradle/parser.go
@@ -1,12 +1,15 @@
 package gradle
 
 import (
+	"bufio"
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
 )
 
 // dependencyGraphJSON is the top-level output produced by snyk-deps-init.gradle.
+// The file is NDJSON: line 1 is the metadata object, each subsequent line is one project.
 type dependencyGraphJSON struct {
 	Metadata struct {
 		GradleVersion string `json:"gradleVersion"`
@@ -85,12 +88,43 @@ type allDepEntry struct {
 	ID string `json:"id"`
 }
 
-// parseDependencyGraphJSON deserialises the JSON file produced by snyk-deps-init.gradle.
+// parseDependencyGraphJSON deserialises the NDJSON file produced by snyk-deps-init.gradle.
+// Line 1 is parsed as metadata; each subsequent non-blank line is parsed as a project.
 func parseDependencyGraphJSON(reader io.Reader) (*dependencyGraphJSON, error) {
+	scanner := bufio.NewScanner(reader)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024*1024) // 1GB max line size
+
 	var result dependencyGraphJSON
-	decoder := json.NewDecoder(reader)
-	if err := decoder.Decode(&result); err != nil {
-		return nil, fmt.Errorf("failed to parse snyk-deps-init.gradle output: %w", err)
+	var recordsRead int
+
+	for scanner.Scan() {
+		line := bytes.TrimSpace(scanner.Bytes())
+		if len(line) == 0 {
+			continue
+		}
+		recordsRead++
+
+		if recordsRead == 1 {
+			if err := json.Unmarshal(line, &result.Metadata); err != nil {
+				return nil, fmt.Errorf("failed to parse metadata line: %w", err)
+			}
+			continue
+		}
+
+		var proj gradleProject
+		if err := json.Unmarshal(line, &proj); err != nil {
+			return nil, fmt.Errorf("failed to parse project line %d: %w", recordsRead, err)
+		}
+		result.Projects = append(result.Projects, proj)
 	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("error reading NDJSON output: %w", err)
+	}
+
+	if recordsRead == 0 {
+		return nil, fmt.Errorf("NDJSON output is empty")
+	}
+
 	return &result, nil
 }

--- a/pkg/ecosystems/gradle/parser_test.go
+++ b/pkg/ecosystems/gradle/parser_test.go
@@ -12,45 +12,8 @@ import (
 
 func TestParseDependencyGraphJSON(t *testing.T) {
 	t.Run("parses valid JSON with a single project", func(t *testing.T) {
-		input := []byte(`{
-			"metadata": {
-				"gradleVersion": "8.5",
-				"javaVersion": "17.0.9",
-				"generatedAt": "2024-01-01T00:00:00Z",
-				"rootProject": {
-					"name": "my-app",
-					"group": "com.example",
-					"version": "1.0.0",
-					"path": "/projects/my-app"
-				}
-			},
-			"projects": [
-				{
-					"name": "my-app",
-					"group": "com.example",
-					"version": "1.0.0",
-					"path": ":",
-					"gav": "com.example:my-app:1.0.0",
-					"buildFile": "/projects/my-app/build.gradle",
-					"configurations": [
-						{
-							"name": "runtimeClasspath",
-							"description": "Runtime classpath",
-							"root": {
-								"id": "com.example:my-app:1.0.0",
-								"dependencies": [
-									{
-										"id": "com.google.guava:guava:32.1.2-jre",
-										"dependencies": []
-									}
-								]
-							},
-							"allDependencies": []
-						}
-					]
-				}
-			]
-		}`)
+		input := []byte(`{"gradleVersion":"8.5","javaVersion":"17.0.9","generatedAt":"2024-01-01T00:00:00Z","rootProject":{"name":"my-app","group":"com.example","version":"1.0.0","path":"/projects/my-app"}}
+{"name":"my-app","group":"com.example","version":"1.0.0","path":":","gav":"com.example:my-app:1.0.0","buildFile":"/projects/my-app/build.gradle","configurations":[{"name":"runtimeClasspath","description":"Runtime classpath","root":{"id":"com.example:my-app:1.0.0","dependencies":[{"id":"com.google.guava:guava:32.1.2-jre","dependencies":[]}]},"allDependencies":[]}]}`)
 
 		result, err := parseDependencyGraphJSON(bytes.NewReader(input))
 		require.NoError(t, err)
@@ -74,13 +37,9 @@ func TestParseDependencyGraphJSON(t *testing.T) {
 	})
 
 	t.Run("parses multiple projects", func(t *testing.T) {
-		input := []byte(`{
-			"metadata": {"gradleVersion": "8.5", "javaVersion": "17", "generatedAt": "", "rootProject": {"name": "root", "group": "", "version": "", "path": ""}},
-			"projects": [
-				{"name": "root", "group": "com.example", "version": "1.0", "path": ":", "gav": "com.example:root:1.0", "buildFile": "", "configurations": []},
-				{"name": "app", "group": "com.example", "version": "1.0", "path": ":app", "gav": "com.example:app:1.0", "buildFile": "", "configurations": []}
-			]
-		}`)
+		input := []byte(`{"gradleVersion":"8.5","javaVersion":"17","generatedAt":"","rootProject":{"name":"root","group":"","version":"","path":""}}
+{"name":"root","group":"com.example","version":"1.0","path":":","gav":"com.example:root:1.0","buildFile":"","configurations":[]}
+{"name":"app","group":"com.example","version":"1.0","path":":app","gav":"com.example:app:1.0","buildFile":"","configurations":[]}`)
 
 		result, err := parseDependencyGraphJSON(bytes.NewReader(input))
 		require.NoError(t, err)
@@ -100,29 +59,8 @@ func TestParseDependencyGraphJSON(t *testing.T) {
 	})
 
 	t.Run("parses pruned and unresolved dependencies", func(t *testing.T) {
-		input := []byte(`{
-			"metadata": {"gradleVersion": "8.5", "javaVersion": "17", "generatedAt": "", "rootProject": {"name": "root", "group": "", "version": "", "path": ""}},
-			"projects": [
-				{
-					"name": "root", "group": "com.example", "version": "1.0", "path": ":", "gav": "com.example:root:1.0", "buildFile": "",
-					"configurations": [
-						{
-							"name": "runtimeClasspath",
-							"description": "",
-							"root": {
-								"id": "com.example:root:1.0",
-								"dependencies": [
-									{"id": "com.example:a:1.0", "pruned": "cycle", "dependencies": []},
-									{"id": "com.example:b:1.0", "pruned": "visited", "dependencies": []},
-									{"id": "com.example:c:1.0", "unresolved": true, "reason": "not found", "dependencies": []}
-								]
-							},
-							"allDependencies": []
-						}
-					]
-				}
-			]
-		}`)
+		input := []byte(`{"gradleVersion":"8.5","javaVersion":"17","generatedAt":"","rootProject":{"name":"root","group":"","version":"","path":""}}
+{"name":"root","group":"com.example","version":"1.0","path":":","gav":"com.example:root:1.0","buildFile":"","configurations":[{"name":"runtimeClasspath","description":"","root":{"id":"com.example:root:1.0","dependencies":[{"id":"com.example:a:1.0","pruned":"cycle","dependencies":[]},{"id":"com.example:b:1.0","pruned":"visited","dependencies":[]},{"id":"com.example:c:1.0","unresolved":true,"reason":"not found","dependencies":[]}]},"allDependencies":[]}]}`)
 
 		result, err := parseDependencyGraphJSON(bytes.NewReader(input))
 		require.NoError(t, err)
@@ -137,17 +75,8 @@ func TestParseDependencyGraphJSON(t *testing.T) {
 	})
 
 	t.Run("parses configuration error field", func(t *testing.T) {
-		input := []byte(`{
-			"metadata": {"gradleVersion": "8.5", "javaVersion": "17", "generatedAt": "", "rootProject": {"name": "root", "group": "", "version": "", "path": ""}},
-			"projects": [
-				{
-					"name": "root", "group": "", "version": "1.0", "path": ":", "gav": ":root:1.0", "buildFile": "",
-					"configurations": [
-						{"name": "brokenConfig", "description": "", "root": {"id": "", "dependencies": []}, "allDependencies": [], "error": "resolution failed"}
-					]
-				}
-			]
-		}`)
+		input := []byte(`{"gradleVersion":"8.5","javaVersion":"17","generatedAt":"","rootProject":{"name":"root","group":"","version":"","path":""}}
+{"name":"root","group":"","version":"1.0","path":":","gav":":root:1.0","buildFile":"","configurations":[{"name":"brokenConfig","description":"","root":{"id":"","dependencies":[]},"allDependencies":[],"error":"resolution failed"}]}`)
 
 		result, err := parseDependencyGraphJSON(bytes.NewReader(input))
 		require.NoError(t, err)
@@ -166,5 +95,12 @@ func TestParseDependencyGraphJSON(t *testing.T) {
 	t.Run("returns error for empty input", func(t *testing.T) {
 		_, err := parseDependencyGraphJSON(bytes.NewReader([]byte(``)))
 		require.Error(t, err)
+		assert.Contains(t, err.Error(), "NDJSON output is empty")
+	})
+
+	t.Run("returns error for file with only blank lines", func(t *testing.T) {
+		_, err := parseDependencyGraphJSON(bytes.NewReader([]byte("\n\n\n")))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "NDJSON output is empty")
 	})
 }

--- a/pkg/ecosystems/gradle/plugin.go
+++ b/pkg/ecosystems/gradle/plugin.go
@@ -49,8 +49,7 @@ func (p Plugin) GetName() string {
 //     passed to Gradle via --init-script (required for dependency graph generation).
 //     Users can provide additional init scripts via --init-script which are passed
 //     as supplementary --init-script flags.
-//   - The Gradle invocation always uses --no-daemon, --no-parallel for predictable,
-//     isolated execution.
+//   - The Gradle invocation always uses --no-daemon for predictable, isolated execution.
 //   - The init script traverses all sub-projects automatically; each sub-project
 //     yields one SCAResult.  Use --gradle-sub-project to filter to a single one.
 func (p Plugin) BuildDepGraphsFromDir(

--- a/pkg/ecosystems/gradle/plugin_test.go
+++ b/pkg/ecosystems/gradle/plugin_test.go
@@ -395,97 +395,13 @@ func TestTargetFileFiltering_MockedOutput(t *testing.T) {
 	log := logger.Nop()
 	p := Plugin{}
 
-	// Simulate the JSON that would be returned by Gradle's :snykDependencyGraph task
-	// This represents a multi-project build with root, app, and lib subprojects
-	mockMultiProjectJSON := `{
-  "metadata": {
-    "gradleVersion": "8.0",
-    "javaVersion": "17.0.1",
-    "generatedAt": "2023-01-01T12:00:00Z",
-    "rootProject": {
-      "name": "myproject",
-      "group": "com.example",
-      "version": "1.0.0",
-      "path": "/project"
-    }
-  },
-  "projects": [
-    {
-      "name": "myproject",
-      "group": "com.example",
-      "version": "1.0.0",
-      "path": ":",
-      "gav": "com.example:myproject:1.0.0",
-      "buildFile": "/project/build.gradle",
-      "plugins": ["java"],
-      "configurations": [
-        {
-          "name": "compileClasspath",
-          "description": "Compile classpath",
-          "root": {
-            "id": "com.example:myproject:1.0.0",
-            "dependencies": []
-          },
-          "allDependencies": []
-        }
-      ]
-    },
-    {
-      "name": "app",
-      "group": "com.example",
-      "version": "1.0.0",
-      "path": ":app",
-      "gav": "com.example:app:1.0.0",
-      "buildFile": "/project/app/build.gradle",
-      "plugins": ["java", "application"],
-      "configurations": [
-        {
-          "name": "compileClasspath",
-          "description": "Compile classpath",
-          "root": {
-            "id": "com.example:app:1.0.0",
-            "dependencies": [
-              {
-                "id": "org.slf4j:slf4j-api:1.7.36",
-                "dependencies": []
-              }
-            ]
-          },
-          "allDependencies": [
-            { "id": "org.slf4j:slf4j-api:1.7.36" }
-          ]
-        }
-      ]
-    },
-    {
-      "name": "lib",
-      "group": "com.example", 
-      "version": "1.0.0",
-      "path": ":lib",
-      "gav": "com.example:lib:1.0.0",
-      "buildFile": "/project/lib/build.gradle",
-      "plugins": ["java-library"],
-      "configurations": [
-        {
-          "name": "compileClasspath",
-          "description": "Compile classpath",
-          "root": {
-            "id": "com.example:lib:1.0.0",
-            "dependencies": [
-              {
-                "id": "com.google.guava:guava:31.1-jre",
-                "dependencies": []
-              }
-            ]
-          },
-          "allDependencies": [
-            { "id": "com.google.guava:guava:31.1-jre" }
-          ]
-        }
-      ]
-    }
-  ]
-}`
+	// Simulate the NDJSON that would be returned by Gradle's :snykDependencyGraph task.
+	// This represents a multi-project build with root, app, and lib subprojects.
+	// Line 1: metadata; lines 2-4: one project per line.
+	mockMultiProjectJSON := `{"gradleVersion":"8.0","javaVersion":"17.0.1","generatedAt":"2023-01-01T12:00:00Z","rootProject":{"name":"myproject","group":"com.example","version":"1.0.0","path":"/project"}}
+{"name":"myproject","group":"com.example","version":"1.0.0","path":":","gav":"com.example:myproject:1.0.0","buildFile":"/project/build.gradle","configurations":[{"name":"compileClasspath","description":"Compile classpath","root":{"id":"com.example:myproject:1.0.0","dependencies":[]},"allDependencies":[]}]}
+{"name":"app","group":"com.example","version":"1.0.0","path":":app","gav":"com.example:app:1.0.0","buildFile":"/project/app/build.gradle","configurations":[{"name":"compileClasspath","description":"Compile classpath","root":{"id":"com.example:app:1.0.0","dependencies":[{"id":"org.slf4j:slf4j-api:1.7.36","dependencies":[]}]},"allDependencies":[{"id":"org.slf4j:slf4j-api:1.7.36"}]}]}
+{"name":"lib","group":"com.example","version":"1.0.0","path":":lib","gav":"com.example:lib:1.0.0","buildFile":"/project/lib/build.gradle","configurations":[{"name":"compileClasspath","description":"Compile classpath","root":{"id":"com.example:lib:1.0.0","dependencies":[{"id":"com.google.guava:guava:31.1-jre","dependencies":[]}]},"allDependencies":[{"id":"com.google.guava:guava:31.1-jre"}]}]}`
 
 	t.Run("demonstrates multi-project output gets filtered to single project", func(t *testing.T) {
 		// Parse the mock JSON as if it came from Gradle


### PR DESCRIPTION
### What this does
This PR improves the Gradle plugin by doing the following:

- Removes `--no-parallel` by restructuring the init script to register an isolated `snykDependencyGraphProject` task per subproject, each writing to its own output file.
- Replaces manually constructed JSON  with NDJSON (one JSON object per line) 

**Jira Ticket** 
[CMPA-474](https://snyksec.atlassian.net/jira/software/c/projects/CMPA/boards/5466?assignee=60162bfac8c36c00698fa2d4&assignee=712020%3A49137baf-8ad3-4bd9-8afd-fb1ab9f5ab8a&selectedIssue=CMPA-474)


[CMPA-474]: https://snyksec.atlassian.net/browse/CMPA-474?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ