### PR TITLE
feat: add support for sub project legacy flag [CMPA-548]

### DIFF
--- a/pkg/ecosystems/options.go
+++ b/pkg/ecosystems/options.go
@@ -53,7 +53,8 @@ type GradleOptions struct {
 	// ConfigurationAttributes filters configurations by attribute values (key:value,key:value).
 	ConfigurationAttributes string `arg:"--configuration-attributes"`
 	// SubProject restricts scanning to a single named Gradle sub-project.
-	SubProject string `arg:"--gradle-sub-project"`
+	// Accepts both --gradle-sub-project and --sub-project (legacy alias).
+	SubProject string `arg:"--gradle-sub-project,--sub-project"`
 	// AllSubProjects scans all sub-projects in a multi-project build.
 	AllSubProjects bool `arg:"--all-sub-projects"`
 	// InitScript overrides the built-in init script with a user-supplied path.

--- a/pkg/ecosystems/options_test.go
+++ b/pkg/ecosystems/options_test.go
@@ -306,6 +306,43 @@ func TestNewPluginOptionsFromRawFlags_StrictOutOfSync(t *testing.T) {
 	}
 }
 
+func TestNewPluginOptionsFromRawFlags_SubProjectAlias(t *testing.T) {
+	tests := []struct {
+		name            string
+		rawFlags        []string
+		expectedProject string
+	}{
+		{
+			name:            "--gradle-sub-project sets SubProject",
+			rawFlags:        []string{"--gradle-sub-project", "app"},
+			expectedProject: "app",
+		},
+		{
+			name:            "--sub-project sets SubProject as legacy alias",
+			rawFlags:        []string{"--sub-project", "app"},
+			expectedProject: "app",
+		},
+		{
+			name:            "--gradle-sub-project with equals syntax",
+			rawFlags:        []string{"--gradle-sub-project=app"},
+			expectedProject: "app",
+		},
+		{
+			name:            "--sub-project with equals syntax",
+			rawFlags:        []string{"--sub-project=app"},
+			expectedProject: "app",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NewPluginOptionsFromRawFlags(tt.rawFlags)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectedProject, got.Gradle.SubProject)
+		})
+	}
+}
+
 func TestNewPluginOptionsFromRawFlags_UnknownFlags(t *testing.T) {
 	rawFlags := []string{
 		"--unknown-flag", "value",


### PR DESCRIPTION
- [X] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [X] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

To keep things consistent with the legacy plugin we are adding the `--sub-project` flag. 

https://snyksec.atlassian.net/jira/software/c/projects/CMPA/boards/5466?assignee=60162bfac8c36c00698fa2d4&selectedIssue=CMPA-548 