### PR TITLE
refactor: use variadic options for plugin registration

### DIFF
--- a/pkg/ecosystems/orchestrator/opts.go
+++ b/pkg/ecosystems/orchestrator/opts.go
@@ -1,0 +1,18 @@
+package orchestrator
+
+type registerOpt func(*PluginRegistry, *pluginEntry)
+
+func withFeatureFlag(flag flag) registerOpt {
+	return func(reg *PluginRegistry, entry *pluginEntry) {
+		if reg.ictx.GetConfiguration().GetBool(flag.Key) {
+			return
+		}
+		entry.skip = true
+	}
+}
+
+func withPluginDependencies(deps ...string) registerOpt {
+	return func(_ *PluginRegistry, entry *pluginEntry) {
+		entry.dependencies = deps
+	}
+}

--- a/pkg/ecosystems/orchestrator/registry.go
+++ b/pkg/ecosystems/orchestrator/registry.go
@@ -17,6 +17,7 @@ import (
 type pluginEntry struct {
 	plugin       ecosystems.SCAPlugin
 	dependencies []string
+	skip         bool
 }
 
 type PluginRegistry struct {
@@ -33,11 +34,11 @@ func NewDefaultPluginRegistry(ictx workflow.InvocationContext) (*PluginRegistry,
 	}
 
 	// javascript
-	if err := r.register(bun.Plugin{}, ""); err != nil {
+	if err := r.register(bun.Plugin{}); err != nil {
 		return nil, fmt.Errorf("failed to register bun plugin: %w", err)
 	}
 	// gradle (opt-in via feature flag)
-	if err := r.register(gradle.Plugin{}, FlagNewGradleResolver.Key); err != nil {
+	if err := r.register(gradle.Plugin{}, withFeatureFlag(FlagNewGradleResolver)); err != nil {
 		return nil, fmt.Errorf("failed to register gradle plugin: %w", err)
 	}
 
@@ -81,16 +82,17 @@ func (r *PluginRegistry) ResolveDepgraphs(dir string, opts *ecosystems.SCAPlugin
 	return resultsChan
 }
 
-func (r *PluginRegistry) register(plugin ecosystems.SCAPlugin, flag string, dependencies ...string) error {
-	if flag != "" {
-		if !r.ictx.GetConfiguration().GetBool(flag) {
-			return nil
-		}
+func (r *PluginRegistry) register(plugin ecosystems.SCAPlugin, opts ...registerOpt) error {
+	entry := pluginEntry{plugin: plugin}
+	for _, opt := range opts {
+		opt(r, &entry)
 	}
-	r.entries = append(r.entries, pluginEntry{
-		plugin:       plugin,
-		dependencies: dependencies,
-	})
+
+	if entry.skip {
+		return nil
+	}
+
+	r.entries = append(r.entries, entry)
 	sorted := r.sortPlugins()
 	if sorted == nil {
 		return fmt.Errorf("circular dependency detected involving plugin: %s", plugin.GetName())

--- a/pkg/ecosystems/orchestrator/registry_test.go
+++ b/pkg/ecosystems/orchestrator/registry_test.go
@@ -51,9 +51,9 @@ func TestPluginRegistry_OrderPreservedWithoutDependencies(t *testing.T) {
 		plugins: make([]ecosystems.SCAPlugin, 0),
 	}
 
-	require.NoError(t, r.register(&mockPlugin{name: "plugin-a"}, ""))
-	require.NoError(t, r.register(&mockPlugin{name: "plugin-b"}, ""))
-	require.NoError(t, r.register(&mockPlugin{name: "plugin-c"}, ""))
+	require.NoError(t, r.register(&mockPlugin{name: "plugin-a"}))
+	require.NoError(t, r.register(&mockPlugin{name: "plugin-b"}))
+	require.NoError(t, r.register(&mockPlugin{name: "plugin-c"}))
 
 	require.Len(t, r.plugins, 3)
 	assert.Equal(t, "plugin-a", r.plugins[0].GetName())
@@ -68,11 +68,11 @@ func TestPluginRegistry_DependenciesRespected(t *testing.T) {
 		plugins: make([]ecosystems.SCAPlugin, 0),
 	}
 
-	err := r.register(&mockPlugin{name: "plugin-c"}, "", "plugin-a")
+	err := r.register(&mockPlugin{name: "plugin-c"}, withPluginDependencies("plugin-a"))
 	require.NoError(t, err)
-	err = r.register(&mockPlugin{name: "plugin-b"}, "", "plugin-a")
+	err = r.register(&mockPlugin{name: "plugin-b"}, withPluginDependencies("plugin-a"))
 	require.NoError(t, err)
-	err = r.register(&mockPlugin{name: "plugin-a"}, "", "")
+	err = r.register(&mockPlugin{name: "plugin-a"})
 	require.NoError(t, err)
 
 	require.Len(t, r.plugins, 3)
@@ -87,11 +87,11 @@ func TestPluginRegistry_ChainedDependencies(t *testing.T) {
 		plugins: make([]ecosystems.SCAPlugin, 0),
 	}
 
-	err := r.register(&mockPlugin{name: "plugin-c"}, "", "plugin-b")
+	err := r.register(&mockPlugin{name: "plugin-c"}, withPluginDependencies("plugin-b"))
 	require.NoError(t, err)
-	err = r.register(&mockPlugin{name: "plugin-b"}, "", "plugin-a")
+	err = r.register(&mockPlugin{name: "plugin-b"}, withPluginDependencies("plugin-a"))
 	require.NoError(t, err)
-	err = r.register(&mockPlugin{name: "plugin-a"}, "", "")
+	err = r.register(&mockPlugin{name: "plugin-a"})
 	require.NoError(t, err)
 
 	require.Len(t, r.plugins, 3)
@@ -146,9 +146,9 @@ func TestPluginRegistry_CircularDependencyReturnsError(t *testing.T) {
 		plugins: make([]ecosystems.SCAPlugin, 0),
 	}
 
-	err := r.register(&mockPlugin{name: "plugin-a"}, "", "plugin-b")
+	err := r.register(&mockPlugin{name: "plugin-a"}, withPluginDependencies("plugin-b"))
 	require.NoError(t, err)
-	err = r.register(&mockPlugin{name: "plugin-b"}, "", "plugin-a")
+	err = r.register(&mockPlugin{name: "plugin-b"}, withPluginDependencies("plugin-a"))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "circular dependency detected")
 	assert.Contains(t, err.Error(), "plugin-b")
@@ -161,9 +161,9 @@ func TestPluginRegistry_NonExistentDependencyIgnored(t *testing.T) {
 		plugins: make([]ecosystems.SCAPlugin, 0),
 	}
 
-	err := r.register(&mockPlugin{name: "plugin-a"}, "")
+	err := r.register(&mockPlugin{name: "plugin-a"})
 	require.NoError(t, err)
-	err = r.register(&mockPlugin{name: "plugin-b"}, "", "non-existent-plugin")
+	err = r.register(&mockPlugin{name: "plugin-b"}, withPluginDependencies("non-existent-plugin"))
 	require.NoError(t, err)
 
 	require.Len(t, r.plugins, 2)
@@ -184,9 +184,9 @@ func TestPluginRegistry_DependencyAddedLater(t *testing.T) {
 		plugins: make([]ecosystems.SCAPlugin, 0),
 	}
 
-	err := r.register(&mockPlugin{name: "plugin-b"}, "", "plugin-a")
+	err := r.register(&mockPlugin{name: "plugin-b"}, withPluginDependencies("plugin-a"))
 	require.NoError(t, err)
-	err = r.register(&mockPlugin{name: "plugin-a"}, "")
+	err = r.register(&mockPlugin{name: "plugin-a"})
 	require.NoError(t, err)
 
 	require.Len(t, r.plugins, 2)
@@ -201,11 +201,11 @@ func TestPluginRegistry_CircularDependencyError(t *testing.T) {
 		plugins: make([]ecosystems.SCAPlugin, 0),
 	}
 
-	err := r.register(&mockPlugin{name: "plugin-a"}, "", "plugin-b")
+	err := r.register(&mockPlugin{name: "plugin-a"}, withPluginDependencies("plugin-b"))
 	require.NoError(t, err)
-	err = r.register(&mockPlugin{name: "plugin-b"}, "", "plugin-c")
+	err = r.register(&mockPlugin{name: "plugin-b"}, withPluginDependencies("plugin-c"))
 	require.NoError(t, err)
-	err = r.register(&mockPlugin{name: "plugin-c"}, "", "plugin-a")
+	err = r.register(&mockPlugin{name: "plugin-c"}, withPluginDependencies("plugin-a"))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "circular dependency detected")
 	assert.Contains(t, err.Error(), "plugin-c")
@@ -222,12 +222,12 @@ func TestPluginRegistry_ResolveDepgraphs_AllProjectsMode(t *testing.T) {
 		name:           "plugin-a",
 		processedFiles: []string{"file-a.txt"},
 		results:        []ecosystems.SCAResult{{ProjectDescriptor: identity.ProjectDescriptor{Identity: identity.ProjectIdentity{ProjectType: "type-a"}}}},
-	}, ""))
+	}))
 	require.NoError(t, r.register(&mockPlugin{
 		name:           "plugin-b",
 		processedFiles: []string{"file-b.txt"},
 		results:        []ecosystems.SCAResult{{ProjectDescriptor: identity.ProjectDescriptor{Identity: identity.ProjectIdentity{ProjectType: "type-b"}}}},
-	}, ""))
+	}))
 
 	opts := ecosystems.NewPluginOptions()
 	opts.Global.AllProjects = true
@@ -250,12 +250,12 @@ func TestPluginRegistry_ResolveDepgraphs_StopsAfterFirstResult(t *testing.T) {
 		name:           "plugin-a",
 		processedFiles: []string{"file-a.txt"},
 		results:        []ecosystems.SCAResult{{ProjectDescriptor: identity.ProjectDescriptor{Identity: identity.ProjectIdentity{ProjectType: "type-a"}}}},
-	}, ""))
+	}))
 	require.NoError(t, r.register(&mockPlugin{
 		name:           "plugin-b",
 		processedFiles: []string{"file-b.txt"},
 		results:        []ecosystems.SCAResult{{ProjectDescriptor: identity.ProjectDescriptor{Identity: identity.ProjectIdentity{ProjectType: "type-b"}}}},
-	}, ""))
+	}))
 
 	opts := ecosystems.NewPluginOptions()
 	opts.Global.AllProjects = false
@@ -279,12 +279,12 @@ func TestPluginRegistry_ResolveDepgraphs_ContinuesWhenNoResults(t *testing.T) {
 		name:           "plugin-a",
 		processedFiles: []string{},
 		results:        []ecosystems.SCAResult{},
-	}, ""))
+	}))
 	require.NoError(t, r.register(&mockPlugin{
 		name:           "plugin-b",
 		processedFiles: []string{"file-b.txt"},
 		results:        []ecosystems.SCAResult{{ProjectDescriptor: identity.ProjectDescriptor{Identity: identity.ProjectIdentity{ProjectType: "type-b"}}}},
-	}, ""))
+	}))
 
 	opts := ecosystems.NewPluginOptions()
 	opts.Global.AllProjects = false
@@ -319,8 +319,8 @@ func TestPluginRegistry_ResolveDepgraphs_PropagatesProcessedFilesAsExcludePaths(
 		processedFiles: []string{"b/lock.json"},
 		results:        []ecosystems.SCAResult{{ProjectDescriptor: identity.ProjectDescriptor{Identity: identity.ProjectIdentity{ProjectType: "type-b"}}}},
 	}
-	require.NoError(t, r.register(pluginA, ""))
-	require.NoError(t, r.register(pluginB, ""))
+	require.NoError(t, r.register(pluginA))
+	require.NoError(t, r.register(pluginB))
 
 	opts := ecosystems.NewPluginOptions()
 	opts.Global.AllProjects = true


### PR DESCRIPTION
### What this does

Changes the registry's `register` function signature to use more Go-idiomatic, variadic options.
