### PR TITLE
refactor: prevent SCAPluginOptions With* from mutating caller slices

### DIFF
--- a/pkg/ecosystems/options.go
+++ b/pkg/ecosystems/options.go
@@ -73,6 +73,26 @@ func NewPluginOptions() *SCAPluginOptions {
 	}
 }
 
+// Clone returns a deep copy of o. Slice fields are copied so mutations through
+// the returned options (e.g. appending to ExcludePaths) cannot leak into the
+// original. *string fields share storage because strings are immutable.
+func (o *SCAPluginOptions) Clone() *SCAPluginOptions {
+	if o == nil {
+		return nil
+	}
+	clone := *o
+	if o.Global.Exclude != nil {
+		clone.Global.Exclude = append(CommaSeparatedString(nil), o.Global.Exclude...)
+	}
+	if o.Global.ExcludePaths != nil {
+		clone.Global.ExcludePaths = append(CommaSeparatedString(nil), o.Global.ExcludePaths...)
+	}
+	if o.Global.RawFlags != nil {
+		clone.Global.RawFlags = append([]string(nil), o.Global.RawFlags...)
+	}
+	return &clone
+}
+
 func NewPluginOptionsFromRawFlags(rawFlags []string) (*SCAPluginOptions, error) {
 	var args struct {
 		GlobalOptions
@@ -121,17 +141,32 @@ func (o *SCAPluginOptions) WithIncludeDev(includeDev bool) *SCAPluginOptions {
 }
 
 func (o *SCAPluginOptions) WithRawFlags(rawflags string) *SCAPluginOptions {
-	o.Global.RawFlags = append(o.Global.RawFlags, rawflags)
+	merged := make([]string, len(o.Global.RawFlags)+1)
+	copy(merged, o.Global.RawFlags)
+	merged[len(o.Global.RawFlags)] = rawflags
+	o.Global.RawFlags = merged
 	return o
 }
 
 func (o *SCAPluginOptions) WithExclude(exclude []string) *SCAPluginOptions {
-	o.Global.Exclude = append(o.Global.Exclude, exclude...)
+	if len(exclude) == 0 {
+		return o
+	}
+	merged := make(CommaSeparatedString, len(o.Global.Exclude)+len(exclude))
+	copy(merged, o.Global.Exclude)
+	copy(merged[len(o.Global.Exclude):], exclude)
+	o.Global.Exclude = merged
 	return o
 }
 
 func (o *SCAPluginOptions) WithExcludePaths(excludePaths []string) *SCAPluginOptions {
-	o.Global.ExcludePaths = append(o.Global.ExcludePaths, excludePaths...)
+	if len(excludePaths) == 0 {
+		return o
+	}
+	merged := make(CommaSeparatedString, len(o.Global.ExcludePaths)+len(excludePaths))
+	copy(merged, o.Global.ExcludePaths)
+	copy(merged[len(o.Global.ExcludePaths):], excludePaths)
+	o.Global.ExcludePaths = merged
 	return o
 }
 

--- a/pkg/ecosystems/options_test.go
+++ b/pkg/ecosystems/options_test.go
@@ -371,3 +371,52 @@ func TestWithIncludeProvenance(t *testing.T) {
 	options = NewPluginOptions().WithIncludeProvenance(false)
 	assert.False(t, options.Global.IncludeProvenance)
 }
+
+func TestSCAPluginOptions_Clone_NilReceiverReturnsNil(t *testing.T) {
+	var o *SCAPluginOptions
+	assert.Nil(t, o.Clone())
+}
+
+func TestSCAPluginOptions_Clone_IsolatesSliceMutations(t *testing.T) {
+	target := "requirements.txt"
+	original := &SCAPluginOptions{
+		Global: GlobalOptions{
+			TargetFile:   &target,
+			Exclude:      CommaSeparatedString{"a"},
+			ExcludePaths: CommaSeparatedString{"x"},
+			RawFlags:     []string{"--foo"},
+		},
+	}
+
+	clone := original.Clone()
+	clone.WithExclude([]string{"b"})
+	clone.WithExcludePaths([]string{"y"})
+	clone.WithRawFlags("--bar")
+
+	assert.Equal(t, CommaSeparatedString{"a"}, original.Global.Exclude)
+	assert.Equal(t, CommaSeparatedString{"x"}, original.Global.ExcludePaths)
+	assert.Equal(t, []string{"--foo"}, original.Global.RawFlags)
+
+	assert.Equal(t, CommaSeparatedString{"a", "b"}, clone.Global.Exclude)
+	assert.Equal(t, CommaSeparatedString{"x", "y"}, clone.Global.ExcludePaths)
+	assert.Equal(t, []string{"--foo", "--bar"}, clone.Global.RawFlags)
+}
+
+func TestSCAPluginOptions_WithFunctionsDoNotMutateHeldSlices(t *testing.T) {
+	o := NewPluginOptions()
+	o.Global.ExcludePaths = CommaSeparatedString{"x"}
+	o.Global.Exclude = CommaSeparatedString{"a"}
+	o.Global.RawFlags = []string{"--foo"}
+
+	heldExcludePaths := o.Global.ExcludePaths
+	heldExclude := o.Global.Exclude
+	heldRawFlags := o.Global.RawFlags
+
+	o.WithExcludePaths([]string{"y"})
+	o.WithExclude([]string{"b"})
+	o.WithRawFlags("--bar")
+
+	assert.Equal(t, CommaSeparatedString{"x"}, heldExcludePaths)
+	assert.Equal(t, CommaSeparatedString{"a"}, heldExclude)
+	assert.Equal(t, []string{"--foo"}, heldRawFlags)
+}

--- a/pkg/ecosystems/orchestrator/registry.go
+++ b/pkg/ecosystems/orchestrator/registry.go
@@ -48,12 +48,8 @@ func NewDefaultPluginRegistry(ictx workflow.InvocationContext) (*PluginRegistry,
 func (r *PluginRegistry) ResolveDepgraphs(dir string, opts *ecosystems.SCAPluginOptions) <-chan ecosystems.SCAResult {
 	resultsChan := make(chan ecosystems.SCAResult)
 
-	// Clone opts so WithExcludePaths mutations during the loop don't reach into the
-	// caller's opts. Other Global fields are shallow-copied; only ExcludePaths is mutated
-	// here, so its backing slice is the only one we need to clone.
-	localOpts := *opts
-	localOpts.Global.ExcludePaths = append(ecosystems.CommaSeparatedString(nil), opts.Global.ExcludePaths...)
-	opts = &localOpts
+	// Clone so per-iteration WithExcludePaths mutations don't leak back to the caller.
+	opts = opts.Clone()
 
 	go func() {
 		defer close(resultsChan)

--- a/pkg/ecosystems/orchestrator/registry_test.go
+++ b/pkg/ecosystems/orchestrator/registry_test.go
@@ -337,6 +337,37 @@ func TestPluginRegistry_ResolveDepgraphs_PropagatesProcessedFilesAsExcludePaths(
 		"processed files must NOT leak onto opts.Global.Exclude — that channel is for basename patterns only")
 }
 
+func TestPluginRegistry_ResolveDepgraphs_DoesNotMutateCallerOpts(t *testing.T) {
+	r := &PluginRegistry{
+		ictx:    setupMockInvocationContext(t),
+		entries: make([]pluginEntry, 0),
+		plugins: make([]ecosystems.SCAPlugin, 0),
+	}
+
+	require.NoError(t, r.register(&mockPlugin{
+		name:           "plugin-a",
+		processedFiles: []string{"a/lock.json"},
+		results:        []ecosystems.SCAResult{{ProjectDescriptor: identity.ProjectDescriptor{Identity: identity.ProjectIdentity{ProjectType: "type-a"}}}},
+	}))
+	require.NoError(t, r.register(&mockPlugin{
+		name:           "plugin-b",
+		processedFiles: []string{"b/lock.json"},
+		results:        []ecosystems.SCAResult{{ProjectDescriptor: identity.ProjectDescriptor{Identity: identity.ProjectIdentity{ProjectType: "type-b"}}}},
+	}))
+
+	opts := ecosystems.NewPluginOptions()
+	opts.Global.AllProjects = true
+	opts.Global.ExcludePaths = ecosystems.CommaSeparatedString{"user-supplied"}
+	heldExcludePaths := opts.Global.ExcludePaths
+
+	collectResults(r.ResolveDepgraphs("/test/dir", opts))
+
+	assert.Equal(t, ecosystems.CommaSeparatedString{"user-supplied"}, opts.Global.ExcludePaths,
+		"caller's opts.Global.ExcludePaths must be unchanged after ResolveDepgraphs")
+	assert.Equal(t, ecosystems.CommaSeparatedString{"user-supplied"}, heldExcludePaths,
+		"caller's slice held before the call must not have its backing array mutated")
+}
+
 func TestPluginRegistry_Register_WithFeatureFlag(t *testing.T) {
 	r := &PluginRegistry{
 		ictx:    setupMockInvocationContext(t),


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

With* methods like WithExcludePaths were appending into (mutating) the receiver's slice. If you held a reference to opts.Global.ExcludePaths before calling WithExcludePaths, it would unexpectedly grow.

Now With* allocates a fresh slice, so prior references stay unchanged. Add Clone() to deep-copy the entire options struct. Add tests to lock in this behavior.
