### PR TITLE
chore: update codeowners [PRODSEC-10215]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
-* @snyk/unify @snyk/codesec_unify @snyk/open-source_composition-analysis 
+* @snyk/open-source_unify @snyk/open-source_composition-analysis 
 
 /pkg/ecosystems/ @snyk/open-source_composition-analysis
-/pkg/ecosystems/python/uv/ @snyk/codesec_unify @snyk/open-source_composition-analysis
-/pkg/depgraph @snyk/unify @snyk/codesec_unify @snyk/open-source_unify
-/pkg/sca_plugin @snyk/unify @snyk/codesec_unify @snyk/open-source_unify 
+/pkg/ecosystems/python/uv/ @snyk/open-source_unify @snyk/open-source_composition-analysis
+/pkg/depgraph @snyk/open-source_unify
+/pkg/sca_plugin @snyk/open-source_unify 


### PR DESCRIPTION
Updates codeowners to append the new github governance managed teams.
For more information, please check https://snyksec.atlassian.net/wiki/spaces/PRODSEC/pages/4613570586/H1+2026+Team+rename+Updates+to+CODEOWNERS+and+repository+collaborators+to+match+organisation+change

[IMPORTANT]: 
   If your service uses vervet, you probably to run a commane like `make generate` to update the vervet files.
   This is specific to your repository as there is not standardisation on the command to run.
   