### PR TITLE
feat: surface unresolved dependencies [CMPA-553]

### DIFF
--- a/pkg/ecosystems/gradle/depgraph.go
+++ b/pkg/ecosystems/gradle/depgraph.go
@@ -112,8 +112,20 @@ type depGraphContext struct {
 //     with a `:constraint` node-ID suffix. They do not affect `processed`, so a
 //     real edge to the same component will still be expanded normally.
 func (ctx *depGraphContext) addDep(dep *gradleDep, parentID string, processed map[string]bool) error {
-	if dep.ID == "" || dep.Unresolved {
+	if dep.ID == "" {
 		return nil
+	}
+
+	if dep.Unresolved {
+		// ":unresolved" suffix avoids colliding with a resolved node for the same coordinate in another configuration.
+		nodeID, name, version := depNodeParts(dep.ID)
+		unresolvedID := nodeID + ":unresolved"
+		ctx.builder.AddNode(unresolvedID, createPkgInfo(name, version, nil, ctx.provenanceMap != nil),
+			depgraph.WithNodeInfo(&depgraph.NodeInfo{
+				Labels: map[string]string{"unresolved": "true"},
+			}),
+		)
+		return ctx.connectOnce(parentID, unresolvedID)
 	}
 
 	nodeID, name, version := depNodeParts(dep.ID)

--- a/pkg/ecosystems/gradle/depgraph_test.go
+++ b/pkg/ecosystems/gradle/depgraph_test.go
@@ -154,10 +154,10 @@ func TestBuildDepGraph(t *testing.T) {
 		assert.Equal(t, 1, sharedEdgesFromB, "b should reference the same shared node")
 	})
 
-	t.Run("skips unresolved dependencies", func(t *testing.T) {
+	t.Run("emits unresolved dependencies as labeled leaf nodes", func(t *testing.T) {
 		proj := makeProject("com.example", "app", "1.0.0", []gradleConfig{
 			makeConfig("runtimeClasspath", "com.example:app:1.0.0", []gradleDep{
-				{ID: "com.example:missing:1.0.0", Unresolved: true, Reason: "not found"},
+				{ID: "com.example:missing:1.0.0", Unresolved: true, Reason: "Could not resolve com.example:missing:1.0.0"},
 				makeDep("com.google.guava:guava:32.1.2-jre"),
 			}),
 		})
@@ -166,8 +166,51 @@ func TestBuildDepGraph(t *testing.T) {
 		require.NoError(t, err)
 
 		ids := nodeIDSet(dg)
-		assert.False(t, ids["com.example:missing@1.0.0"], "unresolved dep should be skipped")
-		assert.True(t, ids["com.google.guava:guava@32.1.2-jre"], "resolved dep should be present")
+		assert.True(t, ids["com.example:missing@1.0.0:unresolved"], "unresolved dep should appear as :unresolved leaf")
+		assert.False(t, ids["com.example:missing@1.0.0"], "unresolved dep should not appear as a normal node")
+		assert.True(t, ids["com.google.guava:guava@32.1.2-jre"], "resolved dep should still be present")
+
+		unresolvedNode := findNodeByID(t, dg, "com.example:missing@1.0.0:unresolved")
+		require.NotNil(t, unresolvedNode.Info)
+		assert.Equal(t, "true", unresolvedNode.Info.Labels["unresolved"])
+		_, hasReason := unresolvedNode.Info.Labels["reason"]
+		assert.False(t, hasReason, "Gradle failure messages must not be copied onto dep-graph labels")
+	})
+
+	t.Run("unresolved dep node ID does not collide with a successfully-resolved node", func(t *testing.T) {
+		// Under different configurations the same coordinate could resolve in one
+		// and fail in another. Both nodes must coexist in the merged graph.
+		proj := makeProject("com.example", "app", "1.0.0", []gradleConfig{
+			makeConfig("compileClasspath", "com.example:app:1.0.0", []gradleDep{
+				makeDep("com.example:lib:1.0.0"),
+			}),
+			makeConfig("runtimeClasspath", "com.example:app:1.0.0", []gradleDep{
+				{ID: "com.example:lib:1.0.0", Unresolved: true, Reason: "content filter"},
+			}),
+		})
+
+		dg, err := buildDepGraph(&proj, nil)
+		require.NoError(t, err)
+
+		ids := nodeIDSet(dg)
+		assert.True(t, ids["com.example:lib@1.0.0"], "resolved node should be present")
+		assert.True(t, ids["com.example:lib@1.0.0:unresolved"], "unresolved node should also be present under different ID")
+	})
+
+	t.Run("skips unresolved dep with empty ID", func(t *testing.T) {
+		proj := makeProject("com.example", "app", "1.0.0", []gradleConfig{
+			makeConfig("runtimeClasspath", "com.example:app:1.0.0", []gradleDep{
+				{ID: "", Unresolved: true, Reason: "selector has no coordinate"},
+				makeDep("com.google.guava:guava:32.1.2-jre"),
+			}),
+		})
+
+		dg, err := buildDepGraph(&proj, nil)
+		require.NoError(t, err)
+
+		ids := nodeIDSet(dg)
+		assert.True(t, ids["com.google.guava:guava@32.1.2-jre"])
+		assert.Equal(t, 2, len(ids), "no node should be created for an empty-ID unresolved dep")
 	})
 
 	t.Run("renders constraint dependencies as labelled :constraint leaves", func(t *testing.T) {

--- a/pkg/ecosystems/gradle/init/snyk-deps-init.gradle
+++ b/pkg/ecosystems/gradle/init/snyk-deps-init.gradle
@@ -158,10 +158,25 @@ def resolveConfiguration(config, includeProvenance = false) {
     def resolutionResult = config.incoming.resolutionResult
     def rootComponent = resolutionResult.root
 
+    // Per-config set of resolved group:module names; used to avoid surfacing false unresolved deps that strict locking emits alongside real resolved deps.
+    def resolvedNames = new HashSet<String>()
+    try {
+        resolutionResult.allComponents.each { component ->
+            def mv = component.moduleVersion
+            if (mv != null && mv.group && mv.name) {
+                // .toString() is load-bearing — GStrings and Strings hash differently.
+                resolvedNames.add("${mv.group}:${mv.name}".toString())
+            }
+        }
+    } catch (Exception ignored) {
+        // allComponents may be unavailable in very old Gradle versions; proceed
+        // without noise filtering rather than failing the whole configuration.
+    }
+
     def rootId = componentId(rootComponent)
     def processed = new HashSet<String>()
     def ancestry = new HashSet<String>()
-    def tree = walkDependencies(rootComponent, processed, ancestry)
+    def tree = walkDependencies(rootComponent, processed, ancestry, resolvedNames)
 
     // Build artifact lookup map once per configuration for O(1) lookups
     def artifactLookup = null
@@ -183,7 +198,7 @@ def resolveConfiguration(config, includeProvenance = false) {
 
 // ── Recursive tree walk ─────────────────────────────────────────────
 
-def walkDependencies(component, Set<String> processed, Set<String> ancestry) {
+def walkDependencies(component, Set<String> processed, Set<String> ancestry, Set<String> resolvedNames = new HashSet<>()) {
     def children = []
 
     component.dependencies.each { dep ->
@@ -224,14 +239,25 @@ def walkDependencies(component, Set<String> processed, Set<String> ancestry) {
                 ancestry.add(id)
                 children << [
                     id          : id,
-                    dependencies: walkDependencies(selected, processed, ancestry),
+                    dependencies: walkDependencies(selected, processed, ancestry, resolvedNames),
                 ]
                 ancestry.remove(id)
             }
         } else if (dep.hasProperty('attempted')) {
-            // UnresolvedDependencyResult
+            // UnresolvedDependencyResult: use attempted when available, fall back to requested.
+            def selector = dep.hasProperty('attempted') && dep.attempted != null
+                ? dep.attempted
+                : (dep.hasProperty('requested') ? dep.requested : null)
+            // Skip project deps and other non-Maven selectors that have no GAV coordinate.
+            if (selector == null || !selector.hasProperty('group') || !selector.hasProperty('module')) return
+            // Skip lock-rejected requests — the module resolved fine at the locked version.
+            def selectorName = "${selector.group}:${selector.module}".toString()
+            if (resolvedNames.contains(selectorName)) return
+            def vc = selector.hasProperty('versionConstraint') ? selector.versionConstraint : null
+            def simpleVersion = selector.hasProperty('version') ? (selector.version ?: 'unspecified') : 'unspecified'
+            def selectorVersion = vc?.requiredVersion ?: vc?.preferredVersion ?: simpleVersion
             children << [
-                id        : dep.attempted.toString(),
+                id        : "${selector.group}:${selector.module}:${selectorVersion}".toString(),
                 unresolved: true,
                 reason    : dep.failure?.message ?: 'unknown',
             ]

--- a/pkg/ecosystems/gradle/plugin_integration_test.go
+++ b/pkg/ecosystems/gradle/plugin_integration_test.go
@@ -132,6 +132,20 @@ func pluginTestCases() map[string]PluginTestCase {
 			Fixture: "same-name-subprojects",
 			Options: ecosystems.NewPluginOptions(),
 		},
+		// Verifies that a dependency Gradle cannot resolve (non-existent version)
+		// surfaces as a labeled :unresolved leaf node rather than being silently dropped.
+		// The fixture also declares a resolvable dep to confirm the two coexist correctly.
+		"unresolved_dep": {
+			Fixture: "unresolved-dep",
+			Options: ecosystems.NewPluginOptions(),
+		},
+		// Verifies that a user-defined configuration with canBeConsumed=true and its own
+		// declared dependency is still walked. Guards against the publication-config filter
+		// (which skips default/archives) accidentally excluding user-defined configs.
+		"user_defined_config": {
+			Fixture: "custom-config",
+			Options: ecosystems.NewPluginOptions(),
+		},
 		// Exercises dynamic version selectors (range `[a, b)`, open `+`) and
 		// resolutionStrategy.force. Resolved versions are wildcarded in the
 		// snapshot to stay resilient to Maven Central transitive bumps.

--- a/pkg/ecosystems/testdata/fixtures/gradle/same-name-subprojects/expected_plugin.json
+++ b/pkg/ecosystems/testdata/fixtures/gradle/same-name-subprojects/expected_plugin.json
@@ -60,6 +60,55 @@
             "name": "com.snyk.fixtures:subproj",
             "version": "1.0.0"
           }
+        },
+        {
+          "id": "com.google.guava:guava@30.1.1-jre",
+          "info": {
+            "name": "com.google.guava:guava",
+            "version": "30.1.1-jre"
+          }
+        },
+        {
+          "id": "com.google.guava:failureaccess@1.0.1",
+          "info": {
+            "name": "com.google.guava:failureaccess",
+            "version": "1.0.1"
+          }
+        },
+        {
+          "id": "com.google.guava:listenablefuture@9999.0-empty-to-avoid-conflict-with-guava",
+          "info": {
+            "name": "com.google.guava:listenablefuture",
+            "version": "9999.0-empty-to-avoid-conflict-with-guava"
+          }
+        },
+        {
+          "id": "com.google.code.findbugs:jsr305@3.0.2",
+          "info": {
+            "name": "com.google.code.findbugs:jsr305",
+            "version": "3.0.2"
+          }
+        },
+        {
+          "id": "org.checkerframework:checker-qual@3.8.0",
+          "info": {
+            "name": "org.checkerframework:checker-qual",
+            "version": "3.8.0"
+          }
+        },
+        {
+          "id": "com.google.errorprone:error_prone_annotations@2.5.1",
+          "info": {
+            "name": "com.google.errorprone:error_prone_annotations",
+            "version": "2.5.1"
+          }
+        },
+        {
+          "id": "com.google.j2objc:j2objc-annotations@1.3",
+          "info": {
+            "name": "com.google.j2objc:j2objc-annotations",
+            "version": "1.3"
+          }
         }
       ],
       "graph": {
@@ -85,6 +134,64 @@
           {
             "nodeId": "com.snyk.fixtures:subproj@1.0.0",
             "pkgId": "com.snyk.fixtures:subproj@1.0.0",
+            "deps": [
+              {
+                "nodeId": "com.google.guava:guava@30.1.1-jre"
+              }
+            ]
+          },
+          {
+            "nodeId": "com.google.guava:guava@30.1.1-jre",
+            "pkgId": "com.google.guava:guava@30.1.1-jre",
+            "deps": [
+              {
+                "nodeId": "com.google.guava:failureaccess@1.0.1"
+              },
+              {
+                "nodeId": "com.google.guava:listenablefuture@9999.0-empty-to-avoid-conflict-with-guava"
+              },
+              {
+                "nodeId": "com.google.code.findbugs:jsr305@3.0.2"
+              },
+              {
+                "nodeId": "org.checkerframework:checker-qual@3.8.0"
+              },
+              {
+                "nodeId": "com.google.errorprone:error_prone_annotations@2.5.1"
+              },
+              {
+                "nodeId": "com.google.j2objc:j2objc-annotations@1.3"
+              }
+            ]
+          },
+          {
+            "nodeId": "com.google.guava:failureaccess@1.0.1",
+            "pkgId": "com.google.guava:failureaccess@1.0.1",
+            "deps": []
+          },
+          {
+            "nodeId": "com.google.guava:listenablefuture@9999.0-empty-to-avoid-conflict-with-guava",
+            "pkgId": "com.google.guava:listenablefuture@9999.0-empty-to-avoid-conflict-with-guava",
+            "deps": []
+          },
+          {
+            "nodeId": "com.google.code.findbugs:jsr305@3.0.2",
+            "pkgId": "com.google.code.findbugs:jsr305@3.0.2",
+            "deps": []
+          },
+          {
+            "nodeId": "org.checkerframework:checker-qual@3.8.0",
+            "pkgId": "org.checkerframework:checker-qual@3.8.0",
+            "deps": []
+          },
+          {
+            "nodeId": "com.google.errorprone:error_prone_annotations@2.5.1",
+            "pkgId": "com.google.errorprone:error_prone_annotations@2.5.1",
+            "deps": []
+          },
+          {
+            "nodeId": "com.google.j2objc:j2objc-annotations@1.3",
+            "pkgId": "com.google.j2objc:j2objc-annotations@1.3",
             "deps": []
           }
         ]
@@ -111,6 +218,55 @@
             "name": "com.snyk.fixtures:subproj",
             "version": "1.0.0"
           }
+        },
+        {
+          "id": "com.google.guava:guava@30.1.1-jre",
+          "info": {
+            "name": "com.google.guava:guava",
+            "version": "30.1.1-jre"
+          }
+        },
+        {
+          "id": "com.google.guava:failureaccess@1.0.1",
+          "info": {
+            "name": "com.google.guava:failureaccess",
+            "version": "1.0.1"
+          }
+        },
+        {
+          "id": "com.google.guava:listenablefuture@9999.0-empty-to-avoid-conflict-with-guava",
+          "info": {
+            "name": "com.google.guava:listenablefuture",
+            "version": "9999.0-empty-to-avoid-conflict-with-guava"
+          }
+        },
+        {
+          "id": "com.google.code.findbugs:jsr305@3.0.2",
+          "info": {
+            "name": "com.google.code.findbugs:jsr305",
+            "version": "3.0.2"
+          }
+        },
+        {
+          "id": "org.checkerframework:checker-qual@3.8.0",
+          "info": {
+            "name": "org.checkerframework:checker-qual",
+            "version": "3.8.0"
+          }
+        },
+        {
+          "id": "com.google.errorprone:error_prone_annotations@2.5.1",
+          "info": {
+            "name": "com.google.errorprone:error_prone_annotations",
+            "version": "2.5.1"
+          }
+        },
+        {
+          "id": "com.google.j2objc:j2objc-annotations@1.3",
+          "info": {
+            "name": "com.google.j2objc:j2objc-annotations",
+            "version": "1.3"
+          }
         }
       ],
       "graph": {
@@ -119,6 +275,64 @@
           {
             "nodeId": "root-node",
             "pkgId": "com.snyk.fixtures:subproj@1.0.0",
+            "deps": [
+              {
+                "nodeId": "com.google.guava:guava@30.1.1-jre"
+              }
+            ]
+          },
+          {
+            "nodeId": "com.google.guava:guava@30.1.1-jre",
+            "pkgId": "com.google.guava:guava@30.1.1-jre",
+            "deps": [
+              {
+                "nodeId": "com.google.guava:failureaccess@1.0.1"
+              },
+              {
+                "nodeId": "com.google.guava:listenablefuture@9999.0-empty-to-avoid-conflict-with-guava"
+              },
+              {
+                "nodeId": "com.google.code.findbugs:jsr305@3.0.2"
+              },
+              {
+                "nodeId": "org.checkerframework:checker-qual@3.8.0"
+              },
+              {
+                "nodeId": "com.google.errorprone:error_prone_annotations@2.5.1"
+              },
+              {
+                "nodeId": "com.google.j2objc:j2objc-annotations@1.3"
+              }
+            ]
+          },
+          {
+            "nodeId": "com.google.guava:failureaccess@1.0.1",
+            "pkgId": "com.google.guava:failureaccess@1.0.1",
+            "deps": []
+          },
+          {
+            "nodeId": "com.google.guava:listenablefuture@9999.0-empty-to-avoid-conflict-with-guava",
+            "pkgId": "com.google.guava:listenablefuture@9999.0-empty-to-avoid-conflict-with-guava",
+            "deps": []
+          },
+          {
+            "nodeId": "com.google.code.findbugs:jsr305@3.0.2",
+            "pkgId": "com.google.code.findbugs:jsr305@3.0.2",
+            "deps": []
+          },
+          {
+            "nodeId": "org.checkerframework:checker-qual@3.8.0",
+            "pkgId": "org.checkerframework:checker-qual@3.8.0",
+            "deps": []
+          },
+          {
+            "nodeId": "com.google.errorprone:error_prone_annotations@2.5.1",
+            "pkgId": "com.google.errorprone:error_prone_annotations@2.5.1",
+            "deps": []
+          },
+          {
+            "nodeId": "com.google.j2objc:j2objc-annotations@1.3",
+            "pkgId": "com.google.j2objc:j2objc-annotations@1.3",
             "deps": []
           }
         ]

--- a/pkg/ecosystems/testdata/fixtures/gradle/same-name-subprojects/subproj/build.gradle
+++ b/pkg/ecosystems/testdata/fixtures/gradle/same-name-subprojects/subproj/build.gradle
@@ -3,5 +3,5 @@ plugins {
 }
 
 dependencies {
-    implementation 'com.google.guava:32.0.1-jre'
+    implementation 'com.google.guava:guava:30.1.1-jre'
 }

--- a/pkg/ecosystems/testdata/fixtures/gradle/unresolved-dep/build.gradle
+++ b/pkg/ecosystems/testdata/fixtures/gradle/unresolved-dep/build.gradle
@@ -1,0 +1,17 @@
+plugins {
+    id 'java'
+}
+
+group = 'com.snyk.fixtures'
+version = '1.0.0'
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    // A real dep that resolves successfully.
+    implementation 'org.apache.commons:commons-lang3:3.14.0'
+    // A dep with a non-existent version — intentionally unresolvable.
+    implementation 'org.slf4j:slf4j-api:999.999.999'
+}

--- a/pkg/ecosystems/testdata/fixtures/gradle/unresolved-dep/expected_plugin.json
+++ b/pkg/ecosystems/testdata/fixtures/gradle/unresolved-dep/expected_plugin.json
@@ -1,0 +1,72 @@
+[
+  {
+    "depGraph": {
+      "schemaVersion": "1.3.0",
+      "pkgManager": {
+        "name": "gradle"
+      },
+      "pkgs": [
+        {
+          "id": "com.snyk.fixtures:unresolved-dep@1.0.0",
+          "info": {
+            "name": "com.snyk.fixtures:unresolved-dep",
+            "version": "1.0.0"
+          }
+        },
+        {
+          "id": "org.apache.commons:commons-lang3@3.14.0",
+          "info": {
+            "name": "org.apache.commons:commons-lang3",
+            "version": "3.14.0"
+          }
+        },
+        {
+          "id": "org.slf4j:slf4j-api@999.999.999",
+          "info": {
+            "name": "org.slf4j:slf4j-api",
+            "version": "999.999.999"
+          }
+        }
+      ],
+      "graph": {
+        "rootNodeId": "root-node",
+        "nodes": [
+          {
+            "nodeId": "root-node",
+            "pkgId": "com.snyk.fixtures:unresolved-dep@1.0.0",
+            "deps": [
+              {
+                "nodeId": "org.apache.commons:commons-lang3@3.14.0"
+              },
+              {
+                "nodeId": "org.slf4j:slf4j-api@999.999.999:unresolved"
+              }
+            ]
+          },
+          {
+            "nodeId": "org.apache.commons:commons-lang3@3.14.0",
+            "pkgId": "org.apache.commons:commons-lang3@3.14.0",
+            "deps": []
+          },
+          {
+            "nodeId": "org.slf4j:slf4j-api@999.999.999:unresolved",
+            "pkgId": "org.slf4j:slf4j-api@999.999.999",
+            "info": {
+              "labels": {
+                "unresolved": "true"
+              }
+            },
+            "deps": []
+          }
+        ]
+      }
+    },
+    "projectDescriptor": {
+      "identity": {
+        "type": "gradle",
+        "targetFile": "build.gradle",
+        "rootComponentName": "com.snyk.fixtures:unresolved-dep"
+      }
+    }
+  }
+]

--- a/pkg/ecosystems/testdata/fixtures/gradle/unresolved-dep/settings.gradle
+++ b/pkg/ecosystems/testdata/fixtures/gradle/unresolved-dep/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'unresolved-dep'


### PR DESCRIPTION
- [X] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [X] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

As part of ongoing support work the snyk-gradle-plugin is in the process of being rewritten using modern gradle apis to solve a few support bugs: [feat: Update init.gradle to use non-deprecated Gradle APIs by cjheppell · Pull Request #337 · snyk/snyk-gradle-plugin](https://github.com/snyk/snyk-gradle-plugin/pull/337/changes#diff-c0f728edeefc1feb5762c48b6097c42a81a6ee217d135ed1727ead0c0f04e425)

This PR addresses the issue of surfacing unresolved dependencies. Previously, dependencies that Gradle couldn't resolve were silently dropped from the dep graph. They now appear as labeled leaf nodes so consumers can see what failed. 

[Jira](https://snyksec.atlassian.net/jira/software/c/projects/CMPA/boards/5466?assignee=60162bfac8c36c00698fa2d4&selectedIssue=CMPA-553)