### PR TITLE
fix: preserve monitor identity for poetry.lock

### DIFF
--- a/pkg/ecosystems/legacy/plugin.go
+++ b/pkg/ecosystems/legacy/plugin.go
@@ -13,6 +13,7 @@ import (
 	gafworkflow "github.com/snyk/go-application-framework/pkg/workflow"
 
 	"github.com/snyk/cli-extension-dep-graph/internal/legacycli"
+	"github.com/snyk/cli-extension-dep-graph/internal/ptrutil"
 	"github.com/snyk/cli-extension-dep-graph/internal/workflow"
 	"github.com/snyk/cli-extension-dep-graph/pkg/depgraph/parsers"
 	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
@@ -100,16 +101,27 @@ func buildLegacyConfig(src configuration.Configuration, opts *ecosystems.SCAPlug
 	return cfg
 }
 
+// mapToTargetFileIdentity mirrors registry's mapping from `targetFileFromPlugin` to target file identifier.
+func mapToTargetFileIdentity(ctx context.Context, log logger.Logger, targetFile *string) *string {
+	if ptrutil.DerefOr(targetFile, "") == "poetry.lock" {
+		log.Info(ctx, "rewriting targetFileFromPlugin: 'poetry.lock' → 'pyproject.toml'")
+		return new("pyproject.toml")
+	}
+	return targetFile
+}
+
 // depGraphOutputToSCAResult converts a parsed legacy CLI output line to an SCAResult.
-// Per-result errors are placed on result.Error; a partial dep graph alongside an error
-// is preserved. The legacy CLI's `normalisedTargetFile` is forwarded onto
-// ResolverMetadata.NormalisedTargetFile (the canonical manifest path); its
-// `targetFileFromPlugin` is forwarded onto Identity.TargetFile (the plugin-reported name).
+// Per-result errors land on result.Error; a partial dep graph alongside an error is
+// preserved.
+//
+// Identity.TargetFile is derived from `targetFileFromPlugin` via mapToDesiredTargetFile
+// so it mirrors the both the legacy CLI's body.targetFile and transformation in registry,
+// to preserve the identity of projects.
 func depGraphOutputToSCAResult(ctx context.Context, log logger.Logger, output *parsers.DepGraphOutput) ecosystems.SCAResult {
 	result := ecosystems.SCAResult{
 		ProjectDescriptor: identity.ProjectDescriptor{
 			Identity: identity.ProjectIdentity{
-				TargetFile:    output.TargetFileFromPlugin,
+				TargetFile:    mapToTargetFileIdentity(ctx, log, output.TargetFileFromPlugin),
 				TargetRuntime: output.TargetRuntime,
 			},
 		},

--- a/pkg/ecosystems/legacy/plugin_test.go
+++ b/pkg/ecosystems/legacy/plugin_test.go
@@ -48,11 +48,15 @@ func TestPlugin_MapsTargetFramework(t *testing.T) {
 	assert.Equal(t, "net6.0", *results.Results[0].ProjectDescriptor.Identity.TargetRuntime)
 }
 
-// TestPlugin_TargetFileForwarding verifies the plugin forwards the legacy CLI's
-// `targetFileFromPlugin` field verbatim onto Identity.TargetFile, and its
-// `normalisedTargetFile` onto ResolverMetadata.NormalisedTargetFile. Downstream
-// emission of MetaKeyTargetFileFromPlugin depends on Identity.TargetFile's nilness
-// exactly matching the CLI's own.
+// TestPlugin_TargetFileForwarding pins how the legacy CLI's `targetFileFromPlugin`
+// flows onto Identity.TargetFile (via mapToDesiredTargetFile) and its
+// `normalisedTargetFile` onto ResolverMetadata.NormalisedTargetFile.
+//
+// Identity.TargetFile MUST mirror body.targetFile so existing monitor projects stay
+// identifiable. When targetFileFromPlugin is omitted, Identity.TargetFile MUST stay
+// nil — do not substitute NormalisedTargetFile, that would create duplicate project
+// records for workspaces, maven, sbt, rubygems and any other plugin emitting no
+// plugin.targetFile.
 func TestPlugin_TargetFileForwarding(t *testing.T) {
 	cases := map[string]struct {
 		body                 string
@@ -62,12 +66,12 @@ func TestPlugin_TargetFileForwarding(t *testing.T) {
 		"CLI emits targetFileFromPlugin → forwarded verbatim": {
 			body:                 `{"depGraph":{"pkgManager":{"name":"nuget"}},"normalisedTargetFile":"project.assets.json","targetFileFromPlugin":"project.assets.json"}`,
 			wantNormalisedTarget: "project.assets.json",
-			wantPluginTargetFile: stringPtr("project.assets.json"),
+			wantPluginTargetFile: new("project.assets.json"),
 		},
 		"CLI emits a distinct targetFileFromPlugin → forwarded verbatim": {
 			body:                 `{"depGraph":{"pkgManager":{"name":"gradle"}},"normalisedTargetFile":"build.gradle.kts","targetFileFromPlugin":"something-else.kts"}`,
 			wantNormalisedTarget: "build.gradle.kts",
-			wantPluginTargetFile: stringPtr("something-else.kts"),
+			wantPluginTargetFile: new("something-else.kts"),
 		},
 		"CLI omits targetFileFromPlugin → forwarded as nil": {
 			body:                 `{"depGraph":{"pkgManager":{"name":"npm"}},"normalisedTargetFile":"package-lock.json"}`,
@@ -78,6 +82,20 @@ func TestPlugin_TargetFileForwarding(t *testing.T) {
 			body:                 `{"depGraph":{"pkgManager":{"name":"npm"}},"normalisedTargetFile":"package-lock.json","workspace":{"type":"npm"}}`,
 			wantNormalisedTarget: "package-lock.json",
 			wantPluginTargetFile: nil,
+		},
+		// Explicit guard against the "default to NormalisedTargetFile when nil" refactor.
+		// NormalisedTargetFile is populated with a meaningful path and targetFileFromPlugin
+		// is omitted — Identity.TargetFile must still be nil, not the normalised path.
+		"NormalisedTargetFile must not substitute for nil targetFileFromPlugin": {
+			body:                 `{"depGraph":{"pkgManager":{"name":"maven"}},"normalisedTargetFile":"subdir/pom.xml"}`,
+			wantNormalisedTarget: "subdir/pom.xml",
+			wantPluginTargetFile: nil,
+		},
+		// Mirror registry's exact-string poetry.lock → pyproject.toml compatibility shim.
+		"targetFileFromPlugin == 'poetry.lock' → rewritten to 'pyproject.toml'": {
+			body:                 `{"depGraph":{"pkgManager":{"name":"poetry"}},"normalisedTargetFile":"pyproject.toml","targetFileFromPlugin":"poetry.lock"}`,
+			wantNormalisedTarget: "pyproject.toml",
+			wantPluginTargetFile: new("pyproject.toml"),
 		},
 	}
 
@@ -104,8 +122,6 @@ func TestPlugin_TargetFileForwarding(t *testing.T) {
 		})
 	}
 }
-
-func stringPtr(s string) *string { return &s }
 
 func TestPlugin_MapsRootComponentName(t *testing.T) {
 	ictx, _ := setupLegacyCLI(t, `{"depGraph":{"pkgManager":{"name":"nuget"},"pkgs":[{"id":"my-project@","info":{"name":"my-project"}}],"graph":{"rootNodeId":"root","nodes":[{"nodeId":"root","pkgId":"my-project@"}]}},"normalisedTargetFile":"project.assets.json","targetFileFromPlugin":"project.assets.json","target":{}}`, nil)


### PR DESCRIPTION
This PR adds a small fix to `Identity.TargetFile` to ensure it matches the logic in Registry. Currently, `depGraphOutputToSCAResult` forwards the legacy CLI's `targetFileFromPlugin` field into `Identity.TargetFile`, and that value flows downstream into the monitor project identity. If it ever diverges from what the legacy CLI itself sends, existing monitor projects are not found and duplicates get created.

Registry applies one compatibility transform on input: exact-string `"poetry.lock"` → `"pyproject.toml"`. `snyk-python-plugin` already [produces](https://github.com/snyk/snyk-python-plugin/blob/718e100/lib/dependencies/inspect-implementation.ts#L55-L74) `"pyproject.toml"`, so the transform is unused today, but if that invariant ever breaks (e.g. changes to the Poetry resolver) we would no longer be matching the behaviour in Registry.