### PR TITLE
feat: honor ExcludePaths in plugins

### DIFF
--- a/pkg/depgraph/sbom_resolution.go
+++ b/pkg/depgraph/sbom_resolution.go
@@ -106,7 +106,6 @@ func handleSBOMResolutionDI(
 	// Generate Results
 	pluginLogger := ecosystemslogger.NewFromZerolog(logger)
 	results := []ecosystems.SCAResult{}
-	var processedFiles []string
 	for _, sp := range scaPlugins {
 		pluginResult, err := sp.BuildDepGraphsFromDir(
 			ctx.Context(),
@@ -128,7 +127,7 @@ func handleSBOMResolutionDI(
 		}
 
 		results = append(results, pluginResult.Results...)
-		processedFiles = append(processedFiles, pluginResult.ProcessedFiles...)
+		pluginOptions.WithExcludePaths(pluginResult.ProcessedFiles)
 		if !allProjects && len(pluginResult.Results) > 0 {
 			break
 		}
@@ -159,7 +158,9 @@ func handleSBOMResolutionDI(
 	totalResults := len(results)
 
 	if totalResults == 0 || allProjects {
-		applyProcessedFilesExclusions(config, processedFiles)
+		// pluginOptions.Global.ExcludePaths holds both the user's --exclude-paths plus every plugin's
+		// ProcessedFiles. Write the union back to the config flag so the legacy CLI sees it.
+		config.Set(workflow.FlagExcludePaths, strings.Join(pluginOptions.Global.ExcludePaths, ","))
 
 		legacyData, err := executeLegacyWorkflow(ctx, config, logger, depGraphWorkflowFunc, results)
 		if err != nil {
@@ -277,22 +278,6 @@ func parseExcludeFlag(excludeFlag string) []string {
 		return nil
 	}
 	return result
-}
-
-func applyProcessedFilesExclusions(config configuration.Configuration, processedFiles []string) {
-	if len(processedFiles) == 0 {
-		return
-	}
-
-	// Use --exclude-paths (not --exclude) so processed file paths are matched
-	// exactly. --exclude only matches by basename, which would incorrectly
-	// exclude all same-named manifests across a workspace.
-	parts := make([]string, 0, len(processedFiles)+1)
-	if existing := config.GetString(workflow.FlagExcludePaths); existing != "" {
-		parts = append(parts, existing)
-	}
-	parts = append(parts, processedFiles...)
-	config.Set(workflow.FlagExcludePaths, strings.Join(parts, ","))
 }
 
 func executeLegacyWorkflow(

--- a/pkg/depgraph/sbom_resolution_test.go
+++ b/pkg/depgraph/sbom_resolution_test.go
@@ -1722,107 +1722,84 @@ func Test_extractProblemResults(t *testing.T) {
 	})
 }
 
-func Test_applyProcessedFilesExclusions(t *testing.T) {
+// Test_processedFilesFlowFromPluginsToExcludeConfig locks in the end-to-end contract that
+// the legacy CLI subprocess sees the full union of paths to skip: the user's --exclude-paths
+// flag combined with every plugin's ProcessedFiles. The union is built up on
+// pluginOptions.Global.ExcludePaths during the plugin loop and written verbatim to the
+// FlagExcludePaths config flag before the legacy workflow is invoked.
+func Test_processedFilesFlowFromPluginsToExcludeConfig(t *testing.T) {
+	dataIdentifier := gafworkflow.NewTypeIdentifier(WorkflowID, workflow.WorkflowIDStr)
+
+	pluginWithProcessedFiles := func(targetFile, name string, processedFiles []string) *mockScaPlugin {
+		return &mockScaPlugin{
+			result: &ecosystems.PluginResult{
+				Results: []ecosystems.SCAResult{{
+					DepGraph: createTestDepGraph(t, "pip", name, "1.0.0"),
+					ProjectDescriptor: identity.ProjectDescriptor{
+						Identity: identity.ProjectIdentity{TargetFile: stringPtr(targetFile)},
+					},
+				}},
+				ProcessedFiles: processedFiles,
+			},
+		}
+	}
+
 	testCases := []struct {
 		name                 string
-		initialExcludePaths  string
-		processedFiles       []string
+		userExcludePaths     string
+		plugins              []ecosystems.SCAPlugin
 		expectedExcludePaths string
 	}{
 		{
-			name:                 "no processed files does not modify config",
-			initialExcludePaths:  "",
-			processedFiles:       []string{},
-			expectedExcludePaths: "",
-		},
-		{
-			name:                 "nil processed files does not modify config",
-			initialExcludePaths:  "",
-			processedFiles:       nil,
-			expectedExcludePaths: "",
-		},
-		{
-			name:                 "single processed file",
-			processedFiles:       []string{"file1.py"},
-			expectedExcludePaths: "file1.py",
-		},
-		{
-			name:                 "multiple processed files",
-			processedFiles:       []string{"file1.py", "file2.py", "file3.py"},
+			name: "union of every plugin's ProcessedFiles",
+			plugins: []ecosystems.SCAPlugin{
+				pluginWithProcessedFiles("pyproject.toml", "project-1", []string{"file1.py", "file2.py"}),
+				pluginWithProcessedFiles("package.json", "project-2", []string{"file3.py"}),
+			},
 			expectedExcludePaths: "file1.py,file2.py,file3.py",
 		},
 		{
-			name:                 "appends to existing exclude-paths",
-			initialExcludePaths:  "existing.txt",
-			processedFiles:       []string{"file1.py", "file2.py"},
-			expectedExcludePaths: "existing.txt,file1.py,file2.py",
+			name:             "user --exclude-paths value is preserved alongside processed files",
+			userExcludePaths: "user-supplied.txt",
+			plugins: []ecosystems.SCAPlugin{
+				pluginWithProcessedFiles("pyproject.toml", "project-1", []string{"file1.py"}),
+			},
+			expectedExcludePaths: "user-supplied.txt,file1.py",
+		},
+		{
+			name:                 "user --exclude-paths value alone when no plugin produced ProcessedFiles",
+			userExcludePaths:     "user-supplied.txt",
+			plugins:              []ecosystems.SCAPlugin{&mockScaPlugin{result: &ecosystems.PluginResult{}}},
+			expectedExcludePaths: "user-supplied.txt",
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			config := configuration.New()
-			if tc.initialExcludePaths != "" {
-				config.Set(workflow.FlagExcludePaths, tc.initialExcludePaths)
+			ctx := setupTestContext(t, true)
+			ctx.config.Set(workflow.FlagAllProjects, true)
+			if tc.userExcludePaths != "" {
+				ctx.config.Set(workflow.FlagExcludePaths, tc.userExcludePaths)
 			}
 
-			applyProcessedFilesExclusions(config, tc.processedFiles)
+			resolutionHandler := NewCalledResolutionHandlerFunc(nil, nil)
+			resolutionHandler.ReturnData = []gafworkflow.Data{
+				gafworkflow.NewData(dataIdentifier, "application/json", []byte(`{"mock":"data"}`)),
+			}
 
-			assert.Equal(t, tc.expectedExcludePaths, config.GetString(workflow.FlagExcludePaths))
+			_, err := handleSBOMResolutionDI(
+				ctx.invocationContext,
+				ctx.config,
+				&nopLogger,
+				tc.plugins,
+				resolutionHandler.Func(),
+			)
+
+			require.NoError(t, err)
+			require.True(t, resolutionHandler.Called)
+			assert.Equal(t, tc.expectedExcludePaths, resolutionHandler.Config.GetString(workflow.FlagExcludePaths))
 		})
 	}
-}
-
-func Test_processedFilesFlowFromPluginsToExcludeConfig(t *testing.T) {
-	ctx := setupTestContext(t, true)
-	resolutionHandler := NewCalledResolutionHandlerFunc(nil, nil)
-	ctx.config.Set(workflow.FlagAllProjects, true)
-
-	dataIdentifier := gafworkflow.NewTypeIdentifier(WorkflowID, workflow.WorkflowIDStr)
-	resolutionHandler.ReturnData = []gafworkflow.Data{
-		gafworkflow.NewData(dataIdentifier, "application/json", []byte(`{"mock":"data"}`)),
-	}
-
-	mockPlugin1 := &mockScaPlugin{
-		result: &ecosystems.PluginResult{
-			Results: []ecosystems.SCAResult{{
-				DepGraph: createTestDepGraph(t, "pip", "project-1", "1.0.0"),
-				ProjectDescriptor: identity.ProjectDescriptor{
-					Identity: identity.ProjectIdentity{
-						TargetFile: stringPtr("pyproject.toml"),
-					},
-				},
-			}},
-			ProcessedFiles: []string{"file1.py", "file2.py"},
-		},
-	}
-	mockPlugin2 := &mockScaPlugin{
-		result: &ecosystems.PluginResult{
-			Results: []ecosystems.SCAResult{{
-				DepGraph: createTestDepGraph(t, "pip", "project-2", "2.0.0"),
-				ProjectDescriptor: identity.ProjectDescriptor{
-					Identity: identity.ProjectIdentity{
-						TargetFile: stringPtr("package.json"),
-					},
-				},
-			}},
-			ProcessedFiles: []string{"file3.py"},
-		},
-	}
-
-	_, err := handleSBOMResolutionDI(
-		ctx.invocationContext,
-		ctx.config,
-		&nopLogger,
-		[]ecosystems.SCAPlugin{mockPlugin1, mockPlugin2},
-		resolutionHandler.Func(),
-	)
-
-	require.NoError(t, err)
-	require.True(t, resolutionHandler.Called)
-	actualExcludePaths := resolutionHandler.Config.GetString(workflow.FlagExcludePaths)
-	assert.Equal(t, "file1.py,file2.py,file3.py", actualExcludePaths,
-		"ProcessedFiles from all plugins should be combined into FlagExcludePaths")
 }
 
 func Test_uvWorkspacePackages_passesOptionToPlugin(t *testing.T) {

--- a/pkg/ecosystems/gradle/plugin.go
+++ b/pkg/ecosystems/gradle/plugin.go
@@ -262,6 +262,9 @@ func (p Plugin) discoverAllGradleProjects(ctx context.Context, dir string, optio
 	if len(options.Global.Exclude) > 0 {
 		findOpts = append(findOpts, discovery.WithExcludes(options.Global.Exclude...))
 	}
+	if len(options.Global.ExcludePaths) > 0 {
+		findOpts = append(findOpts, discovery.WithExcludes(options.Global.ExcludePaths...))
+	}
 
 	files, err := discovery.FindFiles(ctx, dir, findOpts...)
 	if err != nil {

--- a/pkg/ecosystems/gradle/plugin_test.go
+++ b/pkg/ecosystems/gradle/plugin_test.go
@@ -606,3 +606,31 @@ func TestTargetFileFiltering_MockedOutput(t *testing.T) {
 		assert.Len(t, files, 0)
 	})
 }
+
+// TestPlugin_DiscoverAllGradleProjects_HonorsExcludePaths locks in that the gradle plugin
+// reads `opts.Global.ExcludePaths` and passes those paths through to the discovery layer's
+// exclude filter — same contract as the other discovery plugins.
+func TestPlugin_DiscoverAllGradleProjects_HonorsExcludePaths(t *testing.T) {
+	tmpDir := t.TempDir()
+	for _, rel := range []string{"build.gradle", "a/build.gradle", "b/build.gradle"} {
+		full := filepath.Join(tmpDir, rel)
+		require.NoError(t, os.MkdirAll(filepath.Dir(full), 0o755))
+		require.NoError(t, os.WriteFile(full, []byte(""), 0o644))
+	}
+
+	opts := ecosystems.NewPluginOptions().
+		WithAllProjects(true).
+		WithExcludePaths([]string{"a/build.gradle"})
+
+	got, err := Plugin{}.discoverAllGradleProjects(t.Context(), tmpDir, opts)
+	require.NoError(t, err)
+
+	rels := make([]string, len(got))
+	for i, r := range got {
+		rels[i] = r.RelPath
+	}
+	assert.NotContains(t, rels, "a/build.gradle",
+		"discovery must skip the path supplied via opts.Global.ExcludePaths")
+	assert.Contains(t, rels, "build.gradle")
+	assert.Contains(t, rels, "b/build.gradle")
+}

--- a/pkg/ecosystems/javascript/bun/plugin.go
+++ b/pkg/ecosystems/javascript/bun/plugin.go
@@ -218,6 +218,9 @@ func (p Plugin) discoverLockFiles(
 		if len(options.Global.Exclude) > 0 {
 			findOpts = append(findOpts, discovery.WithExcludes(options.Global.Exclude...))
 		}
+		if len(options.Global.ExcludePaths) > 0 {
+			findOpts = append(findOpts, discovery.WithExcludes(options.Global.ExcludePaths...))
+		}
 
 		files, err := discovery.FindFiles(ctx, dir, findOpts...)
 		if err != nil {

--- a/pkg/ecosystems/javascript/bun/plugin_test.go
+++ b/pkg/ecosystems/javascript/bun/plugin_test.go
@@ -366,3 +366,31 @@ func TestParseWhyOutput_ReaderInterface(t *testing.T) {
 	assert.Contains(t, out.ProdDeps, "debug@4.4.3")
 	assert.Contains(t, out.Graph, "ms@2.1.3")
 }
+
+// TestPlugin_DiscoverLockFiles_HonorsExcludePaths locks in that the bun plugin reads
+// `opts.Global.ExcludePaths` and passes those paths through to the discovery layer's
+// exclude filter — same contract as the other discovery plugins.
+func TestPlugin_DiscoverLockFiles_HonorsExcludePaths(t *testing.T) {
+	tmpDir := t.TempDir()
+	for _, rel := range []string{"bun.lock", "a/bun.lock", "b/bun.lock"} {
+		full := filepath.Join(tmpDir, rel)
+		require.NoError(t, os.MkdirAll(filepath.Dir(full), 0o755))
+		require.NoError(t, os.WriteFile(full, []byte(""), 0o600))
+	}
+
+	opts := ecosystems.NewPluginOptions().
+		WithAllProjects(true).
+		WithExcludePaths([]string{"a/bun.lock"})
+
+	got, err := Plugin{}.discoverLockFiles(t.Context(), tmpDir, opts)
+	require.NoError(t, err)
+
+	rels := make([]string, len(got))
+	for i, r := range got {
+		rels[i] = r.RelPath
+	}
+	assert.NotContains(t, rels, "a/bun.lock",
+		"discovery must skip the path supplied via opts.Global.ExcludePaths")
+	assert.Contains(t, rels, "bun.lock")
+	assert.Contains(t, rels, "b/bun.lock")
+}

--- a/pkg/ecosystems/orchestrator/registry.go
+++ b/pkg/ecosystems/orchestrator/registry.go
@@ -66,7 +66,7 @@ func (r *PluginRegistry) ResolveDepgraphs(dir string, opts *ecosystems.SCAPlugin
 				return
 			}
 			processedFiles = append(processedFiles, files...)
-			opts.WithExclude(files)
+			opts.WithExcludePaths(files)
 		}
 
 		select {

--- a/pkg/ecosystems/orchestrator/registry_test.go
+++ b/pkg/ecosystems/orchestrator/registry_test.go
@@ -21,13 +21,24 @@ type mockPlugin struct {
 	name           string
 	processedFiles []string
 	results        []ecosystems.SCAResult
+
+	// capturedExclude / capturedExcludePaths snapshot opts.Global.{Exclude,ExcludePaths}
+	// at the moment BuildDepGraphsFromDir is called, so tests can assert on what each
+	// plugin saw — distinct from the post-loop state of the live opts pointer, which
+	// keeps mutating.
+	capturedExclude      []string
+	capturedExcludePaths []string
 }
 
-func (m mockPlugin) GetName() string {
+func (m *mockPlugin) GetName() string {
 	return m.name
 }
 
-func (m mockPlugin) BuildDepGraphsFromDir(context.Context, logger.Logger, string, *ecosystems.SCAPluginOptions) (*ecosystems.PluginResult, error) {
+func (m *mockPlugin) BuildDepGraphsFromDir(_ context.Context, _ logger.Logger, _ string, opts *ecosystems.SCAPluginOptions) (*ecosystems.PluginResult, error) {
+	if opts != nil {
+		m.capturedExclude = append([]string(nil), opts.Global.Exclude...)
+		m.capturedExcludePaths = append([]string(nil), opts.Global.ExcludePaths...)
+	}
 	return &ecosystems.PluginResult{
 		ProcessedFiles: m.processedFiles,
 		Results:        m.results,
@@ -40,9 +51,9 @@ func TestPluginRegistry_OrderPreservedWithoutDependencies(t *testing.T) {
 		plugins: make([]ecosystems.SCAPlugin, 0),
 	}
 
-	require.NoError(t, r.register(mockPlugin{name: "plugin-a"}, ""))
-	require.NoError(t, r.register(mockPlugin{name: "plugin-b"}, ""))
-	require.NoError(t, r.register(mockPlugin{name: "plugin-c"}, ""))
+	require.NoError(t, r.register(&mockPlugin{name: "plugin-a"}, ""))
+	require.NoError(t, r.register(&mockPlugin{name: "plugin-b"}, ""))
+	require.NoError(t, r.register(&mockPlugin{name: "plugin-c"}, ""))
 
 	require.Len(t, r.plugins, 3)
 	assert.Equal(t, "plugin-a", r.plugins[0].GetName())
@@ -57,11 +68,11 @@ func TestPluginRegistry_DependenciesRespected(t *testing.T) {
 		plugins: make([]ecosystems.SCAPlugin, 0),
 	}
 
-	err := r.register(mockPlugin{name: "plugin-c"}, "", "plugin-a")
+	err := r.register(&mockPlugin{name: "plugin-c"}, "", "plugin-a")
 	require.NoError(t, err)
-	err = r.register(mockPlugin{name: "plugin-b"}, "", "plugin-a")
+	err = r.register(&mockPlugin{name: "plugin-b"}, "", "plugin-a")
 	require.NoError(t, err)
-	err = r.register(mockPlugin{name: "plugin-a"}, "", "")
+	err = r.register(&mockPlugin{name: "plugin-a"}, "", "")
 	require.NoError(t, err)
 
 	require.Len(t, r.plugins, 3)
@@ -76,11 +87,11 @@ func TestPluginRegistry_ChainedDependencies(t *testing.T) {
 		plugins: make([]ecosystems.SCAPlugin, 0),
 	}
 
-	err := r.register(mockPlugin{name: "plugin-c"}, "", "plugin-b")
+	err := r.register(&mockPlugin{name: "plugin-c"}, "", "plugin-b")
 	require.NoError(t, err)
-	err = r.register(mockPlugin{name: "plugin-b"}, "", "plugin-a")
+	err = r.register(&mockPlugin{name: "plugin-b"}, "", "plugin-a")
 	require.NoError(t, err)
-	err = r.register(mockPlugin{name: "plugin-a"}, "", "")
+	err = r.register(&mockPlugin{name: "plugin-a"}, "", "")
 	require.NoError(t, err)
 
 	require.Len(t, r.plugins, 3)
@@ -135,9 +146,9 @@ func TestPluginRegistry_CircularDependencyReturnsError(t *testing.T) {
 		plugins: make([]ecosystems.SCAPlugin, 0),
 	}
 
-	err := r.register(mockPlugin{name: "plugin-a"}, "", "plugin-b")
+	err := r.register(&mockPlugin{name: "plugin-a"}, "", "plugin-b")
 	require.NoError(t, err)
-	err = r.register(mockPlugin{name: "plugin-b"}, "", "plugin-a")
+	err = r.register(&mockPlugin{name: "plugin-b"}, "", "plugin-a")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "circular dependency detected")
 	assert.Contains(t, err.Error(), "plugin-b")
@@ -150,9 +161,9 @@ func TestPluginRegistry_NonExistentDependencyIgnored(t *testing.T) {
 		plugins: make([]ecosystems.SCAPlugin, 0),
 	}
 
-	err := r.register(mockPlugin{name: "plugin-a"}, "")
+	err := r.register(&mockPlugin{name: "plugin-a"}, "")
 	require.NoError(t, err)
-	err = r.register(mockPlugin{name: "plugin-b"}, "", "non-existent-plugin")
+	err = r.register(&mockPlugin{name: "plugin-b"}, "", "non-existent-plugin")
 	require.NoError(t, err)
 
 	require.Len(t, r.plugins, 2)
@@ -173,9 +184,9 @@ func TestPluginRegistry_DependencyAddedLater(t *testing.T) {
 		plugins: make([]ecosystems.SCAPlugin, 0),
 	}
 
-	err := r.register(mockPlugin{name: "plugin-b"}, "", "plugin-a")
+	err := r.register(&mockPlugin{name: "plugin-b"}, "", "plugin-a")
 	require.NoError(t, err)
-	err = r.register(mockPlugin{name: "plugin-a"}, "")
+	err = r.register(&mockPlugin{name: "plugin-a"}, "")
 	require.NoError(t, err)
 
 	require.Len(t, r.plugins, 2)
@@ -190,11 +201,11 @@ func TestPluginRegistry_CircularDependencyError(t *testing.T) {
 		plugins: make([]ecosystems.SCAPlugin, 0),
 	}
 
-	err := r.register(mockPlugin{name: "plugin-a"}, "", "plugin-b")
+	err := r.register(&mockPlugin{name: "plugin-a"}, "", "plugin-b")
 	require.NoError(t, err)
-	err = r.register(mockPlugin{name: "plugin-b"}, "", "plugin-c")
+	err = r.register(&mockPlugin{name: "plugin-b"}, "", "plugin-c")
 	require.NoError(t, err)
-	err = r.register(mockPlugin{name: "plugin-c"}, "", "plugin-a")
+	err = r.register(&mockPlugin{name: "plugin-c"}, "", "plugin-a")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "circular dependency detected")
 	assert.Contains(t, err.Error(), "plugin-c")
@@ -207,12 +218,12 @@ func TestPluginRegistry_ResolveDepgraphs_AllProjectsMode(t *testing.T) {
 		plugins: make([]ecosystems.SCAPlugin, 0),
 	}
 
-	require.NoError(t, r.register(mockPlugin{
+	require.NoError(t, r.register(&mockPlugin{
 		name:           "plugin-a",
 		processedFiles: []string{"file-a.txt"},
 		results:        []ecosystems.SCAResult{{ProjectDescriptor: identity.ProjectDescriptor{Identity: identity.ProjectIdentity{ProjectType: "type-a"}}}},
 	}, ""))
-	require.NoError(t, r.register(mockPlugin{
+	require.NoError(t, r.register(&mockPlugin{
 		name:           "plugin-b",
 		processedFiles: []string{"file-b.txt"},
 		results:        []ecosystems.SCAResult{{ProjectDescriptor: identity.ProjectDescriptor{Identity: identity.ProjectIdentity{ProjectType: "type-b"}}}},
@@ -235,12 +246,12 @@ func TestPluginRegistry_ResolveDepgraphs_StopsAfterFirstResult(t *testing.T) {
 		plugins: make([]ecosystems.SCAPlugin, 0),
 	}
 
-	require.NoError(t, r.register(mockPlugin{
+	require.NoError(t, r.register(&mockPlugin{
 		name:           "plugin-a",
 		processedFiles: []string{"file-a.txt"},
 		results:        []ecosystems.SCAResult{{ProjectDescriptor: identity.ProjectDescriptor{Identity: identity.ProjectIdentity{ProjectType: "type-a"}}}},
 	}, ""))
-	require.NoError(t, r.register(mockPlugin{
+	require.NoError(t, r.register(&mockPlugin{
 		name:           "plugin-b",
 		processedFiles: []string{"file-b.txt"},
 		results:        []ecosystems.SCAResult{{ProjectDescriptor: identity.ProjectDescriptor{Identity: identity.ProjectIdentity{ProjectType: "type-b"}}}},
@@ -264,12 +275,12 @@ func TestPluginRegistry_ResolveDepgraphs_ContinuesWhenNoResults(t *testing.T) {
 		plugins: make([]ecosystems.SCAPlugin, 0),
 	}
 
-	require.NoError(t, r.register(mockPlugin{
+	require.NoError(t, r.register(&mockPlugin{
 		name:           "plugin-a",
 		processedFiles: []string{},
 		results:        []ecosystems.SCAResult{},
 	}, ""))
-	require.NoError(t, r.register(mockPlugin{
+	require.NoError(t, r.register(&mockPlugin{
 		name:           "plugin-b",
 		processedFiles: []string{"file-b.txt"},
 		results:        []ecosystems.SCAResult{{ProjectDescriptor: identity.ProjectDescriptor{Identity: identity.ProjectIdentity{ProjectType: "type-b"}}}},
@@ -284,6 +295,46 @@ func TestPluginRegistry_ResolveDepgraphs_ContinuesWhenNoResults(t *testing.T) {
 
 	assert.Len(t, results, 1)
 	assert.Equal(t, "type-b", results[0].ProjectDescriptor.Identity.ProjectType)
+}
+
+// TestPluginRegistry_ResolveDepgraphs_PropagatesProcessedFilesAsExcludePaths locks in
+// that after a plugin returns ProcessedFiles, every subsequent plugin in the chain sees
+// those paths on `opts.Global.ExcludePaths` so they can skip already-handled files.
+// Processed files are exact paths, not basename patterns, so they belong on the
+// ExcludePaths channel rather than the basename-matching Exclude channel.
+func TestPluginRegistry_ResolveDepgraphs_PropagatesProcessedFilesAsExcludePaths(t *testing.T) {
+	r := &PluginRegistry{
+		ictx:    setupMockInvocationContext(t),
+		entries: make([]pluginEntry, 0),
+		plugins: make([]ecosystems.SCAPlugin, 0),
+	}
+
+	pluginA := &mockPlugin{
+		name:           "plugin-a",
+		processedFiles: []string{"a/lock.json", "a/sub/lock.json"},
+		results:        []ecosystems.SCAResult{{ProjectDescriptor: identity.ProjectDescriptor{Identity: identity.ProjectIdentity{ProjectType: "type-a"}}}},
+	}
+	pluginB := &mockPlugin{
+		name:           "plugin-b",
+		processedFiles: []string{"b/lock.json"},
+		results:        []ecosystems.SCAResult{{ProjectDescriptor: identity.ProjectDescriptor{Identity: identity.ProjectIdentity{ProjectType: "type-b"}}}},
+	}
+	require.NoError(t, r.register(pluginA, ""))
+	require.NoError(t, r.register(pluginB, ""))
+
+	opts := ecosystems.NewPluginOptions()
+	opts.Global.AllProjects = true
+
+	collectResults(r.ResolveDepgraphs("/test/dir", opts))
+
+	assert.Empty(t, pluginA.capturedExcludePaths,
+		"first plugin sees no ExcludePaths because no plugin has run before it")
+	assert.Equal(t, []string{"a/lock.json", "a/sub/lock.json"}, pluginB.capturedExcludePaths,
+		"second plugin must see the first plugin's ProcessedFiles on opts.Global.ExcludePaths")
+	assert.Empty(t, pluginA.capturedExclude,
+		"processed files must NOT leak onto opts.Global.Exclude — that channel is for basename patterns only")
+	assert.Empty(t, pluginB.capturedExclude,
+		"processed files must NOT leak onto opts.Global.Exclude — that channel is for basename patterns only")
 }
 
 func setupMockInvocationContext(t *testing.T) workflow.InvocationContext {

--- a/pkg/ecosystems/python/pip/plugin.go
+++ b/pkg/ecosystems/python/pip/plugin.go
@@ -133,9 +133,10 @@ func (p Plugin) discoverRequirementsFiles(ctx context.Context, dir string, optio
 		// Find all requirements.txt files recursively
 		// Exclude common directories to avoid scanning unnecessary paths
 		defaultExcludes := []string{".*", "__pycache__", "*.egg-info", "dist", "build", "venv"}
-		excludes := make([]string, 0, len(defaultExcludes)+len(options.Global.Exclude))
+		excludes := make([]string, 0, len(defaultExcludes)+len(options.Global.Exclude)+len(options.Global.ExcludePaths))
 		excludes = append(excludes, defaultExcludes...)
 		excludes = append(excludes, options.Global.Exclude...)
+		excludes = append(excludes, options.Global.ExcludePaths...)
 		findOpts = []discovery.FindOption{
 			discovery.WithInclude(requirementsFile),
 			discovery.WithExcludes(excludes...),

--- a/pkg/ecosystems/python/pip/plugin_test.go
+++ b/pkg/ecosystems/python/pip/plugin_test.go
@@ -4,9 +4,14 @@
 package pip
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
 )
 
 func ptr(s string) *string { return &s }
@@ -62,4 +67,33 @@ func TestGetProjectName(t *testing.T) {
 			assert.Equal(t, tt.expected, result)
 		})
 	}
+}
+
+// TestPlugin_DiscoverRequirementsFiles_HonorsExcludePaths locks in that the pip plugin
+// reads `opts.Global.ExcludePaths` (the channel the orchestrator and SBOM-resolution
+// paths use to propagate processed files and the user's `--exclude-paths` flag) and
+// passes those paths through to the discovery layer's exclude filter.
+func TestPlugin_DiscoverRequirementsFiles_HonorsExcludePaths(t *testing.T) {
+	tmpDir := t.TempDir()
+	for _, rel := range []string{"requirements.txt", "a/requirements.txt", "b/requirements.txt"} {
+		full := filepath.Join(tmpDir, rel)
+		require.NoError(t, os.MkdirAll(filepath.Dir(full), 0o755))
+		require.NoError(t, os.WriteFile(full, []byte(""), 0o644))
+	}
+
+	opts := ecosystems.NewPluginOptions().
+		WithAllProjects(true).
+		WithExcludePaths([]string{"a/requirements.txt"})
+
+	got, err := Plugin{}.discoverRequirementsFiles(t.Context(), tmpDir, opts)
+	require.NoError(t, err)
+
+	rels := make([]string, len(got))
+	for i, r := range got {
+		rels[i] = r.RelPath
+	}
+	assert.NotContains(t, rels, "a/requirements.txt",
+		"discovery must skip the path supplied via opts.Global.ExcludePaths")
+	assert.Contains(t, rels, "requirements.txt")
+	assert.Contains(t, rels, "b/requirements.txt")
 }

--- a/pkg/ecosystems/python/pipenv/plugin.go
+++ b/pkg/ecosystems/python/pipenv/plugin.go
@@ -136,9 +136,10 @@ func (p Plugin) discoverPipfiles(ctx context.Context, dir string, options *ecosy
 	case options.Global.AllProjects:
 		// Find all Pipfile files recursively
 		defaultExcludes := []string{".*", "__pycache__", "*.egg-info", "dist", "build", "venv"}
-		excludes := make([]string, 0, len(defaultExcludes)+len(options.Global.Exclude))
+		excludes := make([]string, 0, len(defaultExcludes)+len(options.Global.Exclude)+len(options.Global.ExcludePaths))
 		excludes = append(excludes, defaultExcludes...)
 		excludes = append(excludes, options.Global.Exclude...)
+		excludes = append(excludes, options.Global.ExcludePaths...)
 		findOpts = []discovery.FindOption{
 			discovery.WithInclude(pipfileFile),
 			discovery.WithExcludes(excludes...),

--- a/pkg/ecosystems/python/pipenv/plugin_test.go
+++ b/pkg/ecosystems/python/pipenv/plugin_test.go
@@ -1,0 +1,43 @@
+//go:build !integration
+// +build !integration
+
+package pipenv
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
+)
+
+// TestPlugin_DiscoverPipfiles_HonorsExcludePaths locks in that the pipenv plugin reads
+// `opts.Global.ExcludePaths` and passes those paths through to the discovery layer's
+// exclude filter — same contract as the other discovery plugins.
+func TestPlugin_DiscoverPipfiles_HonorsExcludePaths(t *testing.T) {
+	tmpDir := t.TempDir()
+	for _, rel := range []string{"Pipfile", "a/Pipfile", "b/Pipfile"} {
+		full := filepath.Join(tmpDir, rel)
+		require.NoError(t, os.MkdirAll(filepath.Dir(full), 0o755))
+		require.NoError(t, os.WriteFile(full, []byte(""), 0o644))
+	}
+
+	opts := ecosystems.NewPluginOptions().
+		WithAllProjects(true).
+		WithExcludePaths([]string{"a/Pipfile"})
+
+	got, err := Plugin{}.discoverPipfiles(t.Context(), tmpDir, opts)
+	require.NoError(t, err)
+
+	rels := make([]string, len(got))
+	for i, r := range got {
+		rels[i] = r.RelPath
+	}
+	assert.NotContains(t, rels, "a/Pipfile",
+		"discovery must skip the path supplied via opts.Global.ExcludePaths")
+	assert.Contains(t, rels, "Pipfile")
+	assert.Contains(t, rels, "b/Pipfile")
+}

--- a/pkg/ecosystems/python/uv/plugin.go
+++ b/pkg/ecosystems/python/uv/plugin.go
@@ -286,6 +286,9 @@ func (p Plugin) discoverLockFiles(
 		if len(options.Global.Exclude) > 0 {
 			findOpts = append(findOpts, discovery.WithExcludes(options.Global.Exclude...))
 		}
+		if len(options.Global.ExcludePaths) > 0 {
+			findOpts = append(findOpts, discovery.WithExcludes(options.Global.ExcludePaths...))
+		}
 	default:
 		if targetFile != "" {
 			findOpts = append(findOpts, discovery.WithTargetFile(targetFile))

--- a/pkg/ecosystems/python/uv/plugin_test.go
+++ b/pkg/ecosystems/python/uv/plugin_test.go
@@ -67,7 +67,8 @@ func TestPlugin_BuildDepGraphsFromDir(t *testing.T) {
 		name         string
 		files        []string // files to create relative to root
 		allProjects  bool
-		exclude      []string // directory/file names to exclude
+		exclude      []string // basename/dirname patterns (--exclude semantic)
+		excludePaths []string // exact path patterns (--exclude-paths semantic / processed-files channel)
 		expectedDirs []string // expected directories (relative paths) that should be processed
 		expectedErr  string   // if non-empty, expect error containing this string
 	}{
@@ -155,6 +156,33 @@ func TestPlugin_BuildDepGraphsFromDir(t *testing.T) {
 			expectedDirs: []string{"."},
 		},
 
+		// CLI exclude-paths flag (also covers cross-plugin processed-files propagation, since
+		// orchestrators push processed file paths through this same opts.Global.ExcludePaths channel).
+		{
+			name: "excludes exact paths via excludePaths",
+			files: []string{
+				"uv.lock",
+				"dir1/uv.lock",
+				"dir2/uv.lock",
+			},
+			allProjects:  true,
+			excludePaths: []string{"dir1/uv.lock"},
+			expectedDirs: []string{".", "dir2"},
+		},
+		{
+			name: "exclude and excludePaths combine",
+			files: []string{
+				"uv.lock",
+				"dir1/uv.lock",
+				"dir2/uv.lock",
+				"dir3/uv.lock",
+			},
+			allProjects:  true,
+			exclude:      []string{"dir1"},
+			excludePaths: []string{"dir2/uv.lock"},
+			expectedDirs: []string{".", "dir3"},
+		},
+
 		// Edge cases
 		{
 			name:         "no files found",
@@ -193,7 +221,10 @@ func TestPlugin_BuildDepGraphsFromDir(t *testing.T) {
 
 			// Execute
 			ctx := context.Background()
-			options := ecosystems.NewPluginOptions().WithAllProjects(tt.allProjects).WithExclude(tt.exclude)
+			options := ecosystems.NewPluginOptions().
+				WithAllProjects(tt.allProjects).
+				WithExclude(tt.exclude).
+				WithExcludePaths(tt.excludePaths)
 			pluginResult, err := plugin.BuildDepGraphsFromDir(ctx, testLogger, tmpDir, options)
 
 			// Check error
@@ -431,6 +462,7 @@ func TestBuildFindings_Success(t *testing.T) {
 	assert.NotNil(t, findings[0].DepGraph)
 	assert.Equal(t, "pyproject.toml", findings[0].ProjectDescriptor.GetTargetFile())
 	assert.Nil(t, findings[0].Error)
+	assert.Equal(t, []string{"uv.lock", "pyproject.toml", "requirements.txt"}, buildResult.ProcessedFiles)
 }
 
 func TestBuildFindings_NoProjectRoot_ReturnsErrorFinding(t *testing.T) {


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [ ] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Switches the orchestrator's plugin-loop processed-file propagation from the basename-matching `Exclude` to the exact-path `ExcludePaths`, and wires each discovery plugin (`bun`, `pip`, `pipenv`, `uv`, `gradle`) to honour `opts.Global.ExcludePaths` alongside the existing `opts.Global.Exclude`.

(Note that #166 stacks on top of this PR.)