### PR TITLE
feat: [CMPA-543] Adjusts gradle resolver output to be unpruned DAG

### DIFF
--- a/pkg/ecosystems/gradle/README.md
+++ b/pkg/ecosystems/gradle/README.md
@@ -59,9 +59,11 @@ This results in both versions appearing in the merged graph, potentially causing
 
 **Future considerations**: Per-configuration filtering will likely be added when feature parity work begins, allowing clients to request specific configuration scopes.
 
-#### Edge deduplication and ordering
+#### Edge deduplication and DAG structure
 
 When the same `(parent, child)` edge is contributed by more than one configuration (for example a direct dependency that appears in `compileClasspath`, `runtimeClasspath`, `testCompileClasspath` and `testRuntimeClasspath`), the merged graph contains the edge **exactly once** rather than once per contributing configuration. The dep-graph schema treats each parent's `Deps` as a set of edges, so multi-edges would be schema violations and would inflate downstream vulnerable-path counts.
+
+The resolver produces a **directed acyclic graph (DAG)** where shared dependencies appear as single nodes with multiple parents, rather than duplicated as separate "pruned" nodes. This provides accurate representation of the actual dependency structure where the same component can be reached through different dependency paths.
 
 Configurations are walked in **Gradle's natural evaluation order**, preserving the sequence that Gradle itself uses during dependency resolution. When the same edge appears in multiple configurations, its position in the parent's `Deps` slice is taken from the first configuration in evaluation order that contributes it. This makes the merged graph deterministic across runs and across JDK / Gradle versions, and crucially means that cross-configuration edge ordering **is semantically meaningful** — it reflects Gradle's actual dependency processing sequence rather than arbitrary alphabetical sorting. This provides more accurate representation for clients that need declaration order semantics (for example, to surface the most relevant "nearest" path for a CVE), though `--configuration-matching` will still be valuable for configuration-specific analysis once that lands.
 
@@ -79,6 +81,17 @@ The resolver currently does not capture or report Maven classifiers at all. Depe
 **Implementation**: The init script extracts dependency IDs using `${group}:${name}:${version}` format only. Artifacts with classifiers (e.g., `commons-io:commons-io:2.6:sources`) are treated identically to their main artifacts, potentially causing different classifier variants to be merged in the dependency graph.
 
 This limitation should be addressed if classifier-specific vulnerabilities become relevant or if upstream services begin requiring classifier information for accurate analysis.
+
+### Constraint Edge Handling
+
+**Constraint vs artifact dependencies**
+
+The resolver distinguishes between **constraint edges** (which influence version selection) and **artifact edges** (which represent actual dependencies that appear in classpaths):
+
+- **Constraint sources**: Platform BOMs (`implementation platform(...)`), dependency locking (`gradle.lockfile`), explicit constraints (`constraints {}` blocks)
+- **Representation**: Constraint edges appear as separate nodes with a `:constraint` suffix and appropriate labels, allowing consumers to distinguish them from real artifact dependencies
+
+This separation prevents constraint-derived edges from interfering with the actual dependency graph structure while preserving diagnostic information about what constraints influenced version resolution.
 
 ## Technical Implementation Notes
 

--- a/pkg/ecosystems/gradle/depgraph.go
+++ b/pkg/ecosystems/gradle/depgraph.go
@@ -99,15 +99,16 @@ func buildDepGraph(proj *gradleProject, options *ecosystems.SCAPluginOptions) (*
 // DFS spanning tree of the resolved dependency DAG: each component's children
 // appear under exactly one parent per configuration; every subsequent
 // reference to the same component is emitted with `pruned: "visited"` or
-// `pruned: "cycle"` and no children.  We mirror that shape here:
+// `pruned: "cycle"` and no children.  We produce a DAG by handling pruning as:
 //
 //   - `processed` records every component we've already expanded in this
 //     configuration so a malformed input that includes the same expanded
 //     subtree twice would still be walked at most once.
-//   - Components flagged with any `pruned` value by the init script (or already in
-//     `processed`) become labeled `pruned` leaves so the tree shape matches
-//     `gradle dependencies` text output and downstream "vulnerable path"
-//     counts remain meaningful.
+//   - Components flagged with `pruned: "cycle"` become labeled `pruned` leaves
+//     to maintain the DAG property and avoid infinite recursion.
+//   - Components flagged with `pruned: "visited"` (or already in `processed`)
+//     are connected to their existing node instead of creating pruned nodes,
+//     allowing multiple parents while avoiding infinite recursion.
 //
 // connectOnce wraps depgraph.Builder.ConnectNodes with deduplication so that
 // the same (parent, child) edge is only added once across the entire merged
@@ -119,8 +120,8 @@ func addDep(builder *depgraph.Builder, dep *gradleDep, parentID string, processe
 
 	nodeID, name, version := depNodeParts(dep.ID)
 
-	if dep.Pruned.IsPruned() || processed[nodeID] {
-		// Record a pruned leaf so the dep-graph is still complete, but avoid
+	if dep.Pruned == pruneCycle {
+		// Record a pruned leaf for cycles to maintain DAG property and avoid
 		// infinite recursion.
 		prunedID := nodeID + ":pruned"
 		builder.AddNode(prunedID, &depgraph.PkgInfo{Name: name, Version: version},
@@ -129,6 +130,11 @@ func addDep(builder *depgraph.Builder, dep *gradleDep, parentID string, processe
 			}),
 		)
 		return connectOnce(parentID, prunedID)
+	} else if dep.Pruned == pruneVisited || processed[nodeID] {
+		// For visited nodes, connect to the existing node instead of creating
+		// a pruned version. This produces a DAG where nodes can have multiple
+		// parents but no cycles.
+		return connectOnce(parentID, nodeID)
 	}
 
 	builder.AddNode(nodeID, &depgraph.PkgInfo{Name: name, Version: version})

--- a/pkg/ecosystems/gradle/depgraph.go
+++ b/pkg/ecosystems/gradle/depgraph.go
@@ -109,6 +109,10 @@ func buildDepGraph(proj *gradleProject, options *ecosystems.SCAPluginOptions) (*
 //   - Components flagged with `pruned: "visited"` (or already in `processed`)
 //     are connected to their existing node instead of creating pruned nodes,
 //     allowing multiple parents while avoiding infinite recursion.
+//   - Components flagged with `constraint: true` (from platform BOMs, dependency
+//     locking, or constraints {} blocks) become labeled `constraint` leaves
+//     with a `:constraint` node-ID suffix. They do not affect `processed`, so a
+//     real edge to the same component will still be expanded normally.
 //
 // connectOnce wraps depgraph.Builder.ConnectNodes with deduplication so that
 // the same (parent, child) edge is only added once across the entire merged
@@ -119,6 +123,20 @@ func addDep(builder *depgraph.Builder, dep *gradleDep, parentID string, processe
 	}
 
 	nodeID, name, version := depNodeParts(dep.ID)
+
+	if dep.Constraint {
+		// Constraint edges are a separate node so consumers can distinguish
+		// version-influencing constraints from real artifact dependencies.
+		// Do not mark `processed` — the real edge to this component (if any)
+		// must still be expanded fully.
+		constraintID := nodeID + ":constraint"
+		builder.AddNode(constraintID, &depgraph.PkgInfo{Name: name, Version: version},
+			depgraph.WithNodeInfo(&depgraph.NodeInfo{
+				Labels: map[string]string{"constraint": "true"},
+			}),
+		)
+		return connectOnce(parentID, constraintID)
+	}
 
 	if dep.Pruned == pruneCycle {
 		// Record a pruned leaf for cycles to maintain DAG property and avoid

--- a/pkg/ecosystems/gradle/depgraph_test.go
+++ b/pkg/ecosystems/gradle/depgraph_test.go
@@ -170,6 +170,95 @@ func TestBuildDepGraph(t *testing.T) {
 		assert.True(t, ids["com.google.guava:guava@32.1.2-jre"], "resolved dep should be present")
 	})
 
+	t.Run("renders constraint dependencies as labelled :constraint leaves", func(t *testing.T) {
+		// Constraint edges (from platform BOMs, dependency locking, constraints {}
+		// blocks) should appear as a separate suffixed node so consumers can
+		// distinguish them from real artifact dependencies.
+		proj := makeProject("com.example", "app", "1.0.0", []gradleConfig{
+			makeConfig("runtimeClasspath", "com.example:app:1.0.0", []gradleDep{
+				{ID: "com.google.code.gson:gson:2.8.2", Constraint: true},
+			}),
+		})
+
+		dg, err := buildDepGraph(&proj, nil)
+		require.NoError(t, err)
+
+		ids := nodeIDSet(dg)
+		assert.True(t, ids["com.google.code.gson:gson@2.8.2:constraint"], "constraint dep should appear as :constraint node")
+		assert.False(t, ids["com.google.code.gson:gson@2.8.2"], "constraint-only dep should not also appear as a normal node")
+
+		constraintNode := findNodeByID(t, dg, "com.google.code.gson:gson@2.8.2:constraint")
+		require.NotNil(t, constraintNode.Info)
+		assert.Equal(t, "true", constraintNode.Info.Labels["constraint"])
+	})
+
+	t.Run("constraint nodes are leaves and do not recurse", func(t *testing.T) {
+		// Even if the init script were to (incorrectly) attach children to a
+		// constraint node, addDep should not walk them — constraint edges are
+		// always treated as leaves.
+		proj := makeProject("com.example", "app", "1.0.0", []gradleConfig{
+			makeConfig("runtimeClasspath", "com.example:app:1.0.0", []gradleDep{
+				{
+					ID:         "com.google.code.gson:gson:2.8.2",
+					Constraint: true,
+					Dependencies: []gradleDep{
+						makeDep("should.not.appear:child:1.0.0"),
+					},
+				},
+			}),
+		})
+
+		dg, err := buildDepGraph(&proj, nil)
+		require.NoError(t, err)
+
+		ids := nodeIDSet(dg)
+		assert.True(t, ids["com.google.code.gson:gson@2.8.2:constraint"])
+		assert.False(t, ids["should.not.appear:child@1.0.0"], "constraint nodes must not recurse")
+	})
+
+	t.Run("constraint edge does not poison visited set for real edge to same component", func(t *testing.T) {
+		// Regression for the platform-BOM / lock-file case: a constraint edge
+		// to module X must not cause a subsequent real edge to X to be treated
+		// as already-visited. The real edge must still expand its full subtree.
+		proj := makeProject("com.example", "app", "1.0.0", []gradleConfig{
+			makeConfig("runtimeClasspath", "com.example:app:1.0.0", []gradleDep{
+				{ID: "dom4j:dom4j:1.6.1", Constraint: true},
+				makeDep("dom4j:dom4j:1.6.1", makeDep("xml-apis:xml-apis:1.4.01")),
+			}),
+		})
+
+		dg, err := buildDepGraph(&proj, nil)
+		require.NoError(t, err)
+
+		ids := nodeIDSet(dg)
+		assert.True(t, ids["dom4j:dom4j@1.6.1:constraint"], "constraint edge should produce :constraint node")
+		assert.True(t, ids["dom4j:dom4j@1.6.1"], "real edge should still produce normal node")
+		assert.True(t, ids["xml-apis:xml-apis@1.4.01"], "real edge subtree must expand fully")
+
+		dom4jNode := findNodeByID(t, dg, "dom4j:dom4j@1.6.1")
+		assert.Equal(t, 1, countEdgesTo(dom4jNode, "xml-apis:xml-apis@1.4.01"),
+			"transitive child should be reachable via the real (non-constraint) parent")
+	})
+
+	t.Run("preserves emission order for mixed constraint and real edges", func(t *testing.T) {
+		// When a parent has both constraint and real edges, their order in the
+		// resulting Deps slice should match the input order from the init script.
+		proj := makeProject("com.example", "app", "1.0.0", []gradleConfig{
+			makeConfig("runtimeClasspath", "com.example:app:1.0.0", []gradleDep{
+				{ID: "com.example:locked:1.0.0", Constraint: true},
+				makeDep("com.example:real:1.0.0"),
+			}),
+		})
+
+		dg, err := buildDepGraph(&proj, nil)
+		require.NoError(t, err)
+
+		rootNode := findNodeByID(t, dg, "root-node")
+		require.Len(t, rootNode.Deps, 2)
+		assert.Equal(t, "com.example:locked@1.0.0:constraint", rootNode.Deps[0].NodeID)
+		assert.Equal(t, "com.example:real@1.0.0", rootNode.Deps[1].NodeID)
+	})
+
 	t.Run("skips configurations with errors", func(t *testing.T) {
 		proj := makeProject("com.example", "app", "1.0.0", []gradleConfig{
 			{Name: "runtimeClasspath", Error: "resolution failed"},

--- a/pkg/ecosystems/gradle/depgraph_test.go
+++ b/pkg/ecosystems/gradle/depgraph_test.go
@@ -126,10 +126,13 @@ func TestBuildDepGraph(t *testing.T) {
 		assert.False(t, ids["com.example:a@1.0.0"], "cycle-pruned dep should not appear as normal node")
 	})
 
-	t.Run("handles visited-pruned dependencies as pruned nodes", func(t *testing.T) {
+	t.Run("handles visited-pruned dependencies by connecting to existing nodes", func(t *testing.T) {
+		// Test that visited-pruned dependencies connect to existing nodes instead of creating pruned versions.
+		// We simulate a case where a node is expanded under one parent and then referenced as pruned under another.
 		proj := makeProject("com.example", "app", "1.0.0", []gradleConfig{
 			makeConfig("runtimeClasspath", "com.example:app:1.0.0", []gradleDep{
-				{ID: "com.example:b:2.0.0", Pruned: pruneVisited},
+				makeDep("com.example:a:1.0.0", makeDep("com.example:shared:1.0.0")),                             // First occurrence - creates the node
+				makeDep("com.example:b:1.0.0", gradleDep{ID: "com.example:shared:1.0.0", Pruned: pruneVisited}), // Second occurrence - should connect to existing
 			}),
 		})
 
@@ -137,8 +140,18 @@ func TestBuildDepGraph(t *testing.T) {
 		require.NoError(t, err)
 
 		ids := nodeIDSet(dg)
-		assert.True(t, ids["com.example:b@2.0.0:pruned"], "visited-pruned dep should appear as pruned node")
-		assert.False(t, ids["com.example:b@2.0.0"], "visited-pruned dep should not appear as normal node")
+		assert.True(t, ids["com.example:shared@1.0.0"], "visited-pruned dep should connect to existing node")
+		assert.False(t, ids["com.example:shared@1.0.0:pruned"], "visited-pruned dep should not create pruned node")
+
+		// Verify the shared node has two different parents
+		aNode := findNodeByID(t, dg, "com.example:a@1.0.0")
+		bNode := findNodeByID(t, dg, "com.example:b@1.0.0")
+
+		sharedEdgesFromA := countEdgesTo(aNode, "com.example:shared@1.0.0")
+		sharedEdgesFromB := countEdgesTo(bNode, "com.example:shared@1.0.0")
+
+		assert.Equal(t, 1, sharedEdgesFromA, "a should reference shared node once")
+		assert.Equal(t, 1, sharedEdgesFromB, "b should reference the same shared node")
 	})
 
 	t.Run("skips unresolved dependencies", func(t *testing.T) {
@@ -202,10 +215,11 @@ func TestBuildDepGraph(t *testing.T) {
 		assert.Equal(t, "", dg.Pkgs[0].Info.Version)
 	})
 
-	t.Run("prunes subsequent references to same dependency per configuration", func(t *testing.T) {
+	t.Run("connects subsequent references to same dependency per configuration", func(t *testing.T) {
 		// This test simulates the common case where two parents reference the same child.
 		// The init script would emit the child's full subtree under the first parent and
-		// mark subsequent references as pruned: "visited".
+		// mark subsequent references as pruned: "visited". With DAG behavior, we connect
+		// to the existing node instead of creating pruned versions.
 		proj := makeProject("com.example", "app", "1.0.0", []gradleConfig{
 			makeConfig("runtimeClasspath", "com.example:app:1.0.0", []gradleDep{
 				makeDep("com.example:a:1.0.0", makeDep("com.example:c:1.0.0")),
@@ -217,8 +231,18 @@ func TestBuildDepGraph(t *testing.T) {
 		require.NoError(t, err)
 
 		ids := nodeIDSet(dg)
-		assert.True(t, ids["com.example:c@1.0.0"], "first occurrence should appear as normal node")
-		assert.True(t, ids["com.example:c@1.0.0:pruned"], "subsequent occurrence should appear as pruned node")
+		assert.True(t, ids["com.example:c@1.0.0"], "dependency should appear as normal node")
+		assert.False(t, ids["com.example:c@1.0.0:pruned"], "should not create pruned version for visited nodes")
+
+		// Verify both parents reference the same node
+		aNode := findNodeByID(t, dg, "com.example:a@1.0.0")
+		bNode := findNodeByID(t, dg, "com.example:b@1.0.0")
+
+		cEdgesFromA := countEdgesTo(aNode, "com.example:c@1.0.0")
+		cEdgesFromB := countEdgesTo(bNode, "com.example:c@1.0.0")
+
+		assert.Equal(t, 1, cEdgesFromA, "a should reference c once")
+		assert.Equal(t, 1, cEdgesFromB, "b should reference the same c node")
 	})
 
 	t.Run("preserves different versions of same transitive dependency across configurations", func(t *testing.T) {

--- a/pkg/ecosystems/gradle/init/snyk-deps-init.gradle
+++ b/pkg/ecosystems/gradle/init/snyk-deps-init.gradle
@@ -160,7 +160,20 @@ def walkDependencies(component, Set<String> processed, Set<String> ancestry) {
             // ResolvedDependencyResult
             def id = componentId(selected)
 
-            if (ancestry.contains(id)) {
+            // Constraint edges originate from platform BOMs, dependency locking, and
+            // explicit constraints {} blocks. They influence version selection but do
+            // not represent real artifact dependencies. Emit them as leaves and do not
+            // recurse, mark the target as visited, or affect ancestry — otherwise a
+            // real edge to the same component would be incorrectly reported as
+            // pruned: visited. Property check guards against older Gradle versions
+            // (pre-4.6) where DependencyResult.isConstraint() does not exist.
+            def isConstraintEdge = dep.hasProperty('constraint') && dep.constraint
+            if (isConstraintEdge) {
+                children << [
+                    id        : id,
+                    constraint: true,
+                ]
+            } else if (ancestry.contains(id)) {
                 // True cycle — this component is on the current ancestor chain
                 children << [
                     id    : id,

--- a/pkg/ecosystems/gradle/parser.go
+++ b/pkg/ecosystems/gradle/parser.go
@@ -75,9 +75,15 @@ func (p pruneReason) IsPruned() bool {
 }
 
 // gradleDep is one node in the resolved dependency tree.
+//
+// Constraint edges originate from platform BOMs, dependency locking, and
+// explicit constraints {} blocks. They influence version selection but do not
+// represent real artifact dependencies, and the init script always emits them
+// as leaves (no Dependencies, no Pruned).
 type gradleDep struct {
 	ID           string      `json:"id"`
 	Pruned       pruneReason `json:"pruned,omitempty"`
+	Constraint   bool        `json:"constraint,omitempty"`
 	Unresolved   bool        `json:"unresolved,omitempty"`
 	Reason       string      `json:"reason,omitempty"`
 	Dependencies []gradleDep `json:"dependencies"`

--- a/pkg/ecosystems/gradle/parser_test.go
+++ b/pkg/ecosystems/gradle/parser_test.go
@@ -58,20 +58,23 @@ func TestParseDependencyGraphJSON(t *testing.T) {
 		assert.True(t, foundApp, "should contain app project")
 	})
 
-	t.Run("parses pruned and unresolved dependencies", func(t *testing.T) {
+	t.Run("parses pruned, constraint and unresolved dependencies", func(t *testing.T) {
 		input := []byte(`{"gradleVersion":"8.5","javaVersion":"17","generatedAt":"","rootProject":{"name":"root","group":"","version":"","path":""}}
-{"name":"root","group":"com.example","version":"1.0","path":":","gav":"com.example:root:1.0","buildFile":"","configurations":[{"name":"runtimeClasspath","description":"","root":{"id":"com.example:root:1.0","dependencies":[{"id":"com.example:a:1.0","pruned":"cycle","dependencies":[]},{"id":"com.example:b:1.0","pruned":"visited","dependencies":[]},{"id":"com.example:c:1.0","unresolved":true,"reason":"not found","dependencies":[]}]},"allDependencies":[]}]}`)
+{"name":"root","group":"com.example","version":"1.0","path":":","gav":"com.example:root:1.0","buildFile":"","configurations":[{"name":"runtimeClasspath","description":"","root":{"id":"com.example:root:1.0","dependencies":[{"id":"com.example:a:1.0","pruned":"cycle","dependencies":[]},{"id":"com.example:b:1.0","pruned":"visited","dependencies":[]},{"id":"com.example:c:1.0","unresolved":true,"reason":"not found","dependencies":[]},{"id":"com.example:d:1.0","constraint":true}]},"allDependencies":[]}]}`)
 
 		result, err := parseDependencyGraphJSON(bytes.NewReader(input))
 		require.NoError(t, err)
 
 		deps := result.Projects[0].Configurations[0].Root.Dependencies
-		require.Len(t, deps, 3)
+		require.Len(t, deps, 4)
 		assert.Equal(t, pruneCycle, deps[0].Pruned)
 		assert.Equal(t, pruneVisited, deps[1].Pruned)
 		assert.True(t, deps[2].Pruned.IsEmpty())
 		assert.True(t, deps[2].Unresolved)
 		assert.Equal(t, "not found", deps[2].Reason)
+		assert.True(t, deps[3].Constraint)
+		assert.True(t, deps[3].Pruned.IsEmpty())
+		assert.False(t, deps[3].Unresolved)
 	})
 
 	t.Run("parses configuration error field", func(t *testing.T) {

--- a/pkg/ecosystems/gradle/plugin_integration_test.go
+++ b/pkg/ecosystems/gradle/plugin_integration_test.go
@@ -91,6 +91,28 @@ func pluginTestCases() map[string]PluginTestCase {
 			Fixture: "platform-bom",
 			Options: ecosystems.NewPluginOptions(),
 		},
+		// Exercises the `constraints {}` DSL: pins the resolved version of a
+		// transitive dep without declaring a real edge. Asserts the constraint
+		// edge surfaces as a `:constraint`-suffixed leaf and does not poison
+		// the visited set for the real transitive edge to the same module.
+		"dependency_constraints": {
+			Fixture: "dependency-constraints",
+			Options: ecosystems.NewPluginOptions(),
+		},
+		// Regression fixture for resolutionStrategy.force. `force` is a
+		// version-selection rule, not a constraint edge — the forced module
+		// must appear as a normal node, never as a `:constraint` leaf.
+		"version_forcing": {
+			Fixture: "version-forcing",
+			Options: ecosystems.NewPluginOptions(),
+		},
+		// Regression fixture for dependencySubstitution. Substitution replaces
+		// the target component on an existing edge — the substituted module
+		// must appear as a normal node, never as a `:constraint` leaf.
+		"dependency_substitution": {
+			Fixture: "dependency-substitution",
+			Options: ecosystems.NewPluginOptions(),
+		},
 		// Smoke test that the Kotlin DSL build file (build.gradle.kts) is
 		// discovered and resolved equivalently to its Groovy counterpart.
 		"kts_simple": {

--- a/pkg/ecosystems/gradle/plugin_integration_test.go
+++ b/pkg/ecosystems/gradle/plugin_integration_test.go
@@ -173,6 +173,20 @@ func pluginTestCases() map[string]PluginTestCase {
 			Options:      ecosystems.NewPluginOptions().WithGradleConfigurationMatching("^runtimeClasspath$"),
 			ExpectedFile: "expected_plugin_exact_runtime.json",
 		},
+		// Exercises nested BOM resolution with complex constraint hierarchy.
+		// Validates that imported BOMs produce `:constraint` leaves while
+		// allowing the real dependency paths to be fully expanded.
+		"nested_bom_constraints": {
+			Fixture: "nested-bom-constraints",
+			Options: ecosystems.NewPluginOptions(),
+		},
+		// Multi-module project with platform BOM that imports external BOMs.
+		// Demonstrates nested BOM hierarchy where platform -> external BOMs
+		// -> component constraints, ensuring proper DAG structure.
+		"multi_module_bom": {
+			Fixture: "multi-module-bom",
+			Options: ecosystems.NewPluginOptions(),
+		},
 	}
 }
 

--- a/pkg/ecosystems/testdata/fixtures/gradle/classifiers/expected_plugin.json
+++ b/pkg/ecosystems/testdata/fixtures/gradle/classifiers/expected_plugin.json
@@ -82,7 +82,7 @@
                 "nodeId": "commons-lang:commons-lang@2.5"
               },
               {
-                "nodeId": "commons-logging:commons-logging@1.1.1:pruned"
+                "nodeId": "commons-logging:commons-logging@1.1.1"
               },
               {
                 "nodeId": "net.sf.ezmorph:ezmorph@1.0.6"
@@ -114,33 +114,13 @@
             "deps": []
           },
           {
-            "nodeId": "commons-logging:commons-logging@1.1.1:pruned",
-            "pkgId": "commons-logging:commons-logging@1.1.1",
-            "info": {
-              "labels": {
-                "pruned": "true"
-              }
-            },
-            "deps": []
-          },
-          {
             "nodeId": "net.sf.ezmorph:ezmorph@1.0.6",
             "pkgId": "net.sf.ezmorph:ezmorph@1.0.6",
             "deps": [
               {
-                "nodeId": "commons-lang:commons-lang@2.5:pruned"
+                "nodeId": "commons-lang:commons-lang@2.5"
               }
             ]
-          },
-          {
-            "nodeId": "commons-lang:commons-lang@2.5:pruned",
-            "pkgId": "commons-lang:commons-lang@2.5",
-            "info": {
-              "labels": {
-                "pruned": "true"
-              }
-            },
-            "deps": []
           }
         ]
       }

--- a/pkg/ecosystems/testdata/fixtures/gradle/configuration-matching/expected_plugin.json
+++ b/pkg/ecosystems/testdata/fixtures/gradle/configuration-matching/expected_plugin.json
@@ -312,19 +312,9 @@
             "pkgId": "org.slf4j:slf4j-simple@1.7.36",
             "deps": [
               {
-                "nodeId": "org.slf4j:slf4j-api@1.7.36:pruned"
+                "nodeId": "org.slf4j:slf4j-api@1.7.36"
               }
             ]
-          },
-          {
-            "nodeId": "org.slf4j:slf4j-api@1.7.36:pruned",
-            "pkgId": "org.slf4j:slf4j-api@1.7.36",
-            "info": {
-              "labels": {
-                "pruned": "true"
-              }
-            },
-            "deps": []
           }
         ]
       }

--- a/pkg/ecosystems/testdata/fixtures/gradle/configuration-matching/expected_plugin_runtime_only.json
+++ b/pkg/ecosystems/testdata/fixtures/gradle/configuration-matching/expected_plugin_runtime_only.json
@@ -297,19 +297,9 @@
             "pkgId": "org.slf4j:slf4j-simple@1.7.36",
             "deps": [
               {
-                "nodeId": "org.slf4j:slf4j-api@1.7.36:pruned"
+                "nodeId": "org.slf4j:slf4j-api@1.7.36"
               }
             ]
-          },
-          {
-            "nodeId": "org.slf4j:slf4j-api@1.7.36:pruned",
-            "pkgId": "org.slf4j:slf4j-api@1.7.36",
-            "info": {
-              "labels": {
-                "pruned": "true"
-              }
-            },
-            "deps": []
           }
         ]
       }

--- a/pkg/ecosystems/testdata/fixtures/gradle/configuration-matching/expected_plugin_test_only.json
+++ b/pkg/ecosystems/testdata/fixtures/gradle/configuration-matching/expected_plugin_test_only.json
@@ -282,19 +282,9 @@
             "pkgId": "org.slf4j:slf4j-simple@1.7.36",
             "deps": [
               {
-                "nodeId": "org.slf4j:slf4j-api@1.7.36:pruned"
+                "nodeId": "org.slf4j:slf4j-api@1.7.36"
               }
             ]
-          },
-          {
-            "nodeId": "org.slf4j:slf4j-api@1.7.36:pruned",
-            "pkgId": "org.slf4j:slf4j-api@1.7.36",
-            "info": {
-              "labels": {
-                "pruned": "true"
-              }
-            },
-            "deps": []
           }
         ]
       }

--- a/pkg/ecosystems/testdata/fixtures/gradle/dependency-constraints/build.gradle
+++ b/pkg/ecosystems/testdata/fixtures/gradle/dependency-constraints/build.gradle
@@ -1,0 +1,25 @@
+plugins {
+    id 'java'
+}
+
+group = 'com.snyk.fixtures'
+version = '1.0.0'
+
+repositories {
+    mavenCentral()
+}
+
+// Exercises the `constraints {}` DSL: pins the resolved version of a transitive
+// dependency without declaring a real edge to it. Produces an isConstraint()
+// edge from the configuration root, which the init script must emit as a
+// constraint leaf rather than a real artifact dependency.
+dependencies {
+    // Real transitive pulls jcl-over-slf4j 1.7.30; the constraint below upgrades it.
+    implementation 'org.slf4j:jcl-over-slf4j:1.7.30'
+
+    constraints {
+        implementation('org.slf4j:jcl-over-slf4j:1.7.36') {
+            because 'Pin to a known-good version'
+        }
+    }
+}

--- a/pkg/ecosystems/testdata/fixtures/gradle/dependency-constraints/expected_plugin.json
+++ b/pkg/ecosystems/testdata/fixtures/gradle/dependency-constraints/expected_plugin.json
@@ -1,0 +1,81 @@
+[
+  {
+    "depGraph": {
+      "schemaVersion": "1.3.0",
+      "pkgManager": {
+        "name": "gradle"
+      },
+      "pkgs": [
+        {
+          "id": "com.snyk.fixtures:dependency-constraints@1.0.0",
+          "info": {
+            "name": "com.snyk.fixtures:dependency-constraints",
+            "version": "1.0.0"
+          }
+        },
+        {
+          "id": "org.slf4j:jcl-over-slf4j@1.7.36",
+          "info": {
+            "name": "org.slf4j:jcl-over-slf4j",
+            "version": "1.7.36"
+          }
+        },
+        {
+          "id": "org.slf4j:slf4j-api@1.7.36",
+          "info": {
+            "name": "org.slf4j:slf4j-api",
+            "version": "1.7.36"
+          }
+        }
+      ],
+      "graph": {
+        "rootNodeId": "root-node",
+        "nodes": [
+          {
+            "nodeId": "root-node",
+            "pkgId": "com.snyk.fixtures:dependency-constraints@1.0.0",
+            "deps": [
+              {
+                "nodeId": "org.slf4j:jcl-over-slf4j@1.7.36"
+              },
+              {
+                "nodeId": "org.slf4j:jcl-over-slf4j@1.7.36:constraint"
+              }
+            ]
+          },
+          {
+            "nodeId": "org.slf4j:jcl-over-slf4j@1.7.36",
+            "pkgId": "org.slf4j:jcl-over-slf4j@1.7.36",
+            "deps": [
+              {
+                "nodeId": "org.slf4j:slf4j-api@1.7.36"
+              }
+            ]
+          },
+          {
+            "nodeId": "org.slf4j:slf4j-api@1.7.36",
+            "pkgId": "org.slf4j:slf4j-api@1.7.36",
+            "deps": []
+          },
+          {
+            "nodeId": "org.slf4j:jcl-over-slf4j@1.7.36:constraint",
+            "pkgId": "org.slf4j:jcl-over-slf4j@1.7.36",
+            "info": {
+              "labels": {
+                "constraint": "true"
+              }
+            },
+            "deps": []
+          }
+        ]
+      }
+    },
+    "projectDescriptor": {
+      "identity": {
+        "type": "gradle",
+        "targetFile": "build.gradle",
+        "rootComponentName": "com.snyk.fixtures:dependency-constraints"
+      }
+    }
+  }
+]

--- a/pkg/ecosystems/testdata/fixtures/gradle/dependency-constraints/settings.gradle
+++ b/pkg/ecosystems/testdata/fixtures/gradle/dependency-constraints/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'dependency-constraints'

--- a/pkg/ecosystems/testdata/fixtures/gradle/dependency-substitution/build.gradle
+++ b/pkg/ecosystems/testdata/fixtures/gradle/dependency-substitution/build.gradle
@@ -1,0 +1,24 @@
+plugins {
+    id 'java'
+}
+
+group = 'com.snyk.fixtures'
+version = '1.0.0'
+
+repositories {
+    mavenCentral()
+}
+
+// Regression fixture: dependencySubstitution replaces the target component on
+// an existing edge. The substituted module replaces the original on the same
+// edge — no `:constraint` node should appear.
+configurations.all {
+    resolutionStrategy.dependencySubstitution {
+        substitute module('commons-logging:commons-logging') using module('org.slf4j:jcl-over-slf4j:1.7.36')
+    }
+}
+
+dependencies {
+    implementation 'commons-logging:commons-logging:1.2'
+    implementation 'org.slf4j:slf4j-api:1.7.36'
+}

--- a/pkg/ecosystems/testdata/fixtures/gradle/dependency-substitution/expected_plugin.json
+++ b/pkg/ecosystems/testdata/fixtures/gradle/dependency-substitution/expected_plugin.json
@@ -1,0 +1,71 @@
+[
+  {
+    "depGraph": {
+      "schemaVersion": "1.3.0",
+      "pkgManager": {
+        "name": "gradle"
+      },
+      "pkgs": [
+        {
+          "id": "com.snyk.fixtures:dependency-substitution@1.0.0",
+          "info": {
+            "name": "com.snyk.fixtures:dependency-substitution",
+            "version": "1.0.0"
+          }
+        },
+        {
+          "id": "org.slf4j:jcl-over-slf4j@1.7.36",
+          "info": {
+            "name": "org.slf4j:jcl-over-slf4j",
+            "version": "1.7.36"
+          }
+        },
+        {
+          "id": "org.slf4j:slf4j-api@1.7.36",
+          "info": {
+            "name": "org.slf4j:slf4j-api",
+            "version": "1.7.36"
+          }
+        }
+      ],
+      "graph": {
+        "rootNodeId": "root-node",
+        "nodes": [
+          {
+            "nodeId": "root-node",
+            "pkgId": "com.snyk.fixtures:dependency-substitution@1.0.0",
+            "deps": [
+              {
+                "nodeId": "org.slf4j:jcl-over-slf4j@1.7.36"
+              },
+              {
+                "nodeId": "org.slf4j:slf4j-api@1.7.36"
+              }
+            ]
+          },
+          {
+            "nodeId": "org.slf4j:jcl-over-slf4j@1.7.36",
+            "pkgId": "org.slf4j:jcl-over-slf4j@1.7.36",
+            "deps": [
+              {
+                "nodeId": "org.slf4j:slf4j-api@1.7.36"
+              }
+            ]
+          },
+          {
+            "nodeId": "org.slf4j:slf4j-api@1.7.36",
+            "pkgId": "org.slf4j:slf4j-api@1.7.36",
+            "deps": []
+          }
+        ]
+      }
+    },
+    "projectDescriptor": {
+      "identity": {
+        "type": "gradle",
+        "targetFile": "build.gradle",
+        "rootComponentName": "com.snyk.fixtures:dependency-substitution"
+      }
+    }
+  }
+]

--- a/pkg/ecosystems/testdata/fixtures/gradle/dependency-substitution/settings.gradle
+++ b/pkg/ecosystems/testdata/fixtures/gradle/dependency-substitution/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'dependency-substitution'

--- a/pkg/ecosystems/testdata/fixtures/gradle/dynamic-versions/expected_plugin.json
+++ b/pkg/ecosystems/testdata/fixtures/gradle/dynamic-versions/expected_plugin.json
@@ -189,19 +189,9 @@
             "pkgId": "org.slf4j:slf4j-simple@1.7.30",
             "deps": [
               {
-                "nodeId": "org.slf4j:slf4j-api@1.7.36:pruned"
+                "nodeId": "org.slf4j:slf4j-api@1.7.36"
               }
             ]
-          },
-          {
-            "nodeId": "org.slf4j:slf4j-api@1.7.36:pruned",
-            "pkgId": "org.slf4j:slf4j-api@1.7.36",
-            "info": {
-              "labels": {
-                "pruned": "true"
-              }
-            },
-            "deps": []
           }
         ]
       }

--- a/pkg/ecosystems/testdata/fixtures/gradle/multi-module-bom/build.gradle
+++ b/pkg/ecosystems/testdata/fixtures/gradle/multi-module-bom/build.gradle
@@ -1,0 +1,1 @@
+// Root project - just coordinates the modules

--- a/pkg/ecosystems/testdata/fixtures/gradle/multi-module-bom/consumer/build.gradle
+++ b/pkg/ecosystems/testdata/fixtures/gradle/multi-module-bom/consumer/build.gradle
@@ -1,0 +1,24 @@
+plugins {
+    id 'java'
+}
+
+group = 'com.snyk.fixtures'
+version = '1.0.0'
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    // Import our local platform as a BOM - which itself imports nested BOMs
+    implementation platform(project(':platform'))
+    
+    // Dependencies without versions - should be constrained by nested BOMs through platform
+    implementation 'com.fasterxml.jackson.core:jackson-core'
+    implementation 'org.slf4j:slf4j-api'
+    implementation 'ch.qos.logback:logback-classic'
+    
+    // Dependencies constrained by platform's direct constraints
+    implementation 'org.apache.commons:commons-lang3'
+    implementation 'commons-io:commons-io'
+}

--- a/pkg/ecosystems/testdata/fixtures/gradle/multi-module-bom/expected_plugin.json
+++ b/pkg/ecosystems/testdata/fixtures/gradle/multi-module-bom/expected_plugin.json
@@ -1,0 +1,346 @@
+[
+  {
+    "depGraph": {
+      "schemaVersion": "1.3.0",
+      "pkgManager": {
+        "name": "gradle"
+      },
+      "pkgs": [
+        {
+          "id": ":multi-module-bom@",
+          "info": {
+            "name": ":multi-module-bom"
+          }
+        }
+      ],
+      "graph": {
+        "rootNodeId": "root-node",
+        "nodes": [
+          {
+            "nodeId": "root-node",
+            "pkgId": ":multi-module-bom@",
+            "deps": []
+          }
+        ]
+      }
+    },
+    "projectDescriptor": {
+      "identity": {
+        "type": "gradle",
+        "targetFile": "build.gradle",
+        "rootComponentName": ":multi-module-bom"
+      }
+    }
+  },
+  {
+    "depGraph": {
+      "schemaVersion": "1.3.0",
+      "pkgManager": {
+        "name": "gradle"
+      },
+      "pkgs": [
+        {
+          "id": "com.snyk.fixtures:consumer@1.0.0",
+          "info": {
+            "name": "com.snyk.fixtures:consumer",
+            "version": "1.0.0"
+          }
+        },
+        {
+          "id": "com.snyk.fixtures:platform@1.0.0",
+          "info": {
+            "name": "com.snyk.fixtures:platform",
+            "version": "1.0.0"
+          }
+        },
+        {
+          "id": "com.fasterxml.jackson:jackson-bom@2.15.2",
+          "info": {
+            "name": "com.fasterxml.jackson:jackson-bom",
+            "version": "2.15.2"
+          }
+        },
+        {
+          "id": "com.fasterxml.jackson.core:jackson-core@2.15.2",
+          "info": {
+            "name": "com.fasterxml.jackson.core:jackson-core",
+            "version": "2.15.2"
+          }
+        },
+        {
+          "id": "org.slf4j:slf4j-bom@2.0.9",
+          "info": {
+            "name": "org.slf4j:slf4j-bom",
+            "version": "2.0.9"
+          }
+        },
+        {
+          "id": "org.slf4j:slf4j-api@2.0.9",
+          "info": {
+            "name": "org.slf4j:slf4j-api",
+            "version": "2.0.9"
+          }
+        },
+        {
+          "id": "org.apache.commons:commons-lang3@3.13.0",
+          "info": {
+            "name": "org.apache.commons:commons-lang3",
+            "version": "3.13.0"
+          }
+        },
+        {
+          "id": "commons-io:commons-io@2.14.0",
+          "info": {
+            "name": "commons-io:commons-io",
+            "version": "2.14.0"
+          }
+        },
+        {
+          "id": "ch.qos.logback:logback-classic@1.4.11",
+          "info": {
+            "name": "ch.qos.logback:logback-classic",
+            "version": "1.4.11"
+          }
+        },
+        {
+          "id": "ch.qos.logback:logback-core@1.4.11",
+          "info": {
+            "name": "ch.qos.logback:logback-core",
+            "version": "1.4.11"
+          }
+        }
+      ],
+      "graph": {
+        "rootNodeId": "root-node",
+        "nodes": [
+          {
+            "nodeId": "root-node",
+            "pkgId": "com.snyk.fixtures:consumer@1.0.0",
+            "deps": [
+              {
+                "nodeId": "com.snyk.fixtures:platform@1.0.0"
+              },
+              {
+                "nodeId": "com.fasterxml.jackson.core:jackson-core@2.15.2"
+              },
+              {
+                "nodeId": "org.slf4j:slf4j-api@2.0.9"
+              },
+              {
+                "nodeId": "ch.qos.logback:logback-classic@1.4.11"
+              },
+              {
+                "nodeId": "org.apache.commons:commons-lang3@3.13.0"
+              },
+              {
+                "nodeId": "commons-io:commons-io@2.14.0"
+              }
+            ]
+          },
+          {
+            "nodeId": "com.snyk.fixtures:platform@1.0.0",
+            "pkgId": "com.snyk.fixtures:platform@1.0.0",
+            "deps": [
+              {
+                "nodeId": "com.fasterxml.jackson:jackson-bom@2.15.2"
+              },
+              {
+                "nodeId": "org.slf4j:slf4j-bom@2.0.9"
+              },
+              {
+                "nodeId": "org.apache.commons:commons-lang3@3.13.0:constraint"
+              },
+              {
+                "nodeId": "commons-io:commons-io@2.14.0:constraint"
+              },
+              {
+                "nodeId": "ch.qos.logback:logback-classic@1.4.11:constraint"
+              }
+            ]
+          },
+          {
+            "nodeId": "com.fasterxml.jackson:jackson-bom@2.15.2",
+            "pkgId": "com.fasterxml.jackson:jackson-bom@2.15.2",
+            "deps": [
+              {
+                "nodeId": "com.fasterxml.jackson.core:jackson-core@2.15.2:constraint"
+              }
+            ]
+          },
+          {
+            "nodeId": "com.fasterxml.jackson.core:jackson-core@2.15.2:constraint",
+            "pkgId": "com.fasterxml.jackson.core:jackson-core@2.15.2",
+            "info": {
+              "labels": {
+                "constraint": "true"
+              }
+            },
+            "deps": []
+          },
+          {
+            "nodeId": "org.slf4j:slf4j-bom@2.0.9",
+            "pkgId": "org.slf4j:slf4j-bom@2.0.9",
+            "deps": [
+              {
+                "nodeId": "org.slf4j:slf4j-api@2.0.9:constraint"
+              }
+            ]
+          },
+          {
+            "nodeId": "org.slf4j:slf4j-api@2.0.9:constraint",
+            "pkgId": "org.slf4j:slf4j-api@2.0.9",
+            "info": {
+              "labels": {
+                "constraint": "true"
+              }
+            },
+            "deps": []
+          },
+          {
+            "nodeId": "org.apache.commons:commons-lang3@3.13.0:constraint",
+            "pkgId": "org.apache.commons:commons-lang3@3.13.0",
+            "info": {
+              "labels": {
+                "constraint": "true"
+              }
+            },
+            "deps": []
+          },
+          {
+            "nodeId": "commons-io:commons-io@2.14.0:constraint",
+            "pkgId": "commons-io:commons-io@2.14.0",
+            "info": {
+              "labels": {
+                "constraint": "true"
+              }
+            },
+            "deps": []
+          },
+          {
+            "nodeId": "ch.qos.logback:logback-classic@1.4.11:constraint",
+            "pkgId": "ch.qos.logback:logback-classic@1.4.11",
+            "info": {
+              "labels": {
+                "constraint": "true"
+              }
+            },
+            "deps": []
+          },
+          {
+            "nodeId": "com.fasterxml.jackson.core:jackson-core@2.15.2",
+            "pkgId": "com.fasterxml.jackson.core:jackson-core@2.15.2",
+            "deps": [
+              {
+                "nodeId": "com.fasterxml.jackson:jackson-bom@2.15.2"
+              }
+            ]
+          },
+          {
+            "nodeId": "org.slf4j:slf4j-api@2.0.9",
+            "pkgId": "org.slf4j:slf4j-api@2.0.9",
+            "deps": []
+          },
+          {
+            "nodeId": "ch.qos.logback:logback-classic@1.4.11",
+            "pkgId": "ch.qos.logback:logback-classic@1.4.11",
+            "deps": [
+              {
+                "nodeId": "ch.qos.logback:logback-core@1.4.11"
+              },
+              {
+                "nodeId": "org.slf4j:slf4j-api@2.0.9"
+              }
+            ]
+          },
+          {
+            "nodeId": "ch.qos.logback:logback-core@1.4.11",
+            "pkgId": "ch.qos.logback:logback-core@1.4.11",
+            "deps": []
+          },
+          {
+            "nodeId": "org.apache.commons:commons-lang3@3.13.0",
+            "pkgId": "org.apache.commons:commons-lang3@3.13.0",
+            "deps": []
+          },
+          {
+            "nodeId": "commons-io:commons-io@2.14.0",
+            "pkgId": "commons-io:commons-io@2.14.0",
+            "deps": []
+          }
+        ]
+      }
+    },
+    "projectDescriptor": {
+      "identity": {
+        "type": "gradle",
+        "targetFile": "consumer/build.gradle",
+        "rootComponentName": "com.snyk.fixtures:consumer"
+      }
+    }
+  },
+  {
+    "depGraph": {
+      "schemaVersion": "1.3.0",
+      "pkgManager": {
+        "name": "gradle"
+      },
+      "pkgs": [
+        {
+          "id": "com.snyk.fixtures:platform@1.0.0",
+          "info": {
+            "name": "com.snyk.fixtures:platform",
+            "version": "1.0.0"
+          }
+        },
+        {
+          "id": "com.fasterxml.jackson:jackson-bom@2.15.2",
+          "info": {
+            "name": "com.fasterxml.jackson:jackson-bom",
+            "version": "2.15.2"
+          }
+        },
+        {
+          "id": "org.slf4j:slf4j-bom@2.0.9",
+          "info": {
+            "name": "org.slf4j:slf4j-bom",
+            "version": "2.0.9"
+          }
+        }
+      ],
+      "graph": {
+        "rootNodeId": "root-node",
+        "nodes": [
+          {
+            "nodeId": "root-node",
+            "pkgId": "com.snyk.fixtures:platform@1.0.0",
+            "deps": [
+              {
+                "nodeId": "com.fasterxml.jackson:jackson-bom@2.15.2"
+              },
+              {
+                "nodeId": "org.slf4j:slf4j-bom@2.0.9"
+              }
+            ]
+          },
+          {
+            "nodeId": "com.fasterxml.jackson:jackson-bom@2.15.2",
+            "pkgId": "com.fasterxml.jackson:jackson-bom@2.15.2",
+            "deps": []
+          },
+          {
+            "nodeId": "org.slf4j:slf4j-bom@2.0.9",
+            "pkgId": "org.slf4j:slf4j-bom@2.0.9",
+            "deps": []
+          }
+        ]
+      }
+    },
+    "projectDescriptor": {
+      "identity": {
+        "type": "gradle",
+        "targetFile": "platform/build.gradle",
+        "rootComponentName": "com.snyk.fixtures:platform"
+      }
+    }
+  }
+]

--- a/pkg/ecosystems/testdata/fixtures/gradle/multi-module-bom/platform/build.gradle
+++ b/pkg/ecosystems/testdata/fixtures/gradle/multi-module-bom/platform/build.gradle
@@ -1,0 +1,28 @@
+plugins {
+    id 'java-platform'
+}
+
+group = 'com.snyk.fixtures'
+version = '1.0.0'
+
+repositories {
+    mavenCentral()
+}
+
+// Enable dependencies in platform - needed to import other BOMs
+javaPlatform {
+    allowDependencies()
+}
+
+dependencies {
+    // Import external BOMs - this creates a nested BOM hierarchy
+    api platform('com.fasterxml.jackson:jackson-bom:2.15.2')
+    api platform('org.slf4j:slf4j-bom:2.0.9')
+    
+    constraints {
+        // Additional direct constraints not covered by imported BOMs
+        api 'org.apache.commons:commons-lang3:3.13.0'
+        api 'commons-io:commons-io:2.14.0'
+        api 'ch.qos.logback:logback-classic:1.4.11'
+    }
+}

--- a/pkg/ecosystems/testdata/fixtures/gradle/multi-module-bom/settings.gradle
+++ b/pkg/ecosystems/testdata/fixtures/gradle/multi-module-bom/settings.gradle
@@ -1,0 +1,4 @@
+rootProject.name = 'multi-module-bom'
+
+include 'platform'
+include 'consumer'

--- a/pkg/ecosystems/testdata/fixtures/gradle/nested-bom-constraints/build.gradle
+++ b/pkg/ecosystems/testdata/fixtures/gradle/nested-bom-constraints/build.gradle
@@ -1,0 +1,30 @@
+plugins {
+    id 'java'
+}
+
+group = 'com.snyk.fixtures'
+version = '1.0.0'
+
+repositories {
+    mavenCentral()
+}
+
+// Test nested BOM constraint scenario: Spring Boot BOM internally imports
+// jackson-bom, jetty-bom, jersey-bom, etc. via Maven <scope>import</scope>.
+// This tests whether our "constraint edges are leaves" approach loses any
+// important diagnostic information about BOM hierarchies.
+dependencies {
+    // Spring Boot BOM - internally imports jackson-bom, jetty-bom, etc.
+    implementation platform('org.springframework.boot:spring-boot-dependencies:2.7.14')
+    
+    // Jackson dependencies - versions should be constrained by nested jackson-bom
+    implementation 'com.fasterxml.jackson.core:jackson-core'
+    // Skip databind to avoid version conflicts for this test
+    
+    // Jetty dependencies - versions should be constrained by nested jetty-bom  
+    implementation 'org.eclipse.jetty:jetty-server'
+    implementation 'org.eclipse.jetty:jetty-servlet'
+    
+    // Spring dependency for good measure
+    implementation 'org.springframework:spring-web'
+}

--- a/pkg/ecosystems/testdata/fixtures/gradle/nested-bom-constraints/expected_plugin.json
+++ b/pkg/ecosystems/testdata/fixtures/gradle/nested-bom-constraints/expected_plugin.json
@@ -1,0 +1,461 @@
+[
+  {
+    "depGraph": {
+      "schemaVersion": "1.3.0",
+      "pkgManager": {
+        "name": "gradle"
+      },
+      "pkgs": [
+        {
+          "id": "com.snyk.fixtures:nested-bom-constraints@1.0.0",
+          "info": {
+            "name": "com.snyk.fixtures:nested-bom-constraints",
+            "version": "1.0.0"
+          }
+        },
+        {
+          "id": "org.springframework.boot:spring-boot-dependencies@2.7.14",
+          "info": {
+            "name": "org.springframework.boot:spring-boot-dependencies",
+            "version": "2.7.14"
+          }
+        },
+        {
+          "id": "com.fasterxml.jackson.core:jackson-core@2.13.5",
+          "info": {
+            "name": "com.fasterxml.jackson.core:jackson-core",
+            "version": "2.13.5"
+          }
+        },
+        {
+          "id": "org.eclipse.jetty:jetty-server@9.4.51.v20230217",
+          "info": {
+            "name": "org.eclipse.jetty:jetty-server",
+            "version": "9.4.51.v20230217"
+          }
+        },
+        {
+          "id": "org.eclipse.jetty:jetty-servlet@9.4.51.v20230217",
+          "info": {
+            "name": "org.eclipse.jetty:jetty-servlet",
+            "version": "9.4.51.v20230217"
+          }
+        },
+        {
+          "id": "org.springframework:spring-web@5.3.29",
+          "info": {
+            "name": "org.springframework:spring-web",
+            "version": "5.3.29"
+          }
+        },
+        {
+          "id": "javax.servlet:javax.servlet-api@4.0.1",
+          "info": {
+            "name": "javax.servlet:javax.servlet-api",
+            "version": "4.0.1"
+          }
+        },
+        {
+          "id": "org.eclipse.jetty:jetty-http@9.4.51.v20230217",
+          "info": {
+            "name": "org.eclipse.jetty:jetty-http",
+            "version": "9.4.51.v20230217"
+          }
+        },
+        {
+          "id": "org.eclipse.jetty:jetty-io@9.4.51.v20230217",
+          "info": {
+            "name": "org.eclipse.jetty:jetty-io",
+            "version": "9.4.51.v20230217"
+          }
+        },
+        {
+          "id": "org.eclipse.jetty:jetty-security@9.4.51.v20230217",
+          "info": {
+            "name": "org.eclipse.jetty:jetty-security",
+            "version": "9.4.51.v20230217"
+          }
+        },
+        {
+          "id": "org.eclipse.jetty:jetty-util-ajax@9.4.51.v20230217",
+          "info": {
+            "name": "org.eclipse.jetty:jetty-util-ajax",
+            "version": "9.4.51.v20230217"
+          }
+        },
+        {
+          "id": "org.springframework:spring-beans@5.3.29",
+          "info": {
+            "name": "org.springframework:spring-beans",
+            "version": "5.3.29"
+          }
+        },
+        {
+          "id": "org.springframework:spring-core@5.3.29",
+          "info": {
+            "name": "org.springframework:spring-core",
+            "version": "5.3.29"
+          }
+        },
+        {
+          "id": "org.eclipse.jetty:jetty-util@9.4.51.v20230217",
+          "info": {
+            "name": "org.eclipse.jetty:jetty-util",
+            "version": "9.4.51.v20230217"
+          }
+        },
+        {
+          "id": "org.springframework:spring-jcl@5.3.29",
+          "info": {
+            "name": "org.springframework:spring-jcl",
+            "version": "5.3.29"
+          }
+        },
+        {
+          "id": "com.fasterxml.jackson:jackson-bom@2.13.5",
+          "info": {
+            "name": "com.fasterxml.jackson:jackson-bom",
+            "version": "2.13.5"
+          }
+        }
+      ],
+      "graph": {
+        "rootNodeId": "root-node",
+        "nodes": [
+          {
+            "nodeId": "root-node",
+            "pkgId": "com.snyk.fixtures:nested-bom-constraints@1.0.0",
+            "deps": [
+              {
+                "nodeId": "org.springframework.boot:spring-boot-dependencies@2.7.14"
+              },
+              {
+                "nodeId": "com.fasterxml.jackson.core:jackson-core@2.13.5"
+              },
+              {
+                "nodeId": "org.eclipse.jetty:jetty-server@9.4.51.v20230217"
+              },
+              {
+                "nodeId": "org.eclipse.jetty:jetty-servlet@9.4.51.v20230217"
+              },
+              {
+                "nodeId": "org.springframework:spring-web@5.3.29"
+              }
+            ]
+          },
+          {
+            "nodeId": "org.springframework.boot:spring-boot-dependencies@2.7.14",
+            "pkgId": "org.springframework.boot:spring-boot-dependencies@2.7.14",
+            "deps": [
+              {
+                "nodeId": "com.fasterxml.jackson.core:jackson-core@2.13.5:constraint"
+              },
+              {
+                "nodeId": "org.eclipse.jetty:jetty-server@9.4.51.v20230217:constraint"
+              },
+              {
+                "nodeId": "org.eclipse.jetty:jetty-servlet@9.4.51.v20230217:constraint"
+              },
+              {
+                "nodeId": "org.springframework:spring-web@5.3.29:constraint"
+              },
+              {
+                "nodeId": "javax.servlet:javax.servlet-api@4.0.1:constraint"
+              },
+              {
+                "nodeId": "org.eclipse.jetty:jetty-http@9.4.51.v20230217:constraint"
+              },
+              {
+                "nodeId": "org.eclipse.jetty:jetty-io@9.4.51.v20230217:constraint"
+              },
+              {
+                "nodeId": "org.eclipse.jetty:jetty-security@9.4.51.v20230217:constraint"
+              },
+              {
+                "nodeId": "org.eclipse.jetty:jetty-util-ajax@9.4.51.v20230217:constraint"
+              },
+              {
+                "nodeId": "org.springframework:spring-beans@5.3.29:constraint"
+              },
+              {
+                "nodeId": "org.springframework:spring-core@5.3.29:constraint"
+              },
+              {
+                "nodeId": "org.eclipse.jetty:jetty-util@9.4.51.v20230217:constraint"
+              },
+              {
+                "nodeId": "org.springframework:spring-jcl@5.3.29:constraint"
+              }
+            ]
+          },
+          {
+            "nodeId": "com.fasterxml.jackson.core:jackson-core@2.13.5:constraint",
+            "pkgId": "com.fasterxml.jackson.core:jackson-core@2.13.5",
+            "info": {
+              "labels": {
+                "constraint": "true"
+              }
+            },
+            "deps": []
+          },
+          {
+            "nodeId": "org.eclipse.jetty:jetty-server@9.4.51.v20230217:constraint",
+            "pkgId": "org.eclipse.jetty:jetty-server@9.4.51.v20230217",
+            "info": {
+              "labels": {
+                "constraint": "true"
+              }
+            },
+            "deps": []
+          },
+          {
+            "nodeId": "org.eclipse.jetty:jetty-servlet@9.4.51.v20230217:constraint",
+            "pkgId": "org.eclipse.jetty:jetty-servlet@9.4.51.v20230217",
+            "info": {
+              "labels": {
+                "constraint": "true"
+              }
+            },
+            "deps": []
+          },
+          {
+            "nodeId": "org.springframework:spring-web@5.3.29:constraint",
+            "pkgId": "org.springframework:spring-web@5.3.29",
+            "info": {
+              "labels": {
+                "constraint": "true"
+              }
+            },
+            "deps": []
+          },
+          {
+            "nodeId": "javax.servlet:javax.servlet-api@4.0.1:constraint",
+            "pkgId": "javax.servlet:javax.servlet-api@4.0.1",
+            "info": {
+              "labels": {
+                "constraint": "true"
+              }
+            },
+            "deps": []
+          },
+          {
+            "nodeId": "org.eclipse.jetty:jetty-http@9.4.51.v20230217:constraint",
+            "pkgId": "org.eclipse.jetty:jetty-http@9.4.51.v20230217",
+            "info": {
+              "labels": {
+                "constraint": "true"
+              }
+            },
+            "deps": []
+          },
+          {
+            "nodeId": "org.eclipse.jetty:jetty-io@9.4.51.v20230217:constraint",
+            "pkgId": "org.eclipse.jetty:jetty-io@9.4.51.v20230217",
+            "info": {
+              "labels": {
+                "constraint": "true"
+              }
+            },
+            "deps": []
+          },
+          {
+            "nodeId": "org.eclipse.jetty:jetty-security@9.4.51.v20230217:constraint",
+            "pkgId": "org.eclipse.jetty:jetty-security@9.4.51.v20230217",
+            "info": {
+              "labels": {
+                "constraint": "true"
+              }
+            },
+            "deps": []
+          },
+          {
+            "nodeId": "org.eclipse.jetty:jetty-util-ajax@9.4.51.v20230217:constraint",
+            "pkgId": "org.eclipse.jetty:jetty-util-ajax@9.4.51.v20230217",
+            "info": {
+              "labels": {
+                "constraint": "true"
+              }
+            },
+            "deps": []
+          },
+          {
+            "nodeId": "org.springframework:spring-beans@5.3.29:constraint",
+            "pkgId": "org.springframework:spring-beans@5.3.29",
+            "info": {
+              "labels": {
+                "constraint": "true"
+              }
+            },
+            "deps": []
+          },
+          {
+            "nodeId": "org.springframework:spring-core@5.3.29:constraint",
+            "pkgId": "org.springframework:spring-core@5.3.29",
+            "info": {
+              "labels": {
+                "constraint": "true"
+              }
+            },
+            "deps": []
+          },
+          {
+            "nodeId": "org.eclipse.jetty:jetty-util@9.4.51.v20230217:constraint",
+            "pkgId": "org.eclipse.jetty:jetty-util@9.4.51.v20230217",
+            "info": {
+              "labels": {
+                "constraint": "true"
+              }
+            },
+            "deps": []
+          },
+          {
+            "nodeId": "org.springframework:spring-jcl@5.3.29:constraint",
+            "pkgId": "org.springframework:spring-jcl@5.3.29",
+            "info": {
+              "labels": {
+                "constraint": "true"
+              }
+            },
+            "deps": []
+          },
+          {
+            "nodeId": "com.fasterxml.jackson.core:jackson-core@2.13.5",
+            "pkgId": "com.fasterxml.jackson.core:jackson-core@2.13.5",
+            "deps": [
+              {
+                "nodeId": "com.fasterxml.jackson:jackson-bom@2.13.5"
+              }
+            ]
+          },
+          {
+            "nodeId": "com.fasterxml.jackson:jackson-bom@2.13.5",
+            "pkgId": "com.fasterxml.jackson:jackson-bom@2.13.5",
+            "deps": [
+              {
+                "nodeId": "com.fasterxml.jackson.core:jackson-core@2.13.5:constraint"
+              }
+            ]
+          },
+          {
+            "nodeId": "org.eclipse.jetty:jetty-server@9.4.51.v20230217",
+            "pkgId": "org.eclipse.jetty:jetty-server@9.4.51.v20230217",
+            "deps": [
+              {
+                "nodeId": "javax.servlet:javax.servlet-api@4.0.1"
+              },
+              {
+                "nodeId": "org.eclipse.jetty:jetty-http@9.4.51.v20230217"
+              },
+              {
+                "nodeId": "org.eclipse.jetty:jetty-io@9.4.51.v20230217"
+              }
+            ]
+          },
+          {
+            "nodeId": "javax.servlet:javax.servlet-api@4.0.1",
+            "pkgId": "javax.servlet:javax.servlet-api@4.0.1",
+            "deps": []
+          },
+          {
+            "nodeId": "org.eclipse.jetty:jetty-http@9.4.51.v20230217",
+            "pkgId": "org.eclipse.jetty:jetty-http@9.4.51.v20230217",
+            "deps": [
+              {
+                "nodeId": "org.eclipse.jetty:jetty-util@9.4.51.v20230217"
+              },
+              {
+                "nodeId": "org.eclipse.jetty:jetty-io@9.4.51.v20230217"
+              }
+            ]
+          },
+          {
+            "nodeId": "org.eclipse.jetty:jetty-util@9.4.51.v20230217",
+            "pkgId": "org.eclipse.jetty:jetty-util@9.4.51.v20230217",
+            "deps": []
+          },
+          {
+            "nodeId": "org.eclipse.jetty:jetty-io@9.4.51.v20230217",
+            "pkgId": "org.eclipse.jetty:jetty-io@9.4.51.v20230217",
+            "deps": [
+              {
+                "nodeId": "org.eclipse.jetty:jetty-util@9.4.51.v20230217"
+              }
+            ]
+          },
+          {
+            "nodeId": "org.eclipse.jetty:jetty-servlet@9.4.51.v20230217",
+            "pkgId": "org.eclipse.jetty:jetty-servlet@9.4.51.v20230217",
+            "deps": [
+              {
+                "nodeId": "org.eclipse.jetty:jetty-security@9.4.51.v20230217"
+              },
+              {
+                "nodeId": "org.eclipse.jetty:jetty-util-ajax@9.4.51.v20230217"
+              }
+            ]
+          },
+          {
+            "nodeId": "org.eclipse.jetty:jetty-security@9.4.51.v20230217",
+            "pkgId": "org.eclipse.jetty:jetty-security@9.4.51.v20230217",
+            "deps": [
+              {
+                "nodeId": "org.eclipse.jetty:jetty-server@9.4.51.v20230217"
+              }
+            ]
+          },
+          {
+            "nodeId": "org.eclipse.jetty:jetty-util-ajax@9.4.51.v20230217",
+            "pkgId": "org.eclipse.jetty:jetty-util-ajax@9.4.51.v20230217",
+            "deps": [
+              {
+                "nodeId": "org.eclipse.jetty:jetty-util@9.4.51.v20230217"
+              }
+            ]
+          },
+          {
+            "nodeId": "org.springframework:spring-web@5.3.29",
+            "pkgId": "org.springframework:spring-web@5.3.29",
+            "deps": [
+              {
+                "nodeId": "org.springframework:spring-beans@5.3.29"
+              },
+              {
+                "nodeId": "org.springframework:spring-core@5.3.29"
+              }
+            ]
+          },
+          {
+            "nodeId": "org.springframework:spring-beans@5.3.29",
+            "pkgId": "org.springframework:spring-beans@5.3.29",
+            "deps": [
+              {
+                "nodeId": "org.springframework:spring-core@5.3.29"
+              }
+            ]
+          },
+          {
+            "nodeId": "org.springframework:spring-core@5.3.29",
+            "pkgId": "org.springframework:spring-core@5.3.29",
+            "deps": [
+              {
+                "nodeId": "org.springframework:spring-jcl@5.3.29"
+              }
+            ]
+          },
+          {
+            "nodeId": "org.springframework:spring-jcl@5.3.29",
+            "pkgId": "org.springframework:spring-jcl@5.3.29",
+            "deps": []
+          }
+        ]
+      }
+    },
+    "projectDescriptor": {
+      "identity": {
+        "type": "gradle",
+        "targetFile": "build.gradle",
+        "rootComponentName": "com.snyk.fixtures:nested-bom-constraints"
+      }
+    }
+  }
+]

--- a/pkg/ecosystems/testdata/fixtures/gradle/nested-bom-constraints/settings.gradle
+++ b/pkg/ecosystems/testdata/fixtures/gradle/nested-bom-constraints/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'nested-bom-constraints'

--- a/pkg/ecosystems/testdata/fixtures/gradle/platform-bom/expected_plugin.json
+++ b/pkg/ecosystems/testdata/fixtures/gradle/platform-bom/expected_plugin.json
@@ -65,15 +65,45 @@
             "pkgId": "org.springframework.boot:spring-boot-dependencies@1.5.8.RELEASE",
             "deps": [
               {
-                "nodeId": "com.google.code.gson:gson@2.8.2"
+                "nodeId": "com.google.code.gson:gson@2.8.2:constraint"
               },
               {
-                "nodeId": "dom4j:dom4j@1.6.1"
+                "nodeId": "dom4j:dom4j@1.6.1:constraint"
               },
               {
-                "nodeId": "xml-apis:xml-apis@1.4.01"
+                "nodeId": "xml-apis:xml-apis@1.4.01:constraint"
               }
             ]
+          },
+          {
+            "nodeId": "com.google.code.gson:gson@2.8.2:constraint",
+            "pkgId": "com.google.code.gson:gson@2.8.2",
+            "info": {
+              "labels": {
+                "constraint": "true"
+              }
+            },
+            "deps": []
+          },
+          {
+            "nodeId": "dom4j:dom4j@1.6.1:constraint",
+            "pkgId": "dom4j:dom4j@1.6.1",
+            "info": {
+              "labels": {
+                "constraint": "true"
+              }
+            },
+            "deps": []
+          },
+          {
+            "nodeId": "xml-apis:xml-apis@1.4.01:constraint",
+            "pkgId": "xml-apis:xml-apis@1.4.01",
+            "info": {
+              "labels": {
+                "constraint": "true"
+              }
+            },
+            "deps": []
           },
           {
             "nodeId": "com.google.code.gson:gson@2.8.2",

--- a/pkg/ecosystems/testdata/fixtures/gradle/platform-bom/expected_plugin.json
+++ b/pkg/ecosystems/testdata/fixtures/gradle/platform-bom/expected_plugin.json
@@ -53,10 +53,10 @@
                 "nodeId": "org.springframework.boot:spring-boot-dependencies@1.5.8.RELEASE"
               },
               {
-                "nodeId": "com.google.code.gson:gson@2.8.2:pruned"
+                "nodeId": "com.google.code.gson:gson@2.8.2"
               },
               {
-                "nodeId": "dom4j:dom4j@1.6.1:pruned"
+                "nodeId": "dom4j:dom4j@1.6.1"
               }
             ]
           },
@@ -71,7 +71,7 @@
                 "nodeId": "dom4j:dom4j@1.6.1"
               },
               {
-                "nodeId": "xml-apis:xml-apis@1.4.01:pruned"
+                "nodeId": "xml-apis:xml-apis@1.4.01"
               }
             ]
           },
@@ -92,36 +92,6 @@
           {
             "nodeId": "xml-apis:xml-apis@1.4.01",
             "pkgId": "xml-apis:xml-apis@1.4.01",
-            "deps": []
-          },
-          {
-            "nodeId": "xml-apis:xml-apis@1.4.01:pruned",
-            "pkgId": "xml-apis:xml-apis@1.4.01",
-            "info": {
-              "labels": {
-                "pruned": "true"
-              }
-            },
-            "deps": []
-          },
-          {
-            "nodeId": "com.google.code.gson:gson@2.8.2:pruned",
-            "pkgId": "com.google.code.gson:gson@2.8.2",
-            "info": {
-              "labels": {
-                "pruned": "true"
-              }
-            },
-            "deps": []
-          },
-          {
-            "nodeId": "dom4j:dom4j@1.6.1:pruned",
-            "pkgId": "dom4j:dom4j@1.6.1",
-            "info": {
-              "labels": {
-                "pruned": "true"
-              }
-            },
             "deps": []
           }
         ]

--- a/pkg/ecosystems/testdata/fixtures/gradle/version-forcing/build.gradle
+++ b/pkg/ecosystems/testdata/fixtures/gradle/version-forcing/build.gradle
@@ -1,0 +1,24 @@
+plugins {
+    id 'java'
+}
+
+group = 'com.snyk.fixtures'
+version = '1.0.0'
+
+repositories {
+    mavenCentral()
+}
+
+// Regression fixture: resolutionStrategy.force is a version-selection rule,
+// not a constraint edge. The forced module must appear as a normal node in
+// its existing graph position (under guice as a transitive), with the forced
+// version selected — never as a `:constraint`-suffixed leaf.
+configurations.all {
+    resolutionStrategy {
+        force 'com.google.guava:guava:32.0.1-jre'
+    }
+}
+
+dependencies {
+    implementation 'com.google.inject:guice:5.1.0'
+}

--- a/pkg/ecosystems/testdata/fixtures/gradle/version-forcing/expected_plugin.json
+++ b/pkg/ecosystems/testdata/fixtures/gradle/version-forcing/expected_plugin.json
@@ -7,17 +7,31 @@
       },
       "pkgs": [
         {
-          "id": "com.snyk.fixtures:with-lock-file@1.0.0",
+          "id": "com.snyk.fixtures:version-forcing@1.0.0",
           "info": {
-            "name": "com.snyk.fixtures:with-lock-file",
+            "name": "com.snyk.fixtures:version-forcing",
             "version": "1.0.0"
           }
         },
         {
-          "id": "org.codehaus.groovy:groovy@3.0.3",
+          "id": "com.google.inject:guice@5.1.0",
           "info": {
-            "name": "org.codehaus.groovy:groovy",
-            "version": "3.0.3"
+            "name": "com.google.inject:guice",
+            "version": "5.1.0"
+          }
+        },
+        {
+          "id": "javax.inject:javax.inject@1",
+          "info": {
+            "name": "javax.inject:javax.inject",
+            "version": "1"
+          }
+        },
+        {
+          "id": "aopalliance:aopalliance@1.0",
+          "info": {
+            "name": "aopalliance:aopalliance",
+            "version": "1.0"
           }
         },
         {
@@ -75,53 +89,36 @@
         "nodes": [
           {
             "nodeId": "root-node",
-            "pkgId": "com.snyk.fixtures:with-lock-file@1.0.0",
+            "pkgId": "com.snyk.fixtures:version-forcing@1.0.0",
             "deps": [
               {
-                "nodeId": "org.codehaus.groovy:groovy@3.0.3"
-              },
-              {
-                "nodeId": "org.codehaus.groovy:groovy@3.0.3:constraint"
-              },
-              {
-                "nodeId": "com.google.guava:guava@32.0.1-jre"
-              },
-              {
-                "nodeId": "com.google.guava:guava@32.0.1-jre:constraint"
-              },
-              {
-                "nodeId": "com.google.guava:failureaccess@1.0.1:constraint"
-              },
-              {
-                "nodeId": "com.google.guava:listenablefuture@9999.0-empty-to-avoid-conflict-with-guava:constraint"
-              },
-              {
-                "nodeId": "com.google.code.findbugs:jsr305@3.0.2:constraint"
-              },
-              {
-                "nodeId": "org.checkerframework:checker-qual@3.33.0:constraint"
-              },
-              {
-                "nodeId": "com.google.errorprone:error_prone_annotations@2.18.0:constraint"
-              },
-              {
-                "nodeId": "com.google.j2objc:j2objc-annotations@2.8:constraint"
+                "nodeId": "com.google.inject:guice@5.1.0"
               }
             ]
           },
           {
-            "nodeId": "org.codehaus.groovy:groovy@3.0.3",
-            "pkgId": "org.codehaus.groovy:groovy@3.0.3",
+            "nodeId": "com.google.inject:guice@5.1.0",
+            "pkgId": "com.google.inject:guice@5.1.0",
+            "deps": [
+              {
+                "nodeId": "javax.inject:javax.inject@1"
+              },
+              {
+                "nodeId": "aopalliance:aopalliance@1.0"
+              },
+              {
+                "nodeId": "com.google.guava:guava@32.0.1-jre"
+              }
+            ]
+          },
+          {
+            "nodeId": "javax.inject:javax.inject@1",
+            "pkgId": "javax.inject:javax.inject@1",
             "deps": []
           },
           {
-            "nodeId": "org.codehaus.groovy:groovy@3.0.3:constraint",
-            "pkgId": "org.codehaus.groovy:groovy@3.0.3",
-            "info": {
-              "labels": {
-                "constraint": "true"
-              }
-            },
+            "nodeId": "aopalliance:aopalliance@1.0",
+            "pkgId": "aopalliance:aopalliance@1.0",
             "deps": []
           },
           {
@@ -177,76 +174,6 @@
             "nodeId": "com.google.j2objc:j2objc-annotations@2.8",
             "pkgId": "com.google.j2objc:j2objc-annotations@2.8",
             "deps": []
-          },
-          {
-            "nodeId": "com.google.guava:guava@32.0.1-jre:constraint",
-            "pkgId": "com.google.guava:guava@32.0.1-jre",
-            "info": {
-              "labels": {
-                "constraint": "true"
-              }
-            },
-            "deps": []
-          },
-          {
-            "nodeId": "com.google.guava:failureaccess@1.0.1:constraint",
-            "pkgId": "com.google.guava:failureaccess@1.0.1",
-            "info": {
-              "labels": {
-                "constraint": "true"
-              }
-            },
-            "deps": []
-          },
-          {
-            "nodeId": "com.google.guava:listenablefuture@9999.0-empty-to-avoid-conflict-with-guava:constraint",
-            "pkgId": "com.google.guava:listenablefuture@9999.0-empty-to-avoid-conflict-with-guava",
-            "info": {
-              "labels": {
-                "constraint": "true"
-              }
-            },
-            "deps": []
-          },
-          {
-            "nodeId": "com.google.code.findbugs:jsr305@3.0.2:constraint",
-            "pkgId": "com.google.code.findbugs:jsr305@3.0.2",
-            "info": {
-              "labels": {
-                "constraint": "true"
-              }
-            },
-            "deps": []
-          },
-          {
-            "nodeId": "org.checkerframework:checker-qual@3.33.0:constraint",
-            "pkgId": "org.checkerframework:checker-qual@3.33.0",
-            "info": {
-              "labels": {
-                "constraint": "true"
-              }
-            },
-            "deps": []
-          },
-          {
-            "nodeId": "com.google.errorprone:error_prone_annotations@2.18.0:constraint",
-            "pkgId": "com.google.errorprone:error_prone_annotations@2.18.0",
-            "info": {
-              "labels": {
-                "constraint": "true"
-              }
-            },
-            "deps": []
-          },
-          {
-            "nodeId": "com.google.j2objc:j2objc-annotations@2.8:constraint",
-            "pkgId": "com.google.j2objc:j2objc-annotations@2.8",
-            "info": {
-              "labels": {
-                "constraint": "true"
-              }
-            },
-            "deps": []
           }
         ]
       }
@@ -255,7 +182,7 @@
       "identity": {
         "type": "gradle",
         "targetFile": "build.gradle",
-        "rootComponentName": "com.snyk.fixtures:with-lock-file"
+        "rootComponentName": "com.snyk.fixtures:version-forcing"
       }
     }
   }

--- a/pkg/ecosystems/testdata/fixtures/gradle/version-forcing/settings.gradle
+++ b/pkg/ecosystems/testdata/fixtures/gradle/version-forcing/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'version-forcing'

--- a/pkg/ecosystems/testdata/fixtures/gradle/with-lock-file/expected_plugin.json
+++ b/pkg/ecosystems/testdata/fixtures/gradle/with-lock-file/expected_plugin.json
@@ -81,47 +81,31 @@
                 "nodeId": "org.codehaus.groovy:groovy@3.0.3"
               },
               {
-                "nodeId": "org.codehaus.groovy:groovy@3.0.3:pruned"
-              },
-              {
                 "nodeId": "com.google.guava:guava@32.0.1-jre"
               },
               {
-                "nodeId": "com.google.guava:guava@32.0.1-jre:pruned"
+                "nodeId": "com.google.guava:failureaccess@1.0.1"
               },
               {
-                "nodeId": "com.google.guava:failureaccess@1.0.1:pruned"
+                "nodeId": "com.google.guava:listenablefuture@9999.0-empty-to-avoid-conflict-with-guava"
               },
               {
-                "nodeId": "com.google.guava:listenablefuture@9999.0-empty-to-avoid-conflict-with-guava:pruned"
+                "nodeId": "com.google.code.findbugs:jsr305@3.0.2"
               },
               {
-                "nodeId": "com.google.code.findbugs:jsr305@3.0.2:pruned"
+                "nodeId": "org.checkerframework:checker-qual@3.33.0"
               },
               {
-                "nodeId": "org.checkerframework:checker-qual@3.33.0:pruned"
+                "nodeId": "com.google.errorprone:error_prone_annotations@2.18.0"
               },
               {
-                "nodeId": "com.google.errorprone:error_prone_annotations@2.18.0:pruned"
-              },
-              {
-                "nodeId": "com.google.j2objc:j2objc-annotations@2.8:pruned"
+                "nodeId": "com.google.j2objc:j2objc-annotations@2.8"
               }
             ]
           },
           {
             "nodeId": "org.codehaus.groovy:groovy@3.0.3",
             "pkgId": "org.codehaus.groovy:groovy@3.0.3",
-            "deps": []
-          },
-          {
-            "nodeId": "org.codehaus.groovy:groovy@3.0.3:pruned",
-            "pkgId": "org.codehaus.groovy:groovy@3.0.3",
-            "info": {
-              "labels": {
-                "pruned": "true"
-              }
-            },
             "deps": []
           },
           {
@@ -176,76 +160,6 @@
           {
             "nodeId": "com.google.j2objc:j2objc-annotations@2.8",
             "pkgId": "com.google.j2objc:j2objc-annotations@2.8",
-            "deps": []
-          },
-          {
-            "nodeId": "com.google.guava:guava@32.0.1-jre:pruned",
-            "pkgId": "com.google.guava:guava@32.0.1-jre",
-            "info": {
-              "labels": {
-                "pruned": "true"
-              }
-            },
-            "deps": []
-          },
-          {
-            "nodeId": "com.google.guava:failureaccess@1.0.1:pruned",
-            "pkgId": "com.google.guava:failureaccess@1.0.1",
-            "info": {
-              "labels": {
-                "pruned": "true"
-              }
-            },
-            "deps": []
-          },
-          {
-            "nodeId": "com.google.guava:listenablefuture@9999.0-empty-to-avoid-conflict-with-guava:pruned",
-            "pkgId": "com.google.guava:listenablefuture@9999.0-empty-to-avoid-conflict-with-guava",
-            "info": {
-              "labels": {
-                "pruned": "true"
-              }
-            },
-            "deps": []
-          },
-          {
-            "nodeId": "com.google.code.findbugs:jsr305@3.0.2:pruned",
-            "pkgId": "com.google.code.findbugs:jsr305@3.0.2",
-            "info": {
-              "labels": {
-                "pruned": "true"
-              }
-            },
-            "deps": []
-          },
-          {
-            "nodeId": "org.checkerframework:checker-qual@3.33.0:pruned",
-            "pkgId": "org.checkerframework:checker-qual@3.33.0",
-            "info": {
-              "labels": {
-                "pruned": "true"
-              }
-            },
-            "deps": []
-          },
-          {
-            "nodeId": "com.google.errorprone:error_prone_annotations@2.18.0:pruned",
-            "pkgId": "com.google.errorprone:error_prone_annotations@2.18.0",
-            "info": {
-              "labels": {
-                "pruned": "true"
-              }
-            },
-            "deps": []
-          },
-          {
-            "nodeId": "com.google.j2objc:j2objc-annotations@2.8:pruned",
-            "pkgId": "com.google.j2objc:j2objc-annotations@2.8",
-            "info": {
-              "labels": {
-                "pruned": "true"
-              }
-            },
             "deps": []
           }
         ]


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [ ] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### Summary

Adjust Gradle resolver to produce proper DAG structure and distinguish constraint edges from real dependencies. Two material changes:

1. **Stop creating pruned nodes for visited dependencies** - instead connect to existing nodes to produce a true DAG where nodes can have multiple parents
2. **Add constraint node support** - distinguish constraint edges (from platform BOMs, dependency locking, `constraints {}` blocks) from real artifact dependencies by creating labeled `:constraint` nodes

### Why

#### Pruning

The previous behavior created artificial "pruned" leaf nodes for already-visited dependencies, producing tree structures with duplicated pruned nodes rather than true DAGs.

Cycle detection is preserved - cyclic references still create pruned nodes to maintain DAG properties.

#### Constraints

Gradle's dependency resolution includes constraint edges alongside real artifact dependencies, but these serve fundamentally different purposes:

- **Real edges**: Represent actual artifact dependencies that appear in classpaths
- **Constraint edges**: Influence version selection without adding artifacts (from platform BOMs, dependency locking, explicit constraints)

Previously, both were treated identically, causing confusing graph structures where:
- Lock file constraints appeared as direct dependencies of the root project
- Platform BOM constraints appeared as children of BOM components
- No way to distinguish version-influencing constraints from real dependencies

**New behavior**: Constraint edges are detected in the init script and rendered as separate `:constraint`-suffixed nodes with appropriate labels. This:
- Preserves diagnostic information about what constraints influenced resolution
- Allows consumers to distinguish constraints from real dependencies
- Prevents constraint edges from interfering with real dependency graph expansion
- Maintains cleaner separation between version selection and actual artifact relationships

Added integration test fixtures for `constraints {}` DSL, `resolutionStrategy.force`, and `dependencySubstitution` to ensure proper constraint vs. real dependency classification.
