### PR TITLE
feat: optimise target-file scans [CMPA-546]

### DIFF
--- a/pkg/ecosystems/gradle/init/snyk-deps-init.gradle
+++ b/pkg/ecosystems/gradle/init/snyk-deps-init.gradle
@@ -5,6 +5,10 @@
 //   Line 1:    metadata JSON object
 //   Lines 2+:  one project JSON object per line (newline-delimited JSON)
 //
+// Optional property: -PsnykTargetBuildFile=<absolutePath>
+//   When set, only the project whose build file matches the path runs (skips all others).
+//   Used by the Go plugin when --target-file points to a specific sub-project build file.
+//
 // Uses Gradle's ResolutionResult API (Gradle 4.4+) to programmatically
 // walk the resolved dependency graph per-project, per-configuration.
 //
@@ -15,9 +19,15 @@
 gradle.projectsEvaluated { g ->
     def root = g.rootProject
 
+    // When snykTargetBuildFile is set, only the matching project runs its task.
+    // Otherwise all projects participate (default behaviour).
+    def targetBuildFile = root.findProperty('snykTargetBuildFile')?.toString()
+
     // One task per project, each writing to its own output file.
     // Isolation makes parallel execution safe; snykDependencyGraph depends on all of these.
-    def perProjectTasks = root.allprojects.collect { proj ->
+    def perProjectTasks = root.allprojects
+        .findAll { proj -> !targetBuildFile || getBuildFilePath(proj) == targetBuildFile }
+        .collect { proj ->
         // Resolved at configuration time so outputs.file() can register it for up-to-date checking.
         def outputFile = resolveReportsFile(proj, "snyk-project.ndjson")
 
@@ -228,13 +238,11 @@ def getBuildFilePath(project) {
     try {
         if (project.hasProperty('layout') && project.layout.hasProperty('projectDirectory')) {
             def projectDir = project.layout.projectDirectory.asFile
-            ['build.gradle', 'build.gradle.kts'].each { fileName ->
-                def buildFile = new File(projectDir, fileName)
-                if (buildFile.exists()) {
-                    return buildFile.absolutePath
-                }
+            def found = ['build.gradle', 'build.gradle.kts'].find { fileName ->
+                new File(projectDir, fileName).exists()
             }
-            return new File(projectDir, 'build.gradle').absolutePath
+            return found ? new File(projectDir, found).absolutePath
+                         : new File(projectDir, 'build.gradle').absolutePath
         }
     } catch (Exception e) {
         // Fallback for older Gradle versions or API failures

--- a/pkg/ecosystems/gradle/plugin.go
+++ b/pkg/ecosystems/gradle/plugin.go
@@ -432,7 +432,16 @@ func buildExtraArgs(projectDir string, options *ecosystems.SCAPluginOptions) []s
 		args = append(args, "--init-script", initPath)
 	}
 
-	// Reserved for future flag forwarding (e.g. --configuration, -P flags).
+	// When --target-file is set, scope the Gradle scan to the matching sub-project only.
+	// The init script reads this property and skips dependency resolution for all other projects.
+	if tf := options.Global.TargetFile; tf != nil {
+		absTarget := *tf
+		if !filepath.IsAbs(absTarget) {
+			absTarget = filepath.Join(projectDir, absTarget)
+		}
+		args = append(args, "-PsnykTargetBuildFile="+absTarget)
+	}
+
 	return args
 }
 

--- a/pkg/ecosystems/gradle/plugin_test.go
+++ b/pkg/ecosystems/gradle/plugin_test.go
@@ -386,6 +386,32 @@ func TestBuildExtraArgs(t *testing.T) {
 		args := buildExtraArgs(dir, opts)
 		assert.Equal(t, []string{"--init-script", validScript}, args)
 	})
+
+	t.Run("adds snykTargetBuildFile for relative target file", func(t *testing.T) {
+		tf := "app/build.gradle"
+		opts := &ecosystems.SCAPluginOptions{
+			Global: ecosystems.GlobalOptions{TargetFile: &tf},
+		}
+		args := buildExtraArgs("/project", opts)
+		assert.Contains(t, args, "-PsnykTargetBuildFile=/project/app/build.gradle")
+	})
+
+	t.Run("adds snykTargetBuildFile for absolute target file unchanged", func(t *testing.T) {
+		tf := "/other/app/build.gradle"
+		opts := &ecosystems.SCAPluginOptions{
+			Global: ecosystems.GlobalOptions{TargetFile: &tf},
+		}
+		args := buildExtraArgs("/project", opts)
+		assert.Contains(t, args, "-PsnykTargetBuildFile=/other/app/build.gradle")
+	})
+
+	t.Run("does not add snykTargetBuildFile when target file is not set", func(t *testing.T) {
+		opts := &ecosystems.SCAPluginOptions{}
+		args := buildExtraArgs("/project", opts)
+		for _, arg := range args {
+			assert.NotContains(t, arg, "snykTargetBuildFile")
+		}
+	})
 }
 
 // ── Target file filtering behavior demonstration ──────────────────────────────

--- a/pkg/ecosystems/testdata/fixtures/gradle/kts-simple/expected_plugin.json
+++ b/pkg/ecosystems/testdata/fixtures/gradle/kts-simple/expected_plugin.json
@@ -150,7 +150,7 @@
     "projectDescriptor": {
       "identity": {
         "type": "gradle",
-        "targetFile": "build.gradle",
+        "targetFile": "build.gradle.kts",
         "rootComponentName": "com.snyk.fixtures:kts-simple"
       }
     }


### PR DESCRIPTION
### What this does
This PR scopes Gradle scans to the target sub-project when `--target-file` is set. Previously, when `--target-file` pointed to a sub-project build file, Gradle resolved dependencies for all sub-projects and Go filtered the results afterward. This change passes the target build file path to the init script as -PsnykTargetBuildFile, so only the matching sub-project's dependency resolution task runs. All other sub-projects are skipped entirely.

