### PR TITLE
feat: finding actually resolvable configurations [CMPA-567]

### DIFF
--- a/pkg/ecosystems/gradle/init/snyk-deps-init.gradle
+++ b/pkg/ecosystems/gradle/init/snyk-deps-init.gradle
@@ -113,12 +113,15 @@ def buildProjectEntry(project, confAttrSpec, includeProvenance = false) {
         if (!config.canBeResolved) {
             return false
         }
-        
+        // Skip auto-created publication configs (default, archives) which have no
+        // directly-declared deps. User-defined configs with declared deps are kept.
+        if (config.canBeConsumed && config.dependencies.isEmpty()) {
+            return false
+        }
         // Apply attribute filter if specified
         if (confAttrSpec != null && !matchesAttributeFilter(config, confAttrSpec)) {
             return false
         }
-        
         return true
     }
 

--- a/pkg/ecosystems/gradle/plugin_integration_test.go
+++ b/pkg/ecosystems/gradle/plugin_integration_test.go
@@ -132,6 +132,13 @@ func pluginTestCases() map[string]PluginTestCase {
 			Fixture: "same-name-subprojects",
 			Options: ecosystems.NewPluginOptions(),
 		},
+		// Verifies that a user-defined configuration with canBeConsumed=true and its own
+		// declared dependency is still walked. Guards against the publication-config filter
+		// (which skips default/archives) accidentally excluding user-defined configs.
+		"user_defined_config": {
+			Fixture: "custom-config",
+			Options: ecosystems.NewPluginOptions(),
+		},
 		// Exercises dynamic version selectors (range `[a, b)`, open `+`) and
 		// resolutionStrategy.force. Resolved versions are wildcarded in the
 		// snapshot to stay resilient to Maven Central transitive bumps.

--- a/pkg/ecosystems/testdata/fixtures/gradle/custom-config/build.gradle
+++ b/pkg/ecosystems/testdata/fixtures/gradle/custom-config/build.gradle
@@ -1,0 +1,21 @@
+plugins {
+    id 'java'
+}
+
+group = 'com.snyk.fixtures'
+version = '1.0.0'
+
+repositories {
+    mavenCentral()
+}
+
+// User-defined config: canBeResolved=true and canBeConsumed=true by default,
+// but has its own declared dependency so it must not be filtered out.
+configurations {
+    extraLibs
+}
+
+dependencies {
+    implementation 'org.apache.commons:commons-lang3:3.14.0'
+    extraLibs 'commons-io:commons-io:2.16.1'
+}

--- a/pkg/ecosystems/testdata/fixtures/gradle/custom-config/expected_plugin.json
+++ b/pkg/ecosystems/testdata/fixtures/gradle/custom-config/expected_plugin.json
@@ -1,0 +1,67 @@
+[
+  {
+    "depGraph": {
+      "schemaVersion": "1.3.0",
+      "pkgManager": {
+        "name": "gradle"
+      },
+      "pkgs": [
+        {
+          "id": "com.snyk.fixtures:custom-config@1.0.0",
+          "info": {
+            "name": "com.snyk.fixtures:custom-config",
+            "version": "1.0.0"
+          }
+        },
+        {
+          "id": "org.apache.commons:commons-lang3@3.14.0",
+          "info": {
+            "name": "org.apache.commons:commons-lang3",
+            "version": "3.14.0"
+          }
+        },
+        {
+          "id": "commons-io:commons-io@2.16.1",
+          "info": {
+            "name": "commons-io:commons-io",
+            "version": "2.16.1"
+          }
+        }
+      ],
+      "graph": {
+        "rootNodeId": "root-node",
+        "nodes": [
+          {
+            "nodeId": "root-node",
+            "pkgId": "com.snyk.fixtures:custom-config@1.0.0",
+            "deps": [
+              {
+                "nodeId": "org.apache.commons:commons-lang3@3.14.0"
+              },
+              {
+                "nodeId": "commons-io:commons-io@2.16.1"
+              }
+            ]
+          },
+          {
+            "nodeId": "org.apache.commons:commons-lang3@3.14.0",
+            "pkgId": "org.apache.commons:commons-lang3@3.14.0",
+            "deps": []
+          },
+          {
+            "nodeId": "commons-io:commons-io@2.16.1",
+            "pkgId": "commons-io:commons-io@2.16.1",
+            "deps": []
+          }
+        ]
+      }
+    },
+    "projectDescriptor": {
+      "identity": {
+        "type": "gradle",
+        "targetFile": "build.gradle",
+        "rootComponentName": "com.snyk.fixtures:custom-config"
+      }
+    }
+  }
+]

--- a/pkg/ecosystems/testdata/fixtures/gradle/custom-config/settings.gradle
+++ b/pkg/ecosystems/testdata/fixtures/gradle/custom-config/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'custom-config'

--- a/pkg/ecosystems/testdata/fixtures/gradle/with-lock-file/metadata.json
+++ b/pkg/ecosystems/testdata/fixtures/gradle/with-lock-file/metadata.json
@@ -1,4 +1,4 @@
 {
-  "gradle": ">=8",
-  "reason": "Gradle 6 and 7 have issues with dynamic versions in lock files"
+  "gradle": ">=7",
+  "reason": "Gradle 6 has issues with dynamic versions in lock files"
 }


### PR DESCRIPTION
- [X] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [X] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### Background

Gradle automatically creates default and archives configurations for every Java project. These are marked as both `canBeResolved` and `canBeConsumed`, with no directly-declared dependencies. They aggregate via `extendsFrom` from the real classpath configurations.

Previously the init script walked all `canBeResolved` configurations, which included these. Walking them via ResolutionResult pulls in inherited transitives that don't belong to any real classpath the project builds against, and can surface deps not covered by a lockfile.


### What this does

We now skip configurations that are both consumable and have no directly-declared dependencies. This change matches the approach taken in the v6 snyk-gradle-plugin branch (see [here](https://github.com/snyk/snyk-gradle-plugin/pull/337)). 

[Jira](https://snyksec.atlassian.net/jira/software/c/projects/CMPA/boards/5466?assignee=60162bfac8c36c00698fa2d4&selectedIssue=CMPA-567)
