### PR TITLE
feat: [CMPA-542] Adds support in Gradle resolver for `--include-provenance`

### DIFF
--- a/pkg/ecosystems/gradle/README.md
+++ b/pkg/ecosystems/gradle/README.md
@@ -93,6 +93,19 @@ The resolver distinguishes between **constraint edges** (which influence version
 
 This separation prevents constraint-derived edges from interfering with the actual dependency graph structure while preserving diagnostic information about what constraints influenced version resolution.
 
+### Provenance and Checksum Collection
+
+**`--include-provenance` flag support**
+
+The resolver supports collecting SHA1 checksums and generating Package URLs (PURLs) with checksum qualifiers when the `--include-provenance` flag is enabled:
+
+- Uses Gradle's internal `ChecksumService` for optimal performance when available
+- Falls back to manual SHA1 calculation for compatibility
+- Generates PURLs in `pkg:gradle/group/artifact@version?checksum=sha1:hash` format
+- Skips provenance for BOM/platform dependencies (metadata-only)
+
+This focuses on downloadable artifacts rather than constraint dependencies.
+
 ## Technical Implementation Notes
 
 ### File and Project Discovery

--- a/pkg/ecosystems/gradle/README.md
+++ b/pkg/ecosystems/gradle/README.md
@@ -101,10 +101,14 @@ The resolver supports collecting SHA1 checksums and generating Package URLs (PUR
 
 - Uses Gradle's internal `ChecksumService` for optimal performance when available
 - Falls back to manual SHA1 calculation for compatibility
-- Generates PURLs in `pkg:gradle/group/artifact@version?checksum=sha1:hash` format
+- Generates PURLs in `pkg:maven/group/artifact@version?checksum=sha1:hash` format
 - Skips provenance for BOM/platform dependencies (metadata-only)
 
 This focuses on downloadable artifacts rather than constraint dependencies.
+
+**PURL Type Selection**
+
+The resolver uses `pkg:maven` for standard dependencies following Maven coordinate format (group:artifact:version), not `pkg:gradle`. According to the [PURL specification](https://github.com/package-url/purl-spec/blob/main/types-doc/maven-definition.md), `pkg:maven` is the correct type for "Maven JARs and related artifacts" using groupId/artifactId coordinates. The `pkg:gradle` type is [reserved specifically for Gradle plugins](https://github.com/package-url/purl-spec/blob/main/docs/candidate-purl-types.md) from the Gradle Plugin Portal, not for standard Maven-format dependencies resolved by Gradle builds.
 
 ## Technical Implementation Notes
 

--- a/pkg/ecosystems/gradle/depgraph.go
+++ b/pkg/ecosystems/gradle/depgraph.go
@@ -39,37 +39,27 @@ func buildDepGraph(proj *gradleProject, options *ecosystems.SCAPluginOptions) (*
 
 	rootNodeID := builder.GetRootNode().NodeID
 
-	// edges tracks (parent → set of children) across the entire merged graph
-	// so that an edge contributed by more than one configuration is added to
-	// the dep-graph builder exactly once. The dep-graph schema treats Deps as
-	// a set of edges, but depgraph.Builder.ConnectNodes is not idempotent —
-	// without this guard, a dep present in N configurations would appear as
-	// N parallel edges from the same parent.
-	edges := make(map[string]map[string]bool)
-	connectOnce := func(parentID, childID string) error {
-		children := edges[parentID]
-		if children == nil {
-			children = make(map[string]bool)
-			edges[parentID] = children
-		}
-		if children[childID] {
-			return nil
-		}
-		children[childID] = true
-		if err := builder.ConnectNodes(parentID, childID); err != nil {
-			return fmt.Errorf("failed to connect %s -> %s: %w", parentID, childID, err)
-		}
-		return nil
-	}
+	// Create a map of dependency ID to provenance information for quick lookups
+	provenanceMap := buildProvenanceMap(proj.Configurations, options)
+
+	// Create function to ensure each edge is added only once across configurations
+	connectOnce := createEdgeDeduplicator(builder)
 
 	// Filter configurations based on --configuration-matching if specified
-	configurationsToProcess := proj.Configurations
-	if options != nil && options.Gradle.ConfigurationMatching != "" {
-		var err error
-		configurationsToProcess, err = filterConfigurationsByPattern(proj.Configurations, options.Gradle.ConfigurationMatching)
-		if err != nil {
-			return nil, fmt.Errorf("failed to apply configuration matching pattern '%s': %w", options.Gradle.ConfigurationMatching, err)
-		}
+	var configurationMatching string
+	if options != nil {
+		configurationMatching = options.Gradle.ConfigurationMatching
+	}
+	configurationsToProcess, err := filterConfigurationsByPattern(proj.Configurations, configurationMatching)
+	if err != nil {
+		return nil, fmt.Errorf("failed to apply configuration matching pattern '%s': %w", configurationMatching, err)
+	}
+
+	// Create context with shared state for dependency graph building
+	ctx := &depGraphContext{
+		builder:       builder,
+		connectOnce:   connectOnce,
+		provenanceMap: provenanceMap,
 	}
 
 	// Merge all configurations into a single graph.
@@ -85,13 +75,21 @@ func buildDepGraph(proj *gradleProject, options *ecosystems.SCAPluginOptions) (*
 		}
 		processed := make(map[string]bool) // Fresh processed set per configuration; tracks components whose subtree we've expanded in this configuration
 		for _, dep := range cfg.Root.Dependencies {
-			if err := addDep(builder, &dep, rootNodeID, processed, connectOnce); err != nil {
+			if err := ctx.addDep(&dep, rootNodeID, processed); err != nil {
 				return nil, fmt.Errorf("project %s: %w", proj.Path, err)
 			}
 		}
 	}
 
 	return builder.Build(), nil
+}
+
+// depGraphContext holds shared state for building a dependency graph from Gradle data.
+// This avoids passing multiple parameters through recursive calls.
+type depGraphContext struct {
+	builder       *depgraph.Builder
+	connectOnce   func(parentID, childID string) error
+	provenanceMap map[string]*allDepEntry
 }
 
 // addDep recursively adds a resolved dependency node and its children to the
@@ -113,11 +111,7 @@ func buildDepGraph(proj *gradleProject, options *ecosystems.SCAPluginOptions) (*
 //     locking, or constraints {} blocks) become labeled `constraint` leaves
 //     with a `:constraint` node-ID suffix. They do not affect `processed`, so a
 //     real edge to the same component will still be expanded normally.
-//
-// connectOnce wraps depgraph.Builder.ConnectNodes with deduplication so that
-// the same (parent, child) edge is only added once across the entire merged
-// graph (configurations are merged into one dep-graph per project).
-func addDep(builder *depgraph.Builder, dep *gradleDep, parentID string, processed map[string]bool, connectOnce func(parentID, childID string) error) error {
+func (ctx *depGraphContext) addDep(dep *gradleDep, parentID string, processed map[string]bool) error {
 	if dep.ID == "" || dep.Unresolved {
 		return nil
 	}
@@ -130,39 +124,54 @@ func addDep(builder *depgraph.Builder, dep *gradleDep, parentID string, processe
 		// Do not mark `processed` — the real edge to this component (if any)
 		// must still be expanded fully.
 		constraintID := nodeID + ":constraint"
-		builder.AddNode(constraintID, &depgraph.PkgInfo{Name: name, Version: version},
+		// Constraints don't get PURLs as they're not real downloadable artifacts
+		pkgInfo := &depgraph.PkgInfo{
+			Name:    name,
+			Version: version,
+		}
+		ctx.builder.AddNode(constraintID, pkgInfo,
 			depgraph.WithNodeInfo(&depgraph.NodeInfo{
 				Labels: map[string]string{"constraint": "true"},
 			}),
 		)
-		return connectOnce(parentID, constraintID)
+		return ctx.connectOnce(parentID, constraintID)
 	}
 
 	if dep.Pruned == pruneCycle {
 		// Record a pruned leaf for cycles to maintain DAG property and avoid
 		// infinite recursion.
 		prunedID := nodeID + ":pruned"
-		builder.AddNode(prunedID, &depgraph.PkgInfo{Name: name, Version: version},
+		var provenanceEntry *allDepEntry
+		if ctx.provenanceMap != nil {
+			provenanceEntry = ctx.provenanceMap[dep.ID]
+		}
+		pkgInfo := createPkgInfo(name, version, provenanceEntry, ctx.provenanceMap != nil)
+		ctx.builder.AddNode(prunedID, pkgInfo,
 			depgraph.WithNodeInfo(&depgraph.NodeInfo{
 				Labels: map[string]string{"pruned": "true"},
 			}),
 		)
-		return connectOnce(parentID, prunedID)
+		return ctx.connectOnce(parentID, prunedID)
 	} else if dep.Pruned == pruneVisited || processed[nodeID] {
 		// For visited nodes, connect to the existing node instead of creating
 		// a pruned version. This produces a DAG where nodes can have multiple
 		// parents but no cycles.
-		return connectOnce(parentID, nodeID)
+		return ctx.connectOnce(parentID, nodeID)
 	}
 
-	builder.AddNode(nodeID, &depgraph.PkgInfo{Name: name, Version: version})
-	if err := connectOnce(parentID, nodeID); err != nil {
+	var provenanceEntry *allDepEntry
+	if ctx.provenanceMap != nil {
+		provenanceEntry = ctx.provenanceMap[dep.ID]
+	}
+	pkgInfo := createPkgInfo(name, version, provenanceEntry, ctx.provenanceMap != nil)
+	ctx.builder.AddNode(nodeID, pkgInfo)
+	if err := ctx.connectOnce(parentID, nodeID); err != nil {
 		return err
 	}
 
 	processed[nodeID] = true
 	for _, child := range dep.Dependencies {
-		if err := addDep(builder, &child, nodeID, processed, connectOnce); err != nil {
+		if err := ctx.addDep(&child, nodeID, processed); err != nil {
 			return err
 		}
 	}
@@ -199,7 +208,12 @@ func splitGAV(gav string) (name, version string) {
 
 // filterConfigurationsByPattern filters gradle configurations based on a regex pattern.
 // Returns only configurations whose names match the provided regex pattern.
+// If pattern is empty, returns all configurations (no filtering).
 func filterConfigurationsByPattern(configurations []gradleConfig, pattern string) ([]gradleConfig, error) {
+	if pattern == "" {
+		return configurations, nil
+	}
+
 	regex, err := regexp.Compile(pattern)
 	if err != nil {
 		return nil, fmt.Errorf("invalid regex pattern: %w", err)
@@ -213,4 +227,92 @@ func filterConfigurationsByPattern(configurations []gradleConfig, pattern string
 	}
 
 	return filtered, nil
+}
+
+// buildProvenanceMap creates a map from dependency ID to provenance information
+// for quick lookups during graph building. When --include-provenance is enabled,
+// this allows us to attach checksum and type information to dependencies.
+//
+// Note: If multiple configurations resolve the same dependency ID to different
+// artifacts (different checksums), this takes the first one encountered.
+// This could potentially be improved to handle per-configuration artifacts.
+func buildProvenanceMap(configurations []gradleConfig, options *ecosystems.SCAPluginOptions) map[string]*allDepEntry {
+	if options == nil || !options.Global.IncludeProvenance {
+		return nil
+	}
+
+	provenanceMap := make(map[string]*allDepEntry)
+	for _, cfg := range configurations {
+		for i := range cfg.AllDependencies {
+			entry := &cfg.AllDependencies[i]
+			if entry.Checksum != "" {
+				// Only store if we haven't seen this dependency ID before
+				// This preserves the "first configuration wins" behavior
+				if _, exists := provenanceMap[entry.ID]; !exists {
+					provenanceMap[entry.ID] = entry
+				}
+			}
+		}
+	}
+	return provenanceMap
+}
+
+// createEdgeDeduplicator creates a function that ensures each edge is only
+// added once to the dependency graph, even when the same edge appears in
+// multiple configurations.
+func createEdgeDeduplicator(builder *depgraph.Builder) func(parentID, childID string) error {
+	// edges tracks (parent → set of children) across the entire merged graph
+	// so that an edge contributed by more than one configuration is added to
+	// the dep-graph builder exactly once. The dep-graph schema treats Deps as
+	// a set of edges, but depgraph.Builder.ConnectNodes is not idempotent —
+	// without this guard, a dep present in N configurations would appear as
+	// N parallel edges from the same parent.
+	edges := make(map[string]map[string]bool)
+
+	return func(parentID, childID string) error {
+		children := edges[parentID]
+		if children == nil {
+			children = make(map[string]bool)
+			edges[parentID] = children
+		}
+		if children[childID] {
+			return nil
+		}
+		children[childID] = true
+		if err := builder.ConnectNodes(parentID, childID); err != nil {
+			return fmt.Errorf("failed to connect %s -> %s: %w", parentID, childID, err)
+		}
+		return nil
+	}
+}
+
+// createPkgInfo creates a PkgInfo for standard Gradle dependencies.
+// If provenance is enabled and data is available, PURL with checksum information is included.
+func createPkgInfo(name, version string, provenanceEntry *allDepEntry, provenanceEnabled bool) *depgraph.PkgInfo {
+	pkgInfo := &depgraph.PkgInfo{
+		Name:    name,
+		Version: version,
+	}
+
+	// Only generate PURL when provenance is enabled
+	if provenanceEnabled {
+		// Generate PURL for standard group:artifact dependencies
+		parts := strings.SplitN(name, ":", 2)
+		if len(parts) == 2 {
+			group := parts[0]
+			artifact := parts[1]
+
+			// Create base PURL
+			purl := fmt.Sprintf("pkg:gradle/%s/%s@%s", group, artifact, version)
+
+			// Add checksum qualifier if provenance data is available
+			if provenanceEntry != nil && provenanceEntry.Checksum != "" {
+				purl += fmt.Sprintf("?checksum=sha1:%s", provenanceEntry.Checksum)
+			}
+
+			pkgInfo.PackageURL = purl
+		}
+	}
+
+	return pkgInfo
 }

--- a/pkg/ecosystems/gradle/depgraph.go
+++ b/pkg/ecosystems/gradle/depgraph.go
@@ -302,8 +302,11 @@ func createPkgInfo(name, version string, provenanceEntry *allDepEntry, provenanc
 			group := parts[0]
 			artifact := parts[1]
 
-			// Create base PURL
-			purl := fmt.Sprintf("pkg:gradle/%s/%s@%s", group, artifact, version)
+			// Create base PURL using pkg:maven for standard Maven coordinates
+			// Note: This assumes all dependencies use Maven coordinate format (group:artifact:version).
+			// If we later need to surface actual Gradle plugins from the Plugin Portal,
+			// we would need to detect and use pkg:gradle for those instead.
+			purl := fmt.Sprintf("pkg:maven/%s/%s@%s", group, artifact, version)
 
 			// Add checksum qualifier if provenance data is available
 			if provenanceEntry != nil && provenanceEntry.Checksum != "" {

--- a/pkg/ecosystems/gradle/depgraph_test.go
+++ b/pkg/ecosystems/gradle/depgraph_test.go
@@ -763,7 +763,7 @@ func TestCreatePkgInfo(t *testing.T) {
 
 		assert.Equal(t, "org.example:artifact", pkgInfo.Name)
 		assert.Equal(t, "1.0.0", pkgInfo.Version)
-		assert.Equal(t, "pkg:gradle/org.example/artifact@1.0.0", pkgInfo.PackageURL) // Base PURL when provenance enabled
+		assert.Equal(t, "pkg:maven/org.example/artifact@1.0.0", pkgInfo.PackageURL) // Base PURL when provenance enabled
 	})
 
 	t.Run("creates PkgInfo with checksum PURL when provenance available", func(t *testing.T) {
@@ -777,7 +777,7 @@ func TestCreatePkgInfo(t *testing.T) {
 
 		assert.Equal(t, "org.example:artifact", pkgInfo.Name)
 		assert.Equal(t, "1.0.0", pkgInfo.Version)
-		assert.Equal(t, "pkg:gradle/org.example/artifact@1.0.0?checksum=sha1:abcd1234567890", pkgInfo.PackageURL)
+		assert.Equal(t, "pkg:maven/org.example/artifact@1.0.0?checksum=sha1:abcd1234567890", pkgInfo.PackageURL)
 	})
 
 	t.Run("creates PkgInfo with SHA1 checksum in PURL", func(t *testing.T) {
@@ -789,7 +789,7 @@ func TestCreatePkgInfo(t *testing.T) {
 
 		pkgInfo := createPkgInfo("org.example:artifact", "1.0.0", provenanceEntry, true)
 
-		assert.Equal(t, "pkg:gradle/org.example/artifact@1.0.0?checksum=sha1:abcd1234567890", pkgInfo.PackageURL)
+		assert.Equal(t, "pkg:maven/org.example/artifact@1.0.0?checksum=sha1:abcd1234567890", pkgInfo.PackageURL)
 	})
 
 	t.Run("creates PURL without checksum when checksum is empty", func(t *testing.T) {
@@ -800,7 +800,7 @@ func TestCreatePkgInfo(t *testing.T) {
 
 		pkgInfo := createPkgInfo("org.example:artifact", "1.0.0", provenanceEntry, true)
 
-		assert.Equal(t, "pkg:gradle/org.example/artifact@1.0.0", pkgInfo.PackageURL)
+		assert.Equal(t, "pkg:maven/org.example/artifact@1.0.0", pkgInfo.PackageURL)
 	})
 
 	t.Run("skips PURL for non-standard dependency ID format", func(t *testing.T) {

--- a/pkg/ecosystems/gradle/depgraph_test.go
+++ b/pkg/ecosystems/gradle/depgraph_test.go
@@ -740,4 +740,78 @@ func TestFilterConfigurationsByPattern(t *testing.T) {
 		require.NoError(t, err)
 		assert.Len(t, filtered, 5)
 	})
+
+	t.Run("returns all configurations when pattern is empty", func(t *testing.T) {
+		filtered, err := filterConfigurationsByPattern(configs, "")
+		require.NoError(t, err)
+		assert.Len(t, filtered, 5)
+		assert.Equal(t, configs, filtered) // Should return the exact same slice
+	})
+}
+
+func TestCreatePkgInfo(t *testing.T) {
+	t.Run("creates basic PkgInfo without provenance enabled", func(t *testing.T) {
+		pkgInfo := createPkgInfo("org.example:artifact", "1.0.0", nil, false)
+
+		assert.Equal(t, "org.example:artifact", pkgInfo.Name)
+		assert.Equal(t, "1.0.0", pkgInfo.Version)
+		assert.Empty(t, pkgInfo.PackageURL) // No PURL when provenance disabled
+	})
+
+	t.Run("creates PkgInfo with base PURL when provenance enabled but no provenance data", func(t *testing.T) {
+		pkgInfo := createPkgInfo("org.example:artifact", "1.0.0", nil, true)
+
+		assert.Equal(t, "org.example:artifact", pkgInfo.Name)
+		assert.Equal(t, "1.0.0", pkgInfo.Version)
+		assert.Equal(t, "pkg:gradle/org.example/artifact@1.0.0", pkgInfo.PackageURL) // Base PURL when provenance enabled
+	})
+
+	t.Run("creates PkgInfo with checksum PURL when provenance available", func(t *testing.T) {
+		provenanceEntry := &allDepEntry{
+			ID:       "org.example:artifact:1.0.0",
+			Checksum: "abcd1234567890",
+			Type:     "jar",
+		}
+
+		pkgInfo := createPkgInfo("org.example:artifact", "1.0.0", provenanceEntry, true)
+
+		assert.Equal(t, "org.example:artifact", pkgInfo.Name)
+		assert.Equal(t, "1.0.0", pkgInfo.Version)
+		assert.Equal(t, "pkg:gradle/org.example/artifact@1.0.0?checksum=sha1:abcd1234567890", pkgInfo.PackageURL)
+	})
+
+	t.Run("creates PkgInfo with SHA1 checksum in PURL", func(t *testing.T) {
+		provenanceEntry := &allDepEntry{
+			ID:       "org.example:artifact:1.0.0",
+			Checksum: "abcd1234567890",
+			Type:     "jar",
+		}
+
+		pkgInfo := createPkgInfo("org.example:artifact", "1.0.0", provenanceEntry, true)
+
+		assert.Equal(t, "pkg:gradle/org.example/artifact@1.0.0?checksum=sha1:abcd1234567890", pkgInfo.PackageURL)
+	})
+
+	t.Run("creates PURL without checksum when checksum is empty", func(t *testing.T) {
+		provenanceEntry := &allDepEntry{
+			ID:   "org.example:artifact:1.0.0",
+			Type: "jar",
+		}
+
+		pkgInfo := createPkgInfo("org.example:artifact", "1.0.0", provenanceEntry, true)
+
+		assert.Equal(t, "pkg:gradle/org.example/artifact@1.0.0", pkgInfo.PackageURL)
+	})
+
+	t.Run("skips PURL for non-standard dependency ID format", func(t *testing.T) {
+		provenanceEntry := &allDepEntry{
+			ID:       "invalid-id",
+			Checksum: "abcd1234567890",
+			Type:     "jar",
+		}
+
+		pkgInfo := createPkgInfo("invalid-id", "", provenanceEntry, true)
+
+		assert.Empty(t, pkgInfo.PackageURL)
+	})
 }

--- a/pkg/ecosystems/gradle/init/snyk-deps-init.gradle
+++ b/pkg/ecosystems/gradle/init/snyk-deps-init.gradle
@@ -23,6 +23,9 @@ gradle.projectsEvaluated { g ->
     // Otherwise all projects participate (default behaviour).
     def targetBuildFile = root.findProperty('snykTargetBuildFile')?.toString()
 
+    // Check if provenance (checksums) should be included
+    def includeProvenance = root.findProperty('snykIncludeProvenance')?.toBoolean() ?: false
+
     // One task per project, each writing to its own output file.
     // Isolation makes parallel execution safe; snykDependencyGraph depends on all of these.
     def perProjectTasks = root.allprojects
@@ -42,7 +45,7 @@ gradle.projectsEvaluated { g ->
             }
             doLast {
                 outputFile.parentFile.mkdirs()
-                outputFile.text = groovy.json.JsonOutput.toJson(buildProjectEntry(proj))
+                outputFile.text = groovy.json.JsonOutput.toJson(buildProjectEntry(proj, includeProvenance))
             }
         }
     }
@@ -101,7 +104,7 @@ def buildMetadata(rootProject) {
 
 // ── Per-project entry ───────────────────────────────────────────────
 
-def buildProjectEntry(project) {
+def buildProjectEntry(project, includeProvenance = false) {
     def resolvableConfigs = project.configurations.matching { it.canBeResolved }
 
     def gav = "${project.group}:${project.name}:${project.version}"
@@ -119,7 +122,7 @@ def buildProjectEntry(project) {
 
     resolvableConfigs.each { config ->
         try {
-            def configEntry = resolveConfiguration(config, project)
+            def configEntry = resolveConfiguration(config, includeProvenance)
             if (configEntry != null) {
                 entry.configurations << configEntry
             }
@@ -136,7 +139,7 @@ def buildProjectEntry(project) {
 
 // ── Configuration resolution ────────────────────────────────────────
 
-def resolveConfiguration(config, project) {
+def resolveConfiguration(config, includeProvenance = false) {
     def resolutionResult = config.incoming.resolutionResult
     def rootComponent = resolutionResult.root
 
@@ -144,6 +147,12 @@ def resolveConfiguration(config, project) {
     def processed = new HashSet<String>()
     def ancestry = new HashSet<String>()
     def tree = walkDependencies(rootComponent, processed, ancestry)
+
+    // Build artifact lookup map once per configuration for O(1) lookups
+    def artifactLookup = null
+    if (includeProvenance) {
+        artifactLookup = buildArtifactLookup(config)
+    }
 
     return [
         name            : config.name,
@@ -153,7 +162,7 @@ def resolveConfiguration(config, project) {
             dependencies: tree,
         ],
         // Flat list of all resolved components for quick lookups
-        allDependencies: collectAllDependencies(resolutionResult),
+        allDependencies: collectAllDependencies(resolutionResult, includeProvenance, artifactLookup),
     ]
 }
 
@@ -200,7 +209,6 @@ def walkDependencies(component, Set<String> processed, Set<String> ancestry) {
                 ancestry.add(id)
                 children << [
                     id          : id,
-                    // Omit 'requested' field to reduce memory usage
                     dependencies: walkDependencies(selected, processed, ancestry),
                 ]
                 ancestry.remove(id)
@@ -218,15 +226,61 @@ def walkDependencies(component, Set<String> processed, Set<String> ancestry) {
     return children
 }
 
+// ── Artifact lookup optimization ───────────────────────────────────
+
+// Builds a lookup map from ComponentIdentifier -> List<ResolvedArtifactResult>
+// This converts O(C*A) artifact searches into O(1) lookups per component
+def buildArtifactLookup(config) {
+    def lookup = [:].withDefault { [] }
+    try {
+        def artifactCollection = config.incoming.artifacts
+        def resolvedArtifacts = null
+
+        // Try different API approaches for Gradle version compatibility
+        // We use capability-based detection rather than gradle.gradleVersion parsing
+        // to handle custom builds, snapshots, and vendor distributions robustly
+        try {
+            // Gradle 7+ approach - resolvedArtifacts property
+            def artifactsProvider = artifactCollection.resolvedArtifacts
+            resolvedArtifacts = artifactsProvider.get()
+        } catch (Exception e1) {
+            // Gradle 6 approach - direct iteration over artifact collection
+            resolvedArtifacts = []
+            artifactCollection.each { artifact ->
+                if (artifact instanceof org.gradle.api.artifacts.result.ResolvedArtifactResult) {
+                    resolvedArtifacts << artifact
+                }
+            }
+        }
+
+        resolvedArtifacts.each { artifact ->
+            def componentId = artifact.id.componentIdentifier
+            lookup[componentId] << artifact
+        }
+
+        return lookup
+    } catch (Exception e) {
+        return [:] // Return empty map on any error
+    }
+}
+
 // ── Flat dependency collection ──────────────────────────────────────
 
-def collectAllDependencies(resolutionResult) {
+def collectAllDependencies(resolutionResult, includeProvenance, artifactLookup) {
     def all = []
 
     resolutionResult.allComponents.each { component ->
-        all << [
+        def entry = [
             id: componentId(component),
         ]
+
+        if (includeProvenance) {
+            def provenance = computeProvenance(component, artifactLookup)
+            if (provenance != null) {
+                entry.putAll(provenance)
+            }
+        }
+        all << entry
     }
 
     return all
@@ -268,5 +322,99 @@ def resolveReportsFile(project, String fileName) {
         return new File(project.layout.buildDirectory.dir("reports").get().asFile, fileName)
     } catch (Exception e) {
         return new File(project.buildDir, "reports/${fileName}")
+    }
+}
+
+// Computes provenance information (SHA1 hash and file type) for a resolved component
+// Uses the current configuration's artifacts to find the right artifact for this component
+def computeProvenance(component, artifactLookup) {
+    try {
+        // Check if this is a ModuleComponentIdentifier (external dependency)
+        def id = component.id
+        if (!id.hasProperty('group') || !id.hasProperty('module') || !id.hasProperty('version')) {
+            // Skip project components or components without standard GAV coordinates
+            return null
+        }
+
+        def moduleVersion = component.moduleVersion
+        if (moduleVersion == null) {
+            return null
+        }
+
+        // Use O(1) artifact lookup
+        def matchingArtifacts = artifactLookup[component.id] ?: []
+
+        if (!matchingArtifacts.empty) {
+            // Use the first matching artifact (typically the main JAR)
+            def artifact = matchingArtifacts.first()
+            def file = artifact.file
+
+            // Extract artifact type from file extension (most reliable approach)
+            def type = file.name.lastIndexOf('.') >= 0 ? 
+                file.name.substring(file.name.lastIndexOf('.') + 1) : 'jar'
+
+            // Try to get checksum from Gradle's built-in mechanisms first
+            def checksum = getGradleChecksum(file, artifact)
+            if (checksum == null) {
+                // Fallback to manual calculation if Gradle doesn't provide it
+                checksum = computeSHA1(file)
+            }
+
+            if (checksum != null) {
+                return [
+                    checksum: checksum,
+                    type: type
+                ]
+            }
+        }
+        // Note: BOM/platform dependencies typically don't have traditional artifacts
+        // with files that can be checksummed, so we skip provenance for these
+
+        return null
+    } catch (Exception e) {
+        // Return null on any error to avoid breaking the build
+        return null
+    }
+}
+
+// Attempts to get checksum from Gradle's built-in ChecksumService
+// Returns null if not available, falling back to manual calculation
+def getGradleChecksum(File file, artifact) {
+    // Use Gradle's internal ChecksumService for optimized SHA1 calculation
+    // This is available in Gradle 6+ and provides fast, cached checksums
+
+    if (file.exists()) {
+        try {
+            def services = gradle.services
+            def checksumService = services.get(org.gradle.internal.hash.ChecksumService)
+            def hashCode = checksumService.sha1(file)
+            def result = hashCode.toString()
+            return result
+        } catch (Exception e) {
+            // ChecksumService may not be available in all Gradle versions or builds
+        }
+    }
+    return null
+}
+
+// Computes SHA1 hash of a file manually
+def computeSHA1(File file) {
+    try {
+        if (!file.exists()) {
+            return null
+        }
+
+        def digest = java.security.MessageDigest.getInstance('SHA-1')
+        file.withInputStream { stream ->
+            def buffer = new byte[8192]
+            int bytesRead
+            while ((bytesRead = stream.read(buffer)) != -1) {
+                digest.update(buffer, 0, bytesRead)
+            }
+        }
+        def result = digest.digest().encodeHex().toString()
+        return result
+    } catch (Exception e) {
+        return null
     }
 }

--- a/pkg/ecosystems/gradle/parser.go
+++ b/pkg/ecosystems/gradle/parser.go
@@ -91,7 +91,9 @@ type gradleDep struct {
 
 // allDepEntry is a member of the flat allDependencies list.
 type allDepEntry struct {
-	ID string `json:"id"`
+	ID       string `json:"id"`
+	Checksum string `json:"checksum,omitempty"`
+	Type     string `json:"type,omitempty"`
 }
 
 // parseDependencyGraphJSON deserialises the NDJSON file produced by snyk-deps-init.gradle.

--- a/pkg/ecosystems/gradle/plugin.go
+++ b/pkg/ecosystems/gradle/plugin.go
@@ -442,6 +442,11 @@ func buildExtraArgs(projectDir string, options *ecosystems.SCAPluginOptions) []s
 		args = append(args, "-PsnykTargetBuildFile="+absTarget)
 	}
 
+	// Pass --include-provenance flag to the init script as a Gradle property
+	if options.Global.IncludeProvenance {
+		args = append(args, "-PsnykIncludeProvenance=true")
+	}
+
 	return args
 }
 

--- a/pkg/ecosystems/gradle/plugin_integration_test.go
+++ b/pkg/ecosystems/gradle/plugin_integration_test.go
@@ -187,6 +187,23 @@ func pluginTestCases() map[string]PluginTestCase {
 			Fixture: "multi-module-bom",
 			Options: ecosystems.NewPluginOptions(),
 		},
+		// Provenance integration tests - exercises --include-provenance flag
+		// to verify SHA1 checksums are computed and included in PURLs.
+		"simple_with_provenance": {
+			Fixture:      "simple",
+			Options:      ecosystems.NewPluginOptions().WithIncludeProvenance(true),
+			ExpectedFile: "expected_plugin_with_provenance.json",
+		},
+		"platform_bom_with_provenance": {
+			Fixture:      "platform-bom",
+			Options:      ecosystems.NewPluginOptions().WithIncludeProvenance(true),
+			ExpectedFile: "expected_plugin_with_provenance.json",
+		},
+		"multi_module_with_provenance": {
+			Fixture:      "multi-module",
+			Options:      ecosystems.NewPluginOptions().WithIncludeProvenance(true),
+			ExpectedFile: "expected_plugin_with_provenance.json",
+		},
 	}
 }
 

--- a/pkg/ecosystems/options.go
+++ b/pkg/ecosystems/options.go
@@ -28,6 +28,7 @@ type GlobalOptions struct {
 	ForceSingleGraph              bool                 `arg:"--force-single-graph"`
 	ForceIncludeWorkspacePackages bool                 `arg:"--internal-uv-workspace-packages"`
 	ProjectName                   *string              `arg:"--project-name"`
+	IncludeProvenance             bool                 `arg:"--include-provenance"`
 	RawFlags                      []string
 }
 
@@ -178,5 +179,10 @@ func (o *SCAPluginOptions) WithGradleInitScript(initScript string) *SCAPluginOpt
 
 func (o *SCAPluginOptions) WithGradleSkipWrapper(skipWrapper bool) *SCAPluginOptions {
 	o.Gradle.SkipWrapper = skipWrapper
+	return o
+}
+
+func (o *SCAPluginOptions) WithIncludeProvenance(includeProvenance bool) *SCAPluginOptions {
+	o.Global.IncludeProvenance = includeProvenance
 	return o
 }

--- a/pkg/ecosystems/options_test.go
+++ b/pkg/ecosystems/options_test.go
@@ -33,6 +33,7 @@ func TestNewPluginOptionsFromRawFlags_AllFields(t *testing.T) {
 				"--all-sub-projects",
 				"--init-script", "custom.gradle",
 				"--gradle-skip-wrapper",
+				"--include-provenance",
 			},
 			expected: &SCAPluginOptions{
 				Global: GlobalOptions{
@@ -45,6 +46,7 @@ func TestNewPluginOptionsFromRawFlags_AllFields(t *testing.T) {
 					AllowOutOfSync:                true,
 					ForceSingleGraph:              true,
 					ForceIncludeWorkspacePackages: true,
+					IncludeProvenance:             true,
 				},
 				Python: PythonOptions{
 					NoBuildIsolation: true,
@@ -315,4 +317,18 @@ func TestNewPluginOptionsFromRawFlags_UnknownFlags(t *testing.T) {
 	assert.NotNil(t, got.Global.TargetFile)
 	assert.Equal(t, "package.json", *got.Global.TargetFile)
 	assert.True(t, got.Global.IncludeDev)
+}
+
+func TestNewPluginOptionsFromRawFlags_IncludeProvenance(t *testing.T) {
+	got, err := NewPluginOptionsFromRawFlags([]string{"--include-provenance"})
+	assert.NoError(t, err)
+	assert.True(t, got.Global.IncludeProvenance)
+}
+
+func TestWithIncludeProvenance(t *testing.T) {
+	options := NewPluginOptions().WithIncludeProvenance(true)
+	assert.True(t, options.Global.IncludeProvenance)
+
+	options = NewPluginOptions().WithIncludeProvenance(false)
+	assert.False(t, options.Global.IncludeProvenance)
 }

--- a/pkg/ecosystems/testdata/fixtures/gradle/multi-module/expected_plugin_with_provenance.json
+++ b/pkg/ecosystems/testdata/fixtures/gradle/multi-module/expected_plugin_with_provenance.json
@@ -52,7 +52,7 @@
           "info": {
             "name": "com.snyk.fixtures:lib",
             "version": "1.0.0",
-            "purl": "pkg:gradle/com.snyk.fixtures/lib@1.0.0"
+            "purl": "pkg:maven/com.snyk.fixtures/lib@1.0.0"
           }
         },
         {
@@ -60,7 +60,7 @@
           "info": {
             "name": "org.apache.commons:commons-lang3",
             "version": "3.14.0",
-            "purl": "pkg:gradle/org.apache.commons/commons-lang3@3.14.0?checksum=sha1:1ed471194b02f2c6cb734a0cd6f6f107c673afae"
+            "purl": "pkg:maven/org.apache.commons/commons-lang3@3.14.0?checksum=sha1:1ed471194b02f2c6cb734a0cd6f6f107c673afae"
           }
         },
         {
@@ -68,7 +68,7 @@
           "info": {
             "name": "com.google.guava:guava",
             "version": "30.1.1-jre",
-            "purl": "pkg:gradle/com.google.guava/guava@30.1.1-jre?checksum=sha1:87e0fd1df874ea3cbe577702fe6f17068b790fd8"
+            "purl": "pkg:maven/com.google.guava/guava@30.1.1-jre?checksum=sha1:87e0fd1df874ea3cbe577702fe6f17068b790fd8"
           }
         },
         {
@@ -76,7 +76,7 @@
           "info": {
             "name": "com.google.guava:failureaccess",
             "version": "1.0.1",
-            "purl": "pkg:gradle/com.google.guava/failureaccess@1.0.1?checksum=sha1:1dcf1de382a0bf95a3d8b0849546c88bac1292c9"
+            "purl": "pkg:maven/com.google.guava/failureaccess@1.0.1?checksum=sha1:1dcf1de382a0bf95a3d8b0849546c88bac1292c9"
           }
         },
         {
@@ -84,7 +84,7 @@
           "info": {
             "name": "com.google.guava:listenablefuture",
             "version": "9999.0-empty-to-avoid-conflict-with-guava",
-            "purl": "pkg:gradle/com.google.guava/listenablefuture@9999.0-empty-to-avoid-conflict-with-guava?checksum=sha1:b421526c5f297295adef1c886e5246c39d4ac629"
+            "purl": "pkg:maven/com.google.guava/listenablefuture@9999.0-empty-to-avoid-conflict-with-guava?checksum=sha1:b421526c5f297295adef1c886e5246c39d4ac629"
           }
         },
         {
@@ -92,7 +92,7 @@
           "info": {
             "name": "com.google.code.findbugs:jsr305",
             "version": "3.0.2",
-            "purl": "pkg:gradle/com.google.code.findbugs/jsr305@3.0.2?checksum=sha1:25ea2e8b0c338a877313bd4672d3fe056ea78f0d"
+            "purl": "pkg:maven/com.google.code.findbugs/jsr305@3.0.2?checksum=sha1:25ea2e8b0c338a877313bd4672d3fe056ea78f0d"
           }
         },
         {
@@ -100,7 +100,7 @@
           "info": {
             "name": "org.checkerframework:checker-qual",
             "version": "3.8.0",
-            "purl": "pkg:gradle/org.checkerframework/checker-qual@3.8.0?checksum=sha1:6b83e4a33220272c3a08991498ba9dc09519f190"
+            "purl": "pkg:maven/org.checkerframework/checker-qual@3.8.0?checksum=sha1:6b83e4a33220272c3a08991498ba9dc09519f190"
           }
         },
         {
@@ -108,7 +108,7 @@
           "info": {
             "name": "com.google.errorprone:error_prone_annotations",
             "version": "2.5.1",
-            "purl": "pkg:gradle/com.google.errorprone/error_prone_annotations@2.5.1?checksum=sha1:562d366678b89ce5d6b6b82c1a073880341e3fba"
+            "purl": "pkg:maven/com.google.errorprone/error_prone_annotations@2.5.1?checksum=sha1:562d366678b89ce5d6b6b82c1a073880341e3fba"
           }
         },
         {
@@ -116,7 +116,7 @@
           "info": {
             "name": "com.google.j2objc:j2objc-annotations",
             "version": "1.3",
-            "purl": "pkg:gradle/com.google.j2objc/j2objc-annotations@1.3?checksum=sha1:ba035118bc8bac37d7eff77700720999acd9986d"
+            "purl": "pkg:maven/com.google.j2objc/j2objc-annotations@1.3?checksum=sha1:ba035118bc8bac37d7eff77700720999acd9986d"
           }
         }
       ],
@@ -233,7 +233,7 @@
           "info": {
             "name": "com.google.guava:guava",
             "version": "30.1.1-jre",
-            "purl": "pkg:gradle/com.google.guava/guava@30.1.1-jre?checksum=sha1:87e0fd1df874ea3cbe577702fe6f17068b790fd8"
+            "purl": "pkg:maven/com.google.guava/guava@30.1.1-jre?checksum=sha1:87e0fd1df874ea3cbe577702fe6f17068b790fd8"
           }
         },
         {
@@ -241,7 +241,7 @@
           "info": {
             "name": "com.google.guava:failureaccess",
             "version": "1.0.1",
-            "purl": "pkg:gradle/com.google.guava/failureaccess@1.0.1?checksum=sha1:1dcf1de382a0bf95a3d8b0849546c88bac1292c9"
+            "purl": "pkg:maven/com.google.guava/failureaccess@1.0.1?checksum=sha1:1dcf1de382a0bf95a3d8b0849546c88bac1292c9"
           }
         },
         {
@@ -249,7 +249,7 @@
           "info": {
             "name": "com.google.guava:listenablefuture",
             "version": "9999.0-empty-to-avoid-conflict-with-guava",
-            "purl": "pkg:gradle/com.google.guava/listenablefuture@9999.0-empty-to-avoid-conflict-with-guava?checksum=sha1:b421526c5f297295adef1c886e5246c39d4ac629"
+            "purl": "pkg:maven/com.google.guava/listenablefuture@9999.0-empty-to-avoid-conflict-with-guava?checksum=sha1:b421526c5f297295adef1c886e5246c39d4ac629"
           }
         },
         {
@@ -257,7 +257,7 @@
           "info": {
             "name": "com.google.code.findbugs:jsr305",
             "version": "3.0.2",
-            "purl": "pkg:gradle/com.google.code.findbugs/jsr305@3.0.2?checksum=sha1:25ea2e8b0c338a877313bd4672d3fe056ea78f0d"
+            "purl": "pkg:maven/com.google.code.findbugs/jsr305@3.0.2?checksum=sha1:25ea2e8b0c338a877313bd4672d3fe056ea78f0d"
           }
         },
         {
@@ -265,7 +265,7 @@
           "info": {
             "name": "org.checkerframework:checker-qual",
             "version": "3.8.0",
-            "purl": "pkg:gradle/org.checkerframework/checker-qual@3.8.0?checksum=sha1:6b83e4a33220272c3a08991498ba9dc09519f190"
+            "purl": "pkg:maven/org.checkerframework/checker-qual@3.8.0?checksum=sha1:6b83e4a33220272c3a08991498ba9dc09519f190"
           }
         },
         {
@@ -273,7 +273,7 @@
           "info": {
             "name": "com.google.errorprone:error_prone_annotations",
             "version": "2.5.1",
-            "purl": "pkg:gradle/com.google.errorprone/error_prone_annotations@2.5.1?checksum=sha1:562d366678b89ce5d6b6b82c1a073880341e3fba"
+            "purl": "pkg:maven/com.google.errorprone/error_prone_annotations@2.5.1?checksum=sha1:562d366678b89ce5d6b6b82c1a073880341e3fba"
           }
         },
         {
@@ -281,7 +281,7 @@
           "info": {
             "name": "com.google.j2objc:j2objc-annotations",
             "version": "1.3",
-            "purl": "pkg:gradle/com.google.j2objc/j2objc-annotations@1.3?checksum=sha1:ba035118bc8bac37d7eff77700720999acd9986d"
+            "purl": "pkg:maven/com.google.j2objc/j2objc-annotations@1.3?checksum=sha1:ba035118bc8bac37d7eff77700720999acd9986d"
           }
         }
       ],

--- a/pkg/ecosystems/testdata/fixtures/gradle/multi-module/expected_plugin_with_provenance.json
+++ b/pkg/ecosystems/testdata/fixtures/gradle/multi-module/expected_plugin_with_provenance.json
@@ -1,0 +1,365 @@
+[
+  {
+    "depGraph": {
+      "schemaVersion": "1.3.0",
+      "pkgManager": {
+        "name": "gradle"
+      },
+      "pkgs": [
+        {
+          "id": "com.snyk.fixtures:multi-module-app@1.0.0",
+          "info": {
+            "name": "com.snyk.fixtures:multi-module-app",
+            "version": "1.0.0"
+          }
+        }
+      ],
+      "graph": {
+        "rootNodeId": "root-node",
+        "nodes": [
+          {
+            "nodeId": "root-node",
+            "pkgId": "com.snyk.fixtures:multi-module-app@1.0.0",
+            "deps": []
+          }
+        ]
+      }
+    },
+    "projectDescriptor": {
+      "identity": {
+        "type": "gradle",
+        "targetFile": "build.gradle",
+        "rootComponentName": "com.snyk.fixtures:multi-module-app"
+      }
+    }
+  },
+  {
+    "depGraph": {
+      "schemaVersion": "1.3.0",
+      "pkgManager": {
+        "name": "gradle"
+      },
+      "pkgs": [
+        {
+          "id": "com.snyk.fixtures:app@1.0.0",
+          "info": {
+            "name": "com.snyk.fixtures:app",
+            "version": "1.0.0"
+          }
+        },
+        {
+          "id": "com.snyk.fixtures:lib@1.0.0",
+          "info": {
+            "name": "com.snyk.fixtures:lib",
+            "version": "1.0.0",
+            "purl": "pkg:gradle/com.snyk.fixtures/lib@1.0.0"
+          }
+        },
+        {
+          "id": "org.apache.commons:commons-lang3@3.14.0",
+          "info": {
+            "name": "org.apache.commons:commons-lang3",
+            "version": "3.14.0",
+            "purl": "pkg:gradle/org.apache.commons/commons-lang3@3.14.0?checksum=sha1:1ed471194b02f2c6cb734a0cd6f6f107c673afae"
+          }
+        },
+        {
+          "id": "com.google.guava:guava@30.1.1-jre",
+          "info": {
+            "name": "com.google.guava:guava",
+            "version": "30.1.1-jre",
+            "purl": "pkg:gradle/com.google.guava/guava@30.1.1-jre?checksum=sha1:87e0fd1df874ea3cbe577702fe6f17068b790fd8"
+          }
+        },
+        {
+          "id": "com.google.guava:failureaccess@1.0.1",
+          "info": {
+            "name": "com.google.guava:failureaccess",
+            "version": "1.0.1",
+            "purl": "pkg:gradle/com.google.guava/failureaccess@1.0.1?checksum=sha1:1dcf1de382a0bf95a3d8b0849546c88bac1292c9"
+          }
+        },
+        {
+          "id": "com.google.guava:listenablefuture@9999.0-empty-to-avoid-conflict-with-guava",
+          "info": {
+            "name": "com.google.guava:listenablefuture",
+            "version": "9999.0-empty-to-avoid-conflict-with-guava",
+            "purl": "pkg:gradle/com.google.guava/listenablefuture@9999.0-empty-to-avoid-conflict-with-guava?checksum=sha1:b421526c5f297295adef1c886e5246c39d4ac629"
+          }
+        },
+        {
+          "id": "com.google.code.findbugs:jsr305@3.0.2",
+          "info": {
+            "name": "com.google.code.findbugs:jsr305",
+            "version": "3.0.2",
+            "purl": "pkg:gradle/com.google.code.findbugs/jsr305@3.0.2?checksum=sha1:25ea2e8b0c338a877313bd4672d3fe056ea78f0d"
+          }
+        },
+        {
+          "id": "org.checkerframework:checker-qual@3.8.0",
+          "info": {
+            "name": "org.checkerframework:checker-qual",
+            "version": "3.8.0",
+            "purl": "pkg:gradle/org.checkerframework/checker-qual@3.8.0?checksum=sha1:6b83e4a33220272c3a08991498ba9dc09519f190"
+          }
+        },
+        {
+          "id": "com.google.errorprone:error_prone_annotations@2.5.1",
+          "info": {
+            "name": "com.google.errorprone:error_prone_annotations",
+            "version": "2.5.1",
+            "purl": "pkg:gradle/com.google.errorprone/error_prone_annotations@2.5.1?checksum=sha1:562d366678b89ce5d6b6b82c1a073880341e3fba"
+          }
+        },
+        {
+          "id": "com.google.j2objc:j2objc-annotations@1.3",
+          "info": {
+            "name": "com.google.j2objc:j2objc-annotations",
+            "version": "1.3",
+            "purl": "pkg:gradle/com.google.j2objc/j2objc-annotations@1.3?checksum=sha1:ba035118bc8bac37d7eff77700720999acd9986d"
+          }
+        }
+      ],
+      "graph": {
+        "rootNodeId": "root-node",
+        "nodes": [
+          {
+            "nodeId": "root-node",
+            "pkgId": "com.snyk.fixtures:app@1.0.0",
+            "deps": [
+              {
+                "nodeId": "com.snyk.fixtures:lib@1.0.0"
+              },
+              {
+                "nodeId": "org.apache.commons:commons-lang3@3.14.0"
+              }
+            ]
+          },
+          {
+            "nodeId": "com.snyk.fixtures:lib@1.0.0",
+            "pkgId": "com.snyk.fixtures:lib@1.0.0",
+            "deps": [
+              {
+                "nodeId": "com.google.guava:guava@30.1.1-jre"
+              }
+            ]
+          },
+          {
+            "nodeId": "org.apache.commons:commons-lang3@3.14.0",
+            "pkgId": "org.apache.commons:commons-lang3@3.14.0",
+            "deps": []
+          },
+          {
+            "nodeId": "com.google.guava:guava@30.1.1-jre",
+            "pkgId": "com.google.guava:guava@30.1.1-jre",
+            "deps": [
+              {
+                "nodeId": "com.google.guava:failureaccess@1.0.1"
+              },
+              {
+                "nodeId": "com.google.guava:listenablefuture@9999.0-empty-to-avoid-conflict-with-guava"
+              },
+              {
+                "nodeId": "com.google.code.findbugs:jsr305@3.0.2"
+              },
+              {
+                "nodeId": "org.checkerframework:checker-qual@3.8.0"
+              },
+              {
+                "nodeId": "com.google.errorprone:error_prone_annotations@2.5.1"
+              },
+              {
+                "nodeId": "com.google.j2objc:j2objc-annotations@1.3"
+              }
+            ]
+          },
+          {
+            "nodeId": "com.google.guava:failureaccess@1.0.1",
+            "pkgId": "com.google.guava:failureaccess@1.0.1",
+            "deps": []
+          },
+          {
+            "nodeId": "com.google.guava:listenablefuture@9999.0-empty-to-avoid-conflict-with-guava",
+            "pkgId": "com.google.guava:listenablefuture@9999.0-empty-to-avoid-conflict-with-guava",
+            "deps": []
+          },
+          {
+            "nodeId": "com.google.code.findbugs:jsr305@3.0.2",
+            "pkgId": "com.google.code.findbugs:jsr305@3.0.2",
+            "deps": []
+          },
+          {
+            "nodeId": "org.checkerframework:checker-qual@3.8.0",
+            "pkgId": "org.checkerframework:checker-qual@3.8.0",
+            "deps": []
+          },
+          {
+            "nodeId": "com.google.errorprone:error_prone_annotations@2.5.1",
+            "pkgId": "com.google.errorprone:error_prone_annotations@2.5.1",
+            "deps": []
+          },
+          {
+            "nodeId": "com.google.j2objc:j2objc-annotations@1.3",
+            "pkgId": "com.google.j2objc:j2objc-annotations@1.3",
+            "deps": []
+          }
+        ]
+      }
+    },
+    "projectDescriptor": {
+      "identity": {
+        "type": "gradle",
+        "targetFile": "app/build.gradle",
+        "rootComponentName": "com.snyk.fixtures:app"
+      }
+    }
+  },
+  {
+    "depGraph": {
+      "schemaVersion": "1.3.0",
+      "pkgManager": {
+        "name": "gradle"
+      },
+      "pkgs": [
+        {
+          "id": "com.snyk.fixtures:lib@1.0.0",
+          "info": {
+            "name": "com.snyk.fixtures:lib",
+            "version": "1.0.0"
+          }
+        },
+        {
+          "id": "com.google.guava:guava@30.1.1-jre",
+          "info": {
+            "name": "com.google.guava:guava",
+            "version": "30.1.1-jre",
+            "purl": "pkg:gradle/com.google.guava/guava@30.1.1-jre?checksum=sha1:87e0fd1df874ea3cbe577702fe6f17068b790fd8"
+          }
+        },
+        {
+          "id": "com.google.guava:failureaccess@1.0.1",
+          "info": {
+            "name": "com.google.guava:failureaccess",
+            "version": "1.0.1",
+            "purl": "pkg:gradle/com.google.guava/failureaccess@1.0.1?checksum=sha1:1dcf1de382a0bf95a3d8b0849546c88bac1292c9"
+          }
+        },
+        {
+          "id": "com.google.guava:listenablefuture@9999.0-empty-to-avoid-conflict-with-guava",
+          "info": {
+            "name": "com.google.guava:listenablefuture",
+            "version": "9999.0-empty-to-avoid-conflict-with-guava",
+            "purl": "pkg:gradle/com.google.guava/listenablefuture@9999.0-empty-to-avoid-conflict-with-guava?checksum=sha1:b421526c5f297295adef1c886e5246c39d4ac629"
+          }
+        },
+        {
+          "id": "com.google.code.findbugs:jsr305@3.0.2",
+          "info": {
+            "name": "com.google.code.findbugs:jsr305",
+            "version": "3.0.2",
+            "purl": "pkg:gradle/com.google.code.findbugs/jsr305@3.0.2?checksum=sha1:25ea2e8b0c338a877313bd4672d3fe056ea78f0d"
+          }
+        },
+        {
+          "id": "org.checkerframework:checker-qual@3.8.0",
+          "info": {
+            "name": "org.checkerframework:checker-qual",
+            "version": "3.8.0",
+            "purl": "pkg:gradle/org.checkerframework/checker-qual@3.8.0?checksum=sha1:6b83e4a33220272c3a08991498ba9dc09519f190"
+          }
+        },
+        {
+          "id": "com.google.errorprone:error_prone_annotations@2.5.1",
+          "info": {
+            "name": "com.google.errorprone:error_prone_annotations",
+            "version": "2.5.1",
+            "purl": "pkg:gradle/com.google.errorprone/error_prone_annotations@2.5.1?checksum=sha1:562d366678b89ce5d6b6b82c1a073880341e3fba"
+          }
+        },
+        {
+          "id": "com.google.j2objc:j2objc-annotations@1.3",
+          "info": {
+            "name": "com.google.j2objc:j2objc-annotations",
+            "version": "1.3",
+            "purl": "pkg:gradle/com.google.j2objc/j2objc-annotations@1.3?checksum=sha1:ba035118bc8bac37d7eff77700720999acd9986d"
+          }
+        }
+      ],
+      "graph": {
+        "rootNodeId": "root-node",
+        "nodes": [
+          {
+            "nodeId": "root-node",
+            "pkgId": "com.snyk.fixtures:lib@1.0.0",
+            "deps": [
+              {
+                "nodeId": "com.google.guava:guava@30.1.1-jre"
+              }
+            ]
+          },
+          {
+            "nodeId": "com.google.guava:guava@30.1.1-jre",
+            "pkgId": "com.google.guava:guava@30.1.1-jre",
+            "deps": [
+              {
+                "nodeId": "com.google.guava:failureaccess@1.0.1"
+              },
+              {
+                "nodeId": "com.google.guava:listenablefuture@9999.0-empty-to-avoid-conflict-with-guava"
+              },
+              {
+                "nodeId": "com.google.code.findbugs:jsr305@3.0.2"
+              },
+              {
+                "nodeId": "org.checkerframework:checker-qual@3.8.0"
+              },
+              {
+                "nodeId": "com.google.errorprone:error_prone_annotations@2.5.1"
+              },
+              {
+                "nodeId": "com.google.j2objc:j2objc-annotations@1.3"
+              }
+            ]
+          },
+          {
+            "nodeId": "com.google.guava:failureaccess@1.0.1",
+            "pkgId": "com.google.guava:failureaccess@1.0.1",
+            "deps": []
+          },
+          {
+            "nodeId": "com.google.guava:listenablefuture@9999.0-empty-to-avoid-conflict-with-guava",
+            "pkgId": "com.google.guava:listenablefuture@9999.0-empty-to-avoid-conflict-with-guava",
+            "deps": []
+          },
+          {
+            "nodeId": "com.google.code.findbugs:jsr305@3.0.2",
+            "pkgId": "com.google.code.findbugs:jsr305@3.0.2",
+            "deps": []
+          },
+          {
+            "nodeId": "org.checkerframework:checker-qual@3.8.0",
+            "pkgId": "org.checkerframework:checker-qual@3.8.0",
+            "deps": []
+          },
+          {
+            "nodeId": "com.google.errorprone:error_prone_annotations@2.5.1",
+            "pkgId": "com.google.errorprone:error_prone_annotations@2.5.1",
+            "deps": []
+          },
+          {
+            "nodeId": "com.google.j2objc:j2objc-annotations@1.3",
+            "pkgId": "com.google.j2objc:j2objc-annotations@1.3",
+            "deps": []
+          }
+        ]
+      }
+    },
+    "projectDescriptor": {
+      "identity": {
+        "type": "gradle",
+        "targetFile": "lib/build.gradle",
+        "rootComponentName": "com.snyk.fixtures:lib"
+      }
+    }
+  }
+]

--- a/pkg/ecosystems/testdata/fixtures/gradle/platform-bom/expected_plugin_with_provenance.json
+++ b/pkg/ecosystems/testdata/fixtures/gradle/platform-bom/expected_plugin_with_provenance.json
@@ -1,0 +1,142 @@
+[
+  {
+    "depGraph": {
+      "schemaVersion": "1.3.0",
+      "pkgManager": {
+        "name": "gradle"
+      },
+      "pkgs": [
+        {
+          "id": "com.snyk.fixtures:platform-bom@1.0.0",
+          "info": {
+            "name": "com.snyk.fixtures:platform-bom",
+            "version": "1.0.0"
+          }
+        },
+        {
+          "id": "org.springframework.boot:spring-boot-dependencies@1.5.8.RELEASE",
+          "info": {
+            "name": "org.springframework.boot:spring-boot-dependencies",
+            "version": "1.5.8.RELEASE",
+            "purl": "pkg:gradle/org.springframework.boot/spring-boot-dependencies@1.5.8.RELEASE"
+          }
+        },
+        {
+          "id": "com.google.code.gson:gson@2.8.2",
+          "info": {
+            "name": "com.google.code.gson:gson",
+            "version": "2.8.2",
+            "purl": "pkg:gradle/com.google.code.gson/gson@2.8.2?checksum=sha1:3edcfe49d2c6053a70a2a47e4e1c2f94998a49cf"
+          }
+        },
+        {
+          "id": "dom4j:dom4j@1.6.1",
+          "info": {
+            "name": "dom4j:dom4j",
+            "version": "1.6.1",
+            "purl": "pkg:gradle/dom4j/dom4j@1.6.1?checksum=sha1:5d3ccc056b6f056dbf0dddfdf43894b9065a8f94"
+          }
+        },
+        {
+          "id": "xml-apis:xml-apis@1.4.01",
+          "info": {
+            "name": "xml-apis:xml-apis",
+            "version": "1.4.01",
+            "purl": "pkg:gradle/xml-apis/xml-apis@1.4.01?checksum=sha1:3789d9fada2d3d458c4ba2de349d48780f381ee3"
+          }
+        }
+      ],
+      "graph": {
+        "rootNodeId": "root-node",
+        "nodes": [
+          {
+            "nodeId": "root-node",
+            "pkgId": "com.snyk.fixtures:platform-bom@1.0.0",
+            "deps": [
+              {
+                "nodeId": "org.springframework.boot:spring-boot-dependencies@1.5.8.RELEASE"
+              },
+              {
+                "nodeId": "com.google.code.gson:gson@2.8.2"
+              },
+              {
+                "nodeId": "dom4j:dom4j@1.6.1"
+              }
+            ]
+          },
+          {
+            "nodeId": "org.springframework.boot:spring-boot-dependencies@1.5.8.RELEASE",
+            "pkgId": "org.springframework.boot:spring-boot-dependencies@1.5.8.RELEASE",
+            "deps": [
+              {
+                "nodeId": "com.google.code.gson:gson@2.8.2:constraint"
+              },
+              {
+                "nodeId": "dom4j:dom4j@1.6.1:constraint"
+              },
+              {
+                "nodeId": "xml-apis:xml-apis@1.4.01:constraint"
+              }
+            ]
+          },
+          {
+            "nodeId": "com.google.code.gson:gson@2.8.2:constraint",
+            "pkgId": "com.google.code.gson:gson@2.8.2",
+            "info": {
+              "labels": {
+                "constraint": "true"
+              }
+            },
+            "deps": []
+          },
+          {
+            "nodeId": "dom4j:dom4j@1.6.1:constraint",
+            "pkgId": "dom4j:dom4j@1.6.1",
+            "info": {
+              "labels": {
+                "constraint": "true"
+              }
+            },
+            "deps": []
+          },
+          {
+            "nodeId": "xml-apis:xml-apis@1.4.01:constraint",
+            "pkgId": "xml-apis:xml-apis@1.4.01",
+            "info": {
+              "labels": {
+                "constraint": "true"
+              }
+            },
+            "deps": []
+          },
+          {
+            "nodeId": "com.google.code.gson:gson@2.8.2",
+            "pkgId": "com.google.code.gson:gson@2.8.2",
+            "deps": []
+          },
+          {
+            "nodeId": "dom4j:dom4j@1.6.1",
+            "pkgId": "dom4j:dom4j@1.6.1",
+            "deps": [
+              {
+                "nodeId": "xml-apis:xml-apis@1.4.01"
+              }
+            ]
+          },
+          {
+            "nodeId": "xml-apis:xml-apis@1.4.01",
+            "pkgId": "xml-apis:xml-apis@1.4.01",
+            "deps": []
+          }
+        ]
+      }
+    },
+    "projectDescriptor": {
+      "identity": {
+        "type": "gradle",
+        "targetFile": "build.gradle",
+        "rootComponentName": "com.snyk.fixtures:platform-bom"
+      }
+    }
+  }
+]

--- a/pkg/ecosystems/testdata/fixtures/gradle/platform-bom/expected_plugin_with_provenance.json
+++ b/pkg/ecosystems/testdata/fixtures/gradle/platform-bom/expected_plugin_with_provenance.json
@@ -18,7 +18,7 @@
           "info": {
             "name": "org.springframework.boot:spring-boot-dependencies",
             "version": "1.5.8.RELEASE",
-            "purl": "pkg:gradle/org.springframework.boot/spring-boot-dependencies@1.5.8.RELEASE"
+            "purl": "pkg:maven/org.springframework.boot/spring-boot-dependencies@1.5.8.RELEASE"
           }
         },
         {
@@ -26,7 +26,7 @@
           "info": {
             "name": "com.google.code.gson:gson",
             "version": "2.8.2",
-            "purl": "pkg:gradle/com.google.code.gson/gson@2.8.2?checksum=sha1:3edcfe49d2c6053a70a2a47e4e1c2f94998a49cf"
+            "purl": "pkg:maven/com.google.code.gson/gson@2.8.2?checksum=sha1:3edcfe49d2c6053a70a2a47e4e1c2f94998a49cf"
           }
         },
         {
@@ -34,7 +34,7 @@
           "info": {
             "name": "dom4j:dom4j",
             "version": "1.6.1",
-            "purl": "pkg:gradle/dom4j/dom4j@1.6.1?checksum=sha1:5d3ccc056b6f056dbf0dddfdf43894b9065a8f94"
+            "purl": "pkg:maven/dom4j/dom4j@1.6.1?checksum=sha1:5d3ccc056b6f056dbf0dddfdf43894b9065a8f94"
           }
         },
         {
@@ -42,7 +42,7 @@
           "info": {
             "name": "xml-apis:xml-apis",
             "version": "1.4.01",
-            "purl": "pkg:gradle/xml-apis/xml-apis@1.4.01?checksum=sha1:3789d9fada2d3d458c4ba2de349d48780f381ee3"
+            "purl": "pkg:maven/xml-apis/xml-apis@1.4.01?checksum=sha1:3789d9fada2d3d458c4ba2de349d48780f381ee3"
           }
         }
       ],

--- a/pkg/ecosystems/testdata/fixtures/gradle/simple/expected_plugin_with_provenance.json
+++ b/pkg/ecosystems/testdata/fixtures/gradle/simple/expected_plugin_with_provenance.json
@@ -1,0 +1,166 @@
+[
+  {
+    "depGraph": {
+      "schemaVersion": "1.3.0",
+      "pkgManager": {
+        "name": "gradle"
+      },
+      "pkgs": [
+        {
+          "id": "com.snyk.fixtures:simple-app@1.0.0",
+          "info": {
+            "name": "com.snyk.fixtures:simple-app",
+            "version": "1.0.0"
+          }
+        },
+        {
+          "id": "com.google.guava:guava@30.1.1-jre",
+          "info": {
+            "name": "com.google.guava:guava",
+            "version": "30.1.1-jre",
+            "purl": "pkg:gradle/com.google.guava/guava@30.1.1-jre?checksum=sha1:87e0fd1df874ea3cbe577702fe6f17068b790fd8"
+          }
+        },
+        {
+          "id": "com.google.guava:failureaccess@1.0.1",
+          "info": {
+            "name": "com.google.guava:failureaccess",
+            "version": "1.0.1",
+            "purl": "pkg:gradle/com.google.guava/failureaccess@1.0.1?checksum=sha1:1dcf1de382a0bf95a3d8b0849546c88bac1292c9"
+          }
+        },
+        {
+          "id": "com.google.guava:listenablefuture@9999.0-empty-to-avoid-conflict-with-guava",
+          "info": {
+            "name": "com.google.guava:listenablefuture",
+            "version": "9999.0-empty-to-avoid-conflict-with-guava",
+            "purl": "pkg:gradle/com.google.guava/listenablefuture@9999.0-empty-to-avoid-conflict-with-guava?checksum=sha1:b421526c5f297295adef1c886e5246c39d4ac629"
+          }
+        },
+        {
+          "id": "com.google.code.findbugs:jsr305@3.0.2",
+          "info": {
+            "name": "com.google.code.findbugs:jsr305",
+            "version": "3.0.2",
+            "purl": "pkg:gradle/com.google.code.findbugs/jsr305@3.0.2?checksum=sha1:25ea2e8b0c338a877313bd4672d3fe056ea78f0d"
+          }
+        },
+        {
+          "id": "org.checkerframework:checker-qual@3.8.0",
+          "info": {
+            "name": "org.checkerframework:checker-qual",
+            "version": "3.8.0",
+            "purl": "pkg:gradle/org.checkerframework/checker-qual@3.8.0?checksum=sha1:6b83e4a33220272c3a08991498ba9dc09519f190"
+          }
+        },
+        {
+          "id": "com.google.errorprone:error_prone_annotations@2.5.1",
+          "info": {
+            "name": "com.google.errorprone:error_prone_annotations",
+            "version": "2.5.1",
+            "purl": "pkg:gradle/com.google.errorprone/error_prone_annotations@2.5.1?checksum=sha1:562d366678b89ce5d6b6b82c1a073880341e3fba"
+          }
+        },
+        {
+          "id": "com.google.j2objc:j2objc-annotations@1.3",
+          "info": {
+            "name": "com.google.j2objc:j2objc-annotations",
+            "version": "1.3",
+            "purl": "pkg:gradle/com.google.j2objc/j2objc-annotations@1.3?checksum=sha1:ba035118bc8bac37d7eff77700720999acd9986d"
+          }
+        },
+        {
+          "id": "org.apache.commons:commons-lang3@3.14.0",
+          "info": {
+            "name": "org.apache.commons:commons-lang3",
+            "version": "3.14.0",
+            "purl": "pkg:gradle/org.apache.commons/commons-lang3@3.14.0?checksum=sha1:1ed471194b02f2c6cb734a0cd6f6f107c673afae"
+          }
+        }
+      ],
+      "graph": {
+        "rootNodeId": "root-node",
+        "nodes": [
+          {
+            "nodeId": "root-node",
+            "pkgId": "com.snyk.fixtures:simple-app@1.0.0",
+            "deps": [
+              {
+                "nodeId": "com.google.guava:guava@30.1.1-jre"
+              },
+              {
+                "nodeId": "org.apache.commons:commons-lang3@3.14.0"
+              }
+            ]
+          },
+          {
+            "nodeId": "com.google.guava:guava@30.1.1-jre",
+            "pkgId": "com.google.guava:guava@30.1.1-jre",
+            "deps": [
+              {
+                "nodeId": "com.google.guava:failureaccess@1.0.1"
+              },
+              {
+                "nodeId": "com.google.guava:listenablefuture@9999.0-empty-to-avoid-conflict-with-guava"
+              },
+              {
+                "nodeId": "com.google.code.findbugs:jsr305@3.0.2"
+              },
+              {
+                "nodeId": "org.checkerframework:checker-qual@3.8.0"
+              },
+              {
+                "nodeId": "com.google.errorprone:error_prone_annotations@2.5.1"
+              },
+              {
+                "nodeId": "com.google.j2objc:j2objc-annotations@1.3"
+              }
+            ]
+          },
+          {
+            "nodeId": "com.google.guava:failureaccess@1.0.1",
+            "pkgId": "com.google.guava:failureaccess@1.0.1",
+            "deps": []
+          },
+          {
+            "nodeId": "com.google.guava:listenablefuture@9999.0-empty-to-avoid-conflict-with-guava",
+            "pkgId": "com.google.guava:listenablefuture@9999.0-empty-to-avoid-conflict-with-guava",
+            "deps": []
+          },
+          {
+            "nodeId": "com.google.code.findbugs:jsr305@3.0.2",
+            "pkgId": "com.google.code.findbugs:jsr305@3.0.2",
+            "deps": []
+          },
+          {
+            "nodeId": "org.checkerframework:checker-qual@3.8.0",
+            "pkgId": "org.checkerframework:checker-qual@3.8.0",
+            "deps": []
+          },
+          {
+            "nodeId": "com.google.errorprone:error_prone_annotations@2.5.1",
+            "pkgId": "com.google.errorprone:error_prone_annotations@2.5.1",
+            "deps": []
+          },
+          {
+            "nodeId": "com.google.j2objc:j2objc-annotations@1.3",
+            "pkgId": "com.google.j2objc:j2objc-annotations@1.3",
+            "deps": []
+          },
+          {
+            "nodeId": "org.apache.commons:commons-lang3@3.14.0",
+            "pkgId": "org.apache.commons:commons-lang3@3.14.0",
+            "deps": []
+          }
+        ]
+      }
+    },
+    "projectDescriptor": {
+      "identity": {
+        "type": "gradle",
+        "targetFile": "build.gradle",
+        "rootComponentName": "com.snyk.fixtures:simple-app"
+      }
+    }
+  }
+]

--- a/pkg/ecosystems/testdata/fixtures/gradle/simple/expected_plugin_with_provenance.json
+++ b/pkg/ecosystems/testdata/fixtures/gradle/simple/expected_plugin_with_provenance.json
@@ -18,7 +18,7 @@
           "info": {
             "name": "com.google.guava:guava",
             "version": "30.1.1-jre",
-            "purl": "pkg:gradle/com.google.guava/guava@30.1.1-jre?checksum=sha1:87e0fd1df874ea3cbe577702fe6f17068b790fd8"
+            "purl": "pkg:maven/com.google.guava/guava@30.1.1-jre?checksum=sha1:87e0fd1df874ea3cbe577702fe6f17068b790fd8"
           }
         },
         {
@@ -26,7 +26,7 @@
           "info": {
             "name": "com.google.guava:failureaccess",
             "version": "1.0.1",
-            "purl": "pkg:gradle/com.google.guava/failureaccess@1.0.1?checksum=sha1:1dcf1de382a0bf95a3d8b0849546c88bac1292c9"
+            "purl": "pkg:maven/com.google.guava/failureaccess@1.0.1?checksum=sha1:1dcf1de382a0bf95a3d8b0849546c88bac1292c9"
           }
         },
         {
@@ -34,7 +34,7 @@
           "info": {
             "name": "com.google.guava:listenablefuture",
             "version": "9999.0-empty-to-avoid-conflict-with-guava",
-            "purl": "pkg:gradle/com.google.guava/listenablefuture@9999.0-empty-to-avoid-conflict-with-guava?checksum=sha1:b421526c5f297295adef1c886e5246c39d4ac629"
+            "purl": "pkg:maven/com.google.guava/listenablefuture@9999.0-empty-to-avoid-conflict-with-guava?checksum=sha1:b421526c5f297295adef1c886e5246c39d4ac629"
           }
         },
         {
@@ -42,7 +42,7 @@
           "info": {
             "name": "com.google.code.findbugs:jsr305",
             "version": "3.0.2",
-            "purl": "pkg:gradle/com.google.code.findbugs/jsr305@3.0.2?checksum=sha1:25ea2e8b0c338a877313bd4672d3fe056ea78f0d"
+            "purl": "pkg:maven/com.google.code.findbugs/jsr305@3.0.2?checksum=sha1:25ea2e8b0c338a877313bd4672d3fe056ea78f0d"
           }
         },
         {
@@ -50,7 +50,7 @@
           "info": {
             "name": "org.checkerframework:checker-qual",
             "version": "3.8.0",
-            "purl": "pkg:gradle/org.checkerframework/checker-qual@3.8.0?checksum=sha1:6b83e4a33220272c3a08991498ba9dc09519f190"
+            "purl": "pkg:maven/org.checkerframework/checker-qual@3.8.0?checksum=sha1:6b83e4a33220272c3a08991498ba9dc09519f190"
           }
         },
         {
@@ -58,7 +58,7 @@
           "info": {
             "name": "com.google.errorprone:error_prone_annotations",
             "version": "2.5.1",
-            "purl": "pkg:gradle/com.google.errorprone/error_prone_annotations@2.5.1?checksum=sha1:562d366678b89ce5d6b6b82c1a073880341e3fba"
+            "purl": "pkg:maven/com.google.errorprone/error_prone_annotations@2.5.1?checksum=sha1:562d366678b89ce5d6b6b82c1a073880341e3fba"
           }
         },
         {
@@ -66,7 +66,7 @@
           "info": {
             "name": "com.google.j2objc:j2objc-annotations",
             "version": "1.3",
-            "purl": "pkg:gradle/com.google.j2objc/j2objc-annotations@1.3?checksum=sha1:ba035118bc8bac37d7eff77700720999acd9986d"
+            "purl": "pkg:maven/com.google.j2objc/j2objc-annotations@1.3?checksum=sha1:ba035118bc8bac37d7eff77700720999acd9986d"
           }
         },
         {
@@ -74,7 +74,7 @@
           "info": {
             "name": "org.apache.commons:commons-lang3",
             "version": "3.14.0",
-            "purl": "pkg:gradle/org.apache.commons/commons-lang3@3.14.0?checksum=sha1:1ed471194b02f2c6cb734a0cd6f6f107c673afae"
+            "purl": "pkg:maven/org.apache.commons/commons-lang3@3.14.0?checksum=sha1:1ed471194b02f2c6cb734a0cd6f6f107c673afae"
           }
         }
       ],


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [ ] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### Summary

Adds support for the `--include-provenance` global flag to the Gradle resolver, enabling SHA1 checksum collection and PURL generation with checksum qualifiers.

#### Key Changes

##### Checksum Collection Strategy
- **Leverages Gradle's internal `ChecksumService`** for optimal performance - uses Gradle's cached checksums when available (Gradle 6+)
- **Falls back to manual SHA1 calculation** when ChecksumService unavailable
- **O(1) artifact lookup** - builds a `ComponentIdentifier → List<ResolvedArtifactResult>` map per configuration to avoid O(N²) artifact searches

##### PURL Generation
- **Conditional PURL generation** - only generates PURLs when `--include-provenance` is enabled
- **Checksum qualifiers** - adds `?checksum=sha1:abc123...` to PURLs when checksums are available
- **Base PURLs for missing checksums** - generates `pkg:maven/group/artifact@version` even when checksum unavailable

##### BOM/Platform Dependency Handling
- **Skips provenance for BOMs** - BOM/platform dependencies (like `spring-boot-dependencies`) don't have physical artifacts to checksum, so provenance collection is skipped for these metadata-only dependencies

##### Init Script Enhancements
- **Provenance threading** - passes `includeProvenance` flag through the resolution pipeline
- **Artifact type detection** - extracts file extension as artifact type for dependency classification
- **Error resilience** - checksum failures don't break dependency graph generation

The implementation aligns with Maven plugin behaviour, focusing provenance collection on actual downloadable artifacts rather than metadata dependencies.