### PR TITLE
feat: add NormalisedTargetFile to resolver metadata

### DIFF
--- a/pkg/ecosystems/gradle/plugin.go
+++ b/pkg/ecosystems/gradle/plugin.go
@@ -296,15 +296,6 @@ func (p Plugin) convertProjects(
 		}
 	}
 
-	resolverMetadata := ecosystems.ResolverMetadata{
-		PluginName: PluginName,
-		VersionBuildInfo: map[string]string{
-			metadata.GradleVersion:  parsed.Metadata.GradleVersion,
-			metadata.JavaVersion:    parsed.Metadata.JavaVersion,
-			metadata.BuildTimestamp: parsed.Metadata.GeneratedAt,
-		},
-	}
-
 	// Iterate projects in Gradle evaluation order (preserved by the array format).
 	// The init script outputs projects via root.allprojects.each, which visits
 	// in evaluation order: root first, then subprojects in settings.gradle
@@ -335,6 +326,16 @@ func (p Plugin) convertProjects(
 			absFile = discoveredBuildFile
 		}
 		relFile := relativeTargetFile(dir, absFile)
+
+		resolverMetadata := ecosystems.ResolverMetadata{
+			PluginName: PluginName,
+			VersionBuildInfo: map[string]string{
+				metadata.GradleVersion:  parsed.Metadata.GradleVersion,
+				metadata.JavaVersion:    parsed.Metadata.JavaVersion,
+				metadata.BuildTimestamp: parsed.Metadata.GeneratedAt,
+			},
+			NormalisedTargetFile: relFile,
+		}
 
 		depGraph, err := buildDepGraph(&proj, options)
 		if err != nil {

--- a/pkg/ecosystems/javascript/bun/plugin.go
+++ b/pkg/ecosystems/javascript/bun/plugin.go
@@ -106,6 +106,10 @@ func (p Plugin) buildResults(
 					TargetFile:  &rootTargetFile,
 				},
 			},
+			ResolverMetadata: &ecosystems.ResolverMetadata{
+				PluginName:           PluginName,
+				NormalisedTargetFile: rootTargetFile,
+			},
 			Error: err,
 		}}
 	}

--- a/pkg/ecosystems/legacy/plugin.go
+++ b/pkg/ecosystems/legacy/plugin.go
@@ -241,6 +241,10 @@ func depGraphOutputToSCAResult(ictx workflow.InvocationContext, output *parsers.
 				TargetRuntime: output.TargetRuntime,
 			},
 		},
+		ResolverMetadata: &ecosystems.ResolverMetadata{
+			PluginName:           "legacy",
+			NormalisedTargetFile: output.NormalisedTargetFile,
+		},
 	}
 
 	// If there's an error in the output, parse as ErrorCatalog so os-flows can render it (expected with --print-effective-graph-with-errors).

--- a/pkg/ecosystems/plugin_interface.go
+++ b/pkg/ecosystems/plugin_interface.go
@@ -10,8 +10,9 @@ import (
 )
 
 type ResolverMetadata struct {
-	PluginName       string            `json:"pluginName,omitempty"`
-	VersionBuildInfo map[string]string `json:"versionBuildInfo,omitempty"`
+	PluginName           string            `json:"pluginName,omitempty"`
+	VersionBuildInfo     map[string]string `json:"versionBuildInfo,omitempty"`
+	NormalisedTargetFile string            `json:"normalisedTargetFile,omitempty"`
 }
 
 // SCAResult represents the result of a Software Composition Analysis (SCA),

--- a/pkg/ecosystems/python/pip/depgraph.go
+++ b/pkg/ecosystems/python/pip/depgraph.go
@@ -12,20 +12,6 @@ import (
 	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/logger"
 )
 
-// PkgManagerName represents the package manager name for dependency graphs.
-type PkgManagerName string
-
-// Package manager name constants.
-const (
-	PkgManagerPip    PkgManagerName = "pip"
-	PkgManagerPipenv PkgManagerName = "pipenv"
-)
-
-// String returns the string representation of the package manager name.
-func (p PkgManagerName) String() string {
-	return string(p)
-}
-
 // depStringPattern extracts the package name from a dependency string.
 // Example: "urllib3 (<3,>=1.21.1)" -> "urllib3".
 // Example: "certifi (>=2017.4.17)" -> "certifi".
@@ -64,9 +50,8 @@ func getNodeID(item *InstallItem) string {
 
 // ToDependencyGraph converts a pip install Report into a DepGraph using the dep-graph builder.
 // The root node represents the project and points to all direct dependencies.
-// The pkgManager parameter specifies the package manager name (e.g., PkgManagerPip, PkgManagerPipenv).
 // The projectName parameter sets the root package name (defaults to "root" if empty).
-func (r *Report) ToDependencyGraph(ctx context.Context, log logger.Logger, pkgManager PkgManagerName, projectName string) (*depgraph.DepGraph, error) {
+func (r *Report) ToDependencyGraph(ctx context.Context, log logger.Logger, projectName string) (*depgraph.DepGraph, error) {
 	if r == nil {
 		return nil, fmt.Errorf("report cannot be nil")
 	}
@@ -81,7 +66,7 @@ func (r *Report) ToDependencyGraph(ctx context.Context, log logger.Logger, pkgMa
 
 	// Create a builder with the specified package manager and a root package
 	builder, err := depgraph.NewBuilder(
-		&depgraph.PkgManager{Name: pkgManager.String()},
+		&depgraph.PkgManager{Name: "pip"},
 		&depgraph.PkgInfo{Name: projectName, Version: "0.0.0"},
 	)
 	if err != nil {

--- a/pkg/ecosystems/python/pip/depgraph_test.go
+++ b/pkg/ecosystems/python/pip/depgraph_test.go
@@ -73,7 +73,7 @@ func TestReport_ToDependencyGraph(t *testing.T) {
 			},
 		}
 
-		dg, err := report.ToDependencyGraph(context.Background(), logger.Nop(), PkgManagerPip, "")
+		dg, err := report.ToDependencyGraph(context.Background(), logger.Nop(), "")
 		require.NoError(t, err)
 		require.NotNil(t, dg)
 
@@ -137,7 +137,7 @@ func TestReport_ToDependencyGraph(t *testing.T) {
 			},
 		}
 
-		dg, err := report.ToDependencyGraph(context.Background(), logger.Nop(), PkgManagerPip, "")
+		dg, err := report.ToDependencyGraph(context.Background(), logger.Nop(), "")
 		require.NoError(t, err)
 		require.NotNil(t, dg)
 
@@ -183,7 +183,7 @@ func TestReport_ToDependencyGraph(t *testing.T) {
 			},
 		}
 
-		dg, err := report.ToDependencyGraph(context.Background(), logger.Nop(), PkgManagerPip, "")
+		dg, err := report.ToDependencyGraph(context.Background(), logger.Nop(), "")
 		require.NoError(t, err)
 		require.NotNil(t, dg)
 
@@ -199,7 +199,7 @@ func TestReport_ToDependencyGraph(t *testing.T) {
 			Install: []InstallItem{},
 		}
 
-		dg, err := report.ToDependencyGraph(context.Background(), logger.Nop(), PkgManagerPip, "")
+		dg, err := report.ToDependencyGraph(context.Background(), logger.Nop(), "")
 		require.NoError(t, err)
 		require.NotNil(t, dg)
 
@@ -210,7 +210,7 @@ func TestReport_ToDependencyGraph(t *testing.T) {
 
 	t.Run("nil report", func(t *testing.T) {
 		var report *Report
-		_, err := report.ToDependencyGraph(context.Background(), logger.Nop(), PkgManagerPip, "")
+		_, err := report.ToDependencyGraph(context.Background(), logger.Nop(), "")
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "cannot be nil")
 	})
@@ -268,7 +268,7 @@ func TestReport_ToDependencyGraph(t *testing.T) {
 			},
 		}
 
-		dg, err := report.ToDependencyGraph(context.Background(), logger.Nop(), PkgManagerPip, "")
+		dg, err := report.ToDependencyGraph(context.Background(), logger.Nop(), "")
 		require.NoError(t, err)
 		require.NotNil(t, dg)
 
@@ -330,7 +330,7 @@ func TestReport_ToDependencyGraph(t *testing.T) {
 			},
 		}
 
-		dg, err := report.ToDependencyGraph(context.Background(), logger.Nop(), PkgManagerPip, "")
+		dg, err := report.ToDependencyGraph(context.Background(), logger.Nop(), "")
 		require.NoError(t, err)
 		require.NotNil(t, dg)
 
@@ -388,7 +388,7 @@ func TestToDependencyGraph_PruningBehavior(t *testing.T) {
 			},
 		}
 
-		dg, err := report.ToDependencyGraph(context.Background(), logger.Nop(), PkgManagerPip, "")
+		dg, err := report.ToDependencyGraph(context.Background(), logger.Nop(), "")
 		require.NoError(t, err)
 
 		// Find pkg-a's deps
@@ -452,7 +452,7 @@ func TestToDependencyGraph_PruningBehavior(t *testing.T) {
 			},
 		}
 
-		dg, err := report.ToDependencyGraph(context.Background(), logger.Nop(), PkgManagerPip, "")
+		dg, err := report.ToDependencyGraph(context.Background(), logger.Nop(), "")
 		require.NoError(t, err)
 
 		// Find pkg-a and pkg-b deps
@@ -515,7 +515,7 @@ func TestToDependencyGraph_PruningBehavior(t *testing.T) {
 			},
 		}
 
-		dg, err := report.ToDependencyGraph(context.Background(), logger.Nop(), PkgManagerPip, "")
+		dg, err := report.ToDependencyGraph(context.Background(), logger.Nop(), "")
 		require.NoError(t, err)
 
 		// Find pkg-c's deps - should only have ONE pkg-d, not duplicated

--- a/pkg/ecosystems/python/pip/plugin.go
+++ b/pkg/ecosystems/python/pip/plugin.go
@@ -197,7 +197,7 @@ func (p Plugin) buildDepGraphFromFile(
 	}
 
 	// Convert report to dependency graph
-	depGraph, err := report.ToDependencyGraph(ctx, log, PkgManagerPip, projectName)
+	depGraph, err := report.ToDependencyGraph(ctx, log, projectName)
 	if err != nil {
 		return ecosystems.SCAResult{}, fmt.Errorf("failed to convert pip report to dependency graph for %s: %w", file.RelPath, err)
 	}
@@ -215,7 +215,6 @@ func (p Plugin) buildDepGraphFromFile(
 		ProjectDescriptor: identity.ProjectDescriptor{
 			Identity: identity.ProjectIdentity{
 				ProjectType:       "pip",
-				TargetFile:        &file.RelPath,
 				RootComponentName: rootName,
 			},
 		},
@@ -224,6 +223,7 @@ func (p Plugin) buildDepGraphFromFile(
 			VersionBuildInfo: map[string]string{
 				metadata.PythonVersion: pythonVersion,
 			},
+			NormalisedTargetFile: file.RelPath,
 		},
 	}, nil
 }

--- a/pkg/ecosystems/python/pipenv/plugin.go
+++ b/pkg/ecosystems/python/pipenv/plugin.go
@@ -205,7 +205,7 @@ func (p Plugin) buildDepGraphFromPipfile(
 	}
 
 	// Convert report to dependency graph
-	depGraph, err := report.ToDependencyGraph(ctx, log, pip.PkgManagerPipenv, projectName)
+	depGraph, err := report.ToDependencyGraph(ctx, log, projectName)
 	if err != nil {
 		return ecosystems.SCAResult{}, fmt.Errorf("failed to convert pip report to dependency graph: %w", err)
 	}
@@ -232,6 +232,7 @@ func (p Plugin) buildDepGraphFromPipfile(
 			VersionBuildInfo: map[string]string{
 				metadata.PythonVersion: pythonVersion,
 			},
+			NormalisedTargetFile: file.RelPath,
 		},
 	}, nil
 }

--- a/pkg/ecosystems/python/uv/plugin.go
+++ b/pkg/ecosystems/python/uv/plugin.go
@@ -80,6 +80,10 @@ func (p Plugin) BuildDepGraphsFromDir(
 						TargetFile:  &lockFilePath,
 					},
 				},
+				ResolverMetadata: &scaecosystems.ResolverMetadata{
+					PluginName:           PluginName,
+					NormalisedTargetFile: lockFilePath,
+				},
 				Error: wrappedErr,
 			}
 			combined.Results = append(combined.Results, errorResult)
@@ -126,6 +130,10 @@ func (p Plugin) buildResults(
 						ProjectType: "uv",
 						TargetFile:  &lockFilePath,
 					},
+				},
+				ResolverMetadata: &scaecosystems.ResolverMetadata{
+					PluginName:           PluginName,
+					NormalisedTargetFile: lockFilePath,
 				},
 				Error: noRootErr,
 			}},


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [ ] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Add NormalisedTargetFile to the resolver metadata so its required for the new cli flow.
Added some small fixes for pip/pipenv so that project identity matches the legacy cli
