### PR TITLE
fix: allow plugin registry to check for feature flags

### DIFF
--- a/pkg/ecosystems/orchestrator/flags.go
+++ b/pkg/ecosystems/orchestrator/flags.go
@@ -1,0 +1,24 @@
+package orchestrator
+
+type flag struct {
+	Key   string
+	Value string
+}
+
+var FlagUnifiedTestAPIOsCLI = flag{
+	Key:   "internal_snyk_cli_use_unified_test_api_for_os_cli_test",
+	Value: "unified-test-api-os-cli",
+}
+
+var allFlags = []flag{
+	FlagUnifiedTestAPIOsCLI,
+}
+
+// GetAllFlags returns all feature flags as a map of key to flag name.
+func GetAllFlags() map[string]string {
+	result := make(map[string]string, len(allFlags))
+	for _, f := range allFlags {
+		result[f.Key] = f.Value
+	}
+	return result
+}

--- a/pkg/ecosystems/orchestrator/registry.go
+++ b/pkg/ecosystems/orchestrator/registry.go
@@ -11,9 +11,6 @@ import (
 	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/javascript/bun"
 	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/legacy"
 	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/logger"
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/python/pip"
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/python/pipenv"
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/python/uv"
 )
 
 type pluginEntry struct {
@@ -22,39 +19,34 @@ type pluginEntry struct {
 }
 
 type PluginRegistry struct {
+	ictx    workflow.InvocationContext
 	entries []pluginEntry
 	plugins []ecosystems.SCAPlugin
 }
 
-func NewDefaultPluginRegistry() (*PluginRegistry, error) {
+func NewDefaultPluginRegistry(ictx workflow.InvocationContext) (*PluginRegistry, error) {
 	r := &PluginRegistry{
+		ictx:    ictx,
 		entries: make([]pluginEntry, 0),
 		plugins: make([]ecosystems.SCAPlugin, 0),
 	}
 
 	// javascript
-	if err := r.register(bun.Plugin{}); err != nil {
+	if err := r.register(bun.Plugin{}, ""); err != nil {
 		return nil, fmt.Errorf("failed to register bun plugin: %w", err)
-	}
-	// python
-	if err := r.register(pip.Plugin{}, uv.PluginName); err != nil {
-		return nil, fmt.Errorf("failed to register pip plugin: %w", err)
-	}
-	if err := r.register(pipenv.Plugin{}, uv.PluginName); err != nil {
-		return nil, fmt.Errorf("failed to register pipenv plugin: %w", err)
 	}
 
 	return r, nil
 }
 
-func (r *PluginRegistry) ResolveDepgraphs(ictx workflow.InvocationContext, dir string, opts *ecosystems.SCAPluginOptions) <-chan ecosystems.SCAResult {
+func (r *PluginRegistry) ResolveDepgraphs(dir string, opts *ecosystems.SCAPluginOptions) <-chan ecosystems.SCAResult {
 	resultsChan := make(chan ecosystems.SCAResult)
 
 	go func() {
 		defer close(resultsChan)
 
-		ctx := ictx.Context()
-		enhancedLogger := ictx.GetEnhancedLogger()
+		ctx := r.ictx.Context()
+		enhancedLogger := r.ictx.GetEnhancedLogger()
 		processedFiles := make([]string, 0)
 
 		for _, plugin := range r.plugins {
@@ -78,13 +70,19 @@ func (r *PluginRegistry) ResolveDepgraphs(ictx workflow.InvocationContext, dir s
 		default:
 		}
 
-		executePluginWithResults(ctx, legacy.NewLegacyResolver(ictx, processedFiles), enhancedLogger, dir, opts, resultsChan)
+		executePluginWithResults(ctx, legacy.NewLegacyResolver(r.ictx, processedFiles), enhancedLogger, dir, opts, resultsChan)
 	}()
 
 	return resultsChan
 }
 
-func (r *PluginRegistry) register(plugin ecosystems.SCAPlugin, dependencies ...string) error {
+//nolint:unparam // unset for now but ready for when we need FFs
+func (r *PluginRegistry) register(plugin ecosystems.SCAPlugin, flag string, dependencies ...string) error {
+	if flag != "" {
+		if !r.ictx.GetConfiguration().GetBool(flag) {
+			return nil
+		}
+	}
 	r.entries = append(r.entries, pluginEntry{
 		plugin:       plugin,
 		dependencies: dependencies,

--- a/pkg/ecosystems/orchestrator/registry_test.go
+++ b/pkg/ecosystems/orchestrator/registry_test.go
@@ -40,9 +40,9 @@ func TestPluginRegistry_OrderPreservedWithoutDependencies(t *testing.T) {
 		plugins: make([]ecosystems.SCAPlugin, 0),
 	}
 
-	require.NoError(t, r.register(mockPlugin{name: "plugin-a"}))
-	require.NoError(t, r.register(mockPlugin{name: "plugin-b"}))
-	require.NoError(t, r.register(mockPlugin{name: "plugin-c"}))
+	require.NoError(t, r.register(mockPlugin{name: "plugin-a"}, ""))
+	require.NoError(t, r.register(mockPlugin{name: "plugin-b"}, ""))
+	require.NoError(t, r.register(mockPlugin{name: "plugin-c"}, ""))
 
 	require.Len(t, r.plugins, 3)
 	assert.Equal(t, "plugin-a", r.plugins[0].GetName())
@@ -52,15 +52,16 @@ func TestPluginRegistry_OrderPreservedWithoutDependencies(t *testing.T) {
 
 func TestPluginRegistry_DependenciesRespected(t *testing.T) {
 	r := &PluginRegistry{
+		ictx:    setupMockInvocationContext(t),
 		entries: make([]pluginEntry, 0),
 		plugins: make([]ecosystems.SCAPlugin, 0),
 	}
 
-	err := r.register(mockPlugin{name: "plugin-c"}, "plugin-a")
+	err := r.register(mockPlugin{name: "plugin-c"}, "", "plugin-a")
 	require.NoError(t, err)
-	err = r.register(mockPlugin{name: "plugin-b"}, "plugin-a")
+	err = r.register(mockPlugin{name: "plugin-b"}, "", "plugin-a")
 	require.NoError(t, err)
-	err = r.register(mockPlugin{name: "plugin-a"})
+	err = r.register(mockPlugin{name: "plugin-a"}, "", "")
 	require.NoError(t, err)
 
 	require.Len(t, r.plugins, 3)
@@ -75,11 +76,11 @@ func TestPluginRegistry_ChainedDependencies(t *testing.T) {
 		plugins: make([]ecosystems.SCAPlugin, 0),
 	}
 
-	err := r.register(mockPlugin{name: "plugin-c"}, "plugin-b")
+	err := r.register(mockPlugin{name: "plugin-c"}, "", "plugin-b")
 	require.NoError(t, err)
-	err = r.register(mockPlugin{name: "plugin-b"}, "plugin-a")
+	err = r.register(mockPlugin{name: "plugin-b"}, "", "plugin-a")
 	require.NoError(t, err)
-	err = r.register(mockPlugin{name: "plugin-a"})
+	err = r.register(mockPlugin{name: "plugin-a"}, "", "")
 	require.NoError(t, err)
 
 	require.Len(t, r.plugins, 3)
@@ -89,33 +90,32 @@ func TestPluginRegistry_ChainedDependencies(t *testing.T) {
 }
 
 func TestPluginRegistry_DefaultRegistryOrder(t *testing.T) {
-	r, err := NewDefaultPluginRegistry()
+	r, err := NewDefaultPluginRegistry(setupMockInvocationContext(t))
 	require.NoError(t, err)
 
-	require.Len(t, r.plugins, 3)
+	require.Len(t, r.plugins, 1)
 	assert.Equal(t, "bun", r.plugins[0].GetName())
-	assert.Equal(t, "pip", r.plugins[1].GetName())
-	assert.Equal(t, "pipenv", r.plugins[2].GetName())
 }
 
 func TestPluginRegistry_DefaultRegistryHasNoCircularDependencies(t *testing.T) {
 	// This test ensures NewDefaultPluginRegistry doesn't error due to circular dependencies
-	r, err := NewDefaultPluginRegistry()
+	r, err := NewDefaultPluginRegistry(setupMockInvocationContext(t))
 	require.NoError(t, err, "NewDefaultPluginRegistry should not return error for valid dependency graph")
 	assert.NotNil(t, r)
 	assert.NotNil(t, r.plugins, "plugins should be successfully sorted without circular dependencies")
-	assert.Len(t, r.plugins, 3, "all 3 plugins should be registered")
+	assert.Len(t, r.plugins, 1, "all 1 plugins should be registered")
 }
 
 func TestPluginRegistry_CircularDependencyReturnsError(t *testing.T) {
 	r := &PluginRegistry{
+		ictx:    setupMockInvocationContext(t),
 		entries: make([]pluginEntry, 0),
 		plugins: make([]ecosystems.SCAPlugin, 0),
 	}
 
-	err := r.register(mockPlugin{name: "plugin-a"}, "plugin-b")
+	err := r.register(mockPlugin{name: "plugin-a"}, "", "plugin-b")
 	require.NoError(t, err)
-	err = r.register(mockPlugin{name: "plugin-b"}, "plugin-a")
+	err = r.register(mockPlugin{name: "plugin-b"}, "", "plugin-a")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "circular dependency detected")
 	assert.Contains(t, err.Error(), "plugin-b")
@@ -123,13 +123,14 @@ func TestPluginRegistry_CircularDependencyReturnsError(t *testing.T) {
 
 func TestPluginRegistry_NonExistentDependencyIgnored(t *testing.T) {
 	r := &PluginRegistry{
+		ictx:    setupMockInvocationContext(t),
 		entries: make([]pluginEntry, 0),
 		plugins: make([]ecosystems.SCAPlugin, 0),
 	}
 
-	err := r.register(mockPlugin{name: "plugin-a"})
+	err := r.register(mockPlugin{name: "plugin-a"}, "")
 	require.NoError(t, err)
-	err = r.register(mockPlugin{name: "plugin-b"}, "non-existent-plugin")
+	err = r.register(mockPlugin{name: "plugin-b"}, "", "non-existent-plugin")
 	require.NoError(t, err)
 
 	require.Len(t, r.plugins, 2)
@@ -145,13 +146,14 @@ func TestPluginRegistry_NonExistentDependencyIgnored(t *testing.T) {
 
 func TestPluginRegistry_DependencyAddedLater(t *testing.T) {
 	r := &PluginRegistry{
+		ictx:    setupMockInvocationContext(t),
 		entries: make([]pluginEntry, 0),
 		plugins: make([]ecosystems.SCAPlugin, 0),
 	}
 
-	err := r.register(mockPlugin{name: "plugin-b"}, "plugin-a")
+	err := r.register(mockPlugin{name: "plugin-b"}, "", "plugin-a")
 	require.NoError(t, err)
-	err = r.register(mockPlugin{name: "plugin-a"})
+	err = r.register(mockPlugin{name: "plugin-a"}, "")
 	require.NoError(t, err)
 
 	require.Len(t, r.plugins, 2)
@@ -161,24 +163,24 @@ func TestPluginRegistry_DependencyAddedLater(t *testing.T) {
 
 func TestPluginRegistry_CircularDependencyError(t *testing.T) {
 	r := &PluginRegistry{
+		ictx:    setupMockInvocationContext(t),
 		entries: make([]pluginEntry, 0),
 		plugins: make([]ecosystems.SCAPlugin, 0),
 	}
 
-	err := r.register(mockPlugin{name: "plugin-a"}, "plugin-b")
+	err := r.register(mockPlugin{name: "plugin-a"}, "", "plugin-b")
 	require.NoError(t, err)
-	err = r.register(mockPlugin{name: "plugin-b"}, "plugin-c")
+	err = r.register(mockPlugin{name: "plugin-b"}, "", "plugin-c")
 	require.NoError(t, err)
-	err = r.register(mockPlugin{name: "plugin-c"}, "plugin-a")
+	err = r.register(mockPlugin{name: "plugin-c"}, "", "plugin-a")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "circular dependency detected")
 	assert.Contains(t, err.Error(), "plugin-c")
 }
 
 func TestPluginRegistry_ResolveDepgraphs_AllProjectsMode(t *testing.T) {
-	ictx := setupMockInvocationContext(t)
-
 	r := &PluginRegistry{
+		ictx:    setupMockInvocationContext(t),
 		entries: make([]pluginEntry, 0),
 		plugins: make([]ecosystems.SCAPlugin, 0),
 	}
@@ -187,17 +189,17 @@ func TestPluginRegistry_ResolveDepgraphs_AllProjectsMode(t *testing.T) {
 		name:           "plugin-a",
 		processedFiles: []string{"file-a.txt"},
 		results:        []ecosystems.SCAResult{{ProjectDescriptor: identity.ProjectDescriptor{Identity: identity.ProjectIdentity{ProjectType: "type-a"}}}},
-	}))
+	}, ""))
 	require.NoError(t, r.register(mockPlugin{
 		name:           "plugin-b",
 		processedFiles: []string{"file-b.txt"},
 		results:        []ecosystems.SCAResult{{ProjectDescriptor: identity.ProjectDescriptor{Identity: identity.ProjectIdentity{ProjectType: "type-b"}}}},
-	}))
+	}, ""))
 
 	opts := ecosystems.NewPluginOptions()
 	opts.Global.AllProjects = true
 
-	resultsChan := r.ResolveDepgraphs(ictx, "/test/dir", opts)
+	resultsChan := r.ResolveDepgraphs("/test/dir", opts)
 
 	results := collectResults(resultsChan)
 
@@ -205,9 +207,8 @@ func TestPluginRegistry_ResolveDepgraphs_AllProjectsMode(t *testing.T) {
 }
 
 func TestPluginRegistry_ResolveDepgraphs_StopsAfterFirstResult(t *testing.T) {
-	ictx := setupMockInvocationContext(t)
-
 	r := &PluginRegistry{
+		ictx:    setupMockInvocationContext(t),
 		entries: make([]pluginEntry, 0),
 		plugins: make([]ecosystems.SCAPlugin, 0),
 	}
@@ -216,17 +217,17 @@ func TestPluginRegistry_ResolveDepgraphs_StopsAfterFirstResult(t *testing.T) {
 		name:           "plugin-a",
 		processedFiles: []string{"file-a.txt"},
 		results:        []ecosystems.SCAResult{{ProjectDescriptor: identity.ProjectDescriptor{Identity: identity.ProjectIdentity{ProjectType: "type-a"}}}},
-	}))
+	}, ""))
 	require.NoError(t, r.register(mockPlugin{
 		name:           "plugin-b",
 		processedFiles: []string{"file-b.txt"},
 		results:        []ecosystems.SCAResult{{ProjectDescriptor: identity.ProjectDescriptor{Identity: identity.ProjectIdentity{ProjectType: "type-b"}}}},
-	}))
+	}, ""))
 
 	opts := ecosystems.NewPluginOptions()
 	opts.Global.AllProjects = false
 
-	resultsChan := r.ResolveDepgraphs(ictx, "/test/dir", opts)
+	resultsChan := r.ResolveDepgraphs("/test/dir", opts)
 
 	results := collectResults(resultsChan)
 
@@ -235,9 +236,8 @@ func TestPluginRegistry_ResolveDepgraphs_StopsAfterFirstResult(t *testing.T) {
 }
 
 func TestPluginRegistry_ResolveDepgraphs_ContinuesWhenNoResults(t *testing.T) {
-	ictx := setupMockInvocationContext(t)
-
 	r := &PluginRegistry{
+		ictx:    setupMockInvocationContext(t),
 		entries: make([]pluginEntry, 0),
 		plugins: make([]ecosystems.SCAPlugin, 0),
 	}
@@ -246,17 +246,17 @@ func TestPluginRegistry_ResolveDepgraphs_ContinuesWhenNoResults(t *testing.T) {
 		name:           "plugin-a",
 		processedFiles: []string{},
 		results:        []ecosystems.SCAResult{},
-	}))
+	}, ""))
 	require.NoError(t, r.register(mockPlugin{
 		name:           "plugin-b",
 		processedFiles: []string{"file-b.txt"},
 		results:        []ecosystems.SCAResult{{ProjectDescriptor: identity.ProjectDescriptor{Identity: identity.ProjectIdentity{ProjectType: "type-b"}}}},
-	}))
+	}, ""))
 
 	opts := ecosystems.NewPluginOptions()
 	opts.Global.AllProjects = false
 
-	resultsChan := r.ResolveDepgraphs(ictx, "/test/dir", opts)
+	resultsChan := r.ResolveDepgraphs("/test/dir", opts)
 
 	results := collectResults(resultsChan)
 


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [ ] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Add ability for plugin registry to check for feature flags via the InvocationContext.
Add file that contains all the FF we require for enabling plugins.
