### PR TITLE
feat: incorporate gradle scanner into unified scanning behind a ff [C…

### DIFF
--- a/pkg/ecosystems/orchestrator/flags.go
+++ b/pkg/ecosystems/orchestrator/flags.go
@@ -10,8 +10,14 @@ var FlagUnifiedTestAPIOsCLI = flag{
 	Value: "unified-test-api-os-cli",
 }
 
+var FlagNewGradleResolver = flag{
+	Key:   "internal_new_gradle_resolver",
+	Value: "internal-new-gradle-resolver",
+}
+
 var allFlags = []flag{
 	FlagUnifiedTestAPIOsCLI,
+	FlagNewGradleResolver,
 }
 
 // GetAllFlags returns all feature flags as a map of key to flag name.

--- a/pkg/ecosystems/orchestrator/registry.go
+++ b/pkg/ecosystems/orchestrator/registry.go
@@ -8,6 +8,7 @@ import (
 	"github.com/snyk/go-application-framework/pkg/workflow"
 
 	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
+	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/gradle"
 	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/javascript/bun"
 	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/legacy"
 	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/logger"
@@ -34,6 +35,10 @@ func NewDefaultPluginRegistry(ictx workflow.InvocationContext) (*PluginRegistry,
 	// javascript
 	if err := r.register(bun.Plugin{}, ""); err != nil {
 		return nil, fmt.Errorf("failed to register bun plugin: %w", err)
+	}
+	// gradle (opt-in via feature flag)
+	if err := r.register(gradle.Plugin{}, FlagNewGradleResolver.Key); err != nil {
+		return nil, fmt.Errorf("failed to register gradle plugin: %w", err)
 	}
 
 	return r, nil
@@ -76,7 +81,6 @@ func (r *PluginRegistry) ResolveDepgraphs(dir string, opts *ecosystems.SCAPlugin
 	return resultsChan
 }
 
-//nolint:unparam // unset for now but ready for when we need FFs
 func (r *PluginRegistry) register(plugin ecosystems.SCAPlugin, flag string, dependencies ...string) error {
 	if flag != "" {
 		if !r.ictx.GetConfiguration().GetBool(flag) {

--- a/pkg/ecosystems/orchestrator/registry_test.go
+++ b/pkg/ecosystems/orchestrator/registry_test.go
@@ -93,6 +93,7 @@ func TestPluginRegistry_DefaultRegistryOrder(t *testing.T) {
 	r, err := NewDefaultPluginRegistry(setupMockInvocationContext(t))
 	require.NoError(t, err)
 
+	// Gradle is behind a FF that is off by default.
 	require.Len(t, r.plugins, 1)
 	assert.Equal(t, "bun", r.plugins[0].GetName())
 }
@@ -104,6 +105,27 @@ func TestPluginRegistry_DefaultRegistryHasNoCircularDependencies(t *testing.T) {
 	assert.NotNil(t, r)
 	assert.NotNil(t, r.plugins, "plugins should be successfully sorted without circular dependencies")
 	assert.Len(t, r.plugins, 1, "all 1 plugins should be registered")
+}
+
+func TestPluginRegistry_GradleRegisteredWhenFFEnabled(t *testing.T) {
+	ictx := setupMockInvocationContextWithConfig(t, func(cfg configuration.Configuration) {
+		cfg.Set(FlagNewGradleResolver.Key, true)
+	})
+
+	r, err := NewDefaultPluginRegistry(ictx)
+	require.NoError(t, err)
+
+	require.Len(t, r.plugins, 2)
+	assert.Equal(t, "bun", r.plugins[0].GetName())
+	assert.Equal(t, "gradle", r.plugins[1].GetName())
+}
+
+func TestPluginRegistry_GradleNotRegisteredWhenFFDisabled(t *testing.T) {
+	r, err := NewDefaultPluginRegistry(setupMockInvocationContext(t))
+	require.NoError(t, err)
+
+	require.Len(t, r.plugins, 1)
+	assert.NotEqual(t, "gradle", r.plugins[0].GetName())
 }
 
 func TestPluginRegistry_CircularDependencyReturnsError(t *testing.T) {
@@ -266,11 +288,19 @@ func TestPluginRegistry_ResolveDepgraphs_ContinuesWhenNoResults(t *testing.T) {
 
 func setupMockInvocationContext(t *testing.T) workflow.InvocationContext {
 	t.Helper()
+	return setupMockInvocationContextWithConfig(t, nil)
+}
+
+func setupMockInvocationContextWithConfig(t *testing.T, configure func(configuration.Configuration)) workflow.InvocationContext {
+	t.Helper()
 
 	ctrl := gomock.NewController(t)
 	ictx := gafmocks.NewMockInvocationContext(ctrl)
 	engine := gafmocks.NewMockEngine(ctrl)
 	cfg := configuration.New()
+	if configure != nil {
+		configure(cfg)
+	}
 	logger := zerolog.Nop()
 
 	ictx.EXPECT().GetConfiguration().Return(cfg).AnyTimes()


### PR DESCRIPTION
- [X] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [X] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does
- Hooks the new gradle resolver into the registry. 
- Adds resolver behind a feature flag 

[CMPA-476](https://snyksec.atlassian.net/jira/software/c/projects/CMPA/boards/5466?assignee=60162bfac8c36c00698fa2d4&selectedIssue=CMPA-476)


[CMPA-476]: https://snyksec.atlassian.net/browse/CMPA-476?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ