### PR TITLE
refactor!: stream SCAResults through SCAPlugin via per-graph callback

### DIFF
--- a/pkg/depgraph/sbom_resolution.go
+++ b/pkg/depgraph/sbom_resolution.go
@@ -87,25 +87,48 @@ func handleSBOMResolutionDI(
 	totalResults := 0
 
 	for _, sp := range scaPlugins {
-		pluginResult, err := sp.BuildDepGraphsFromDir(
+		// The sbom_resolution flow runs batch-mode logic (failFast,
+		// JSONL bridge, ExcludePaths propagation) over the entire
+		// plugin output. Collect via the streaming callback into a
+		// local slice; per-plugin peak memory is unchanged from the
+		// previous PluginResult shape — the streaming wins land in
+		// consumers that pipe each SCAResult straight to disk or
+		// network rather than accumulating them.
+		var (
+			results        []ecosystems.SCAResult
+			processedFiles []string
+			seen           = make(map[string]struct{})
+		)
+		err := sp.BuildDepGraphsFromDir(
 			ctx.Context(),
 			pluginLogger,
 			inputDir,
 			pluginOptions,
+			func(r ecosystems.SCAResult) error {
+				results = append(results, r)
+				for _, p := range r.ProcessedFiles {
+					if _, ok := seen[p]; ok {
+						continue
+					}
+					seen[p] = struct{}{}
+					processedFiles = append(processedFiles, p)
+				}
+				return nil
+			},
 		)
 		if err != nil {
 			return nil, fmt.Errorf("error building results: %w", err)
 		}
-		if pluginResult == nil {
+		if len(results) == 0 {
 			continue
 		}
 
-		if ffErr := checkFailFast(logger, failFast, allProjects, pluginResult.Results); ffErr != nil {
+		if ffErr := checkFailFast(logger, failFast, allProjects, results); ffErr != nil {
 			return nil, ffErr
 		}
 
 		pluginData, pluginProblems, err := convertPluginResults(
-			logger, sp, pluginResult.Results, allProjects, forceIncludeWorkspacePackages, targetFile,
+			logger, sp, results, allProjects, forceIncludeWorkspacePackages, targetFile,
 		)
 		if err != nil {
 			return nil, err
@@ -113,11 +136,11 @@ func handleSBOMResolutionDI(
 
 		workflowData = append(workflowData, pluginData...)
 		problemResults = append(problemResults, pluginProblems...)
-		totalResults += len(pluginResult.Results)
+		totalResults += len(results)
 
-		pluginOptions.WithExcludePaths(pluginResult.ProcessedFiles)
+		pluginOptions.WithExcludePaths(processedFiles)
 
-		if !allProjects && len(pluginResult.Results) > 0 {
+		if !allProjects {
 			break
 		}
 	}

--- a/pkg/depgraph/sbom_resolution_test.go
+++ b/pkg/depgraph/sbom_resolution_test.go
@@ -60,7 +60,7 @@ func (m *mockScaPlugin) BuildDepGraphsFromDir(
 	_ logger.Logger,
 	_ string,
 	options *ecosystems.SCAPluginOptions,
-	onGraph func(ecosystems.SCAResult) error,
+	onGraph ecosystems.OnGraphFunc,
 ) error {
 	m.options = options
 	if m.err != nil {

--- a/pkg/depgraph/sbom_resolution_test.go
+++ b/pkg/depgraph/sbom_resolution_test.go
@@ -40,9 +40,13 @@ var uvSBOMConvertExpectedDepGraph string
 //go:embed testdata/uv-sbom-convert-response.json
 var uvSBOMConvertResponse string
 
+// mockScaPlugin emits a configured set of SCAResults through the
+// SCAPlugin callback contract. Each result carries its own
+// ProcessedFiles list (the per-graph attribution downstream consumers
+// rely on).
 type mockScaPlugin struct {
 	name    string
-	result  *ecosystems.PluginResult
+	results []ecosystems.SCAResult
 	err     error
 	options *ecosystems.SCAPluginOptions
 }
@@ -56,15 +60,26 @@ func (m *mockScaPlugin) BuildDepGraphsFromDir(
 	_ logger.Logger,
 	_ string,
 	options *ecosystems.SCAPluginOptions,
-) (*ecosystems.PluginResult, error) {
+	onGraph func(ecosystems.SCAResult) error,
+) error {
 	m.options = options
 	if m.err != nil {
-		return nil, m.err
+		return m.err
 	}
-	if m.result == nil {
-		return &ecosystems.PluginResult{}, nil
+	for _, r := range m.results {
+		if err := onGraph(r); err != nil {
+			return err
+		}
 	}
-	return m.result, nil
+	return nil
+}
+
+// withProcessedFiles returns r with ProcessedFiles set, for use in
+// fixture literals where attaching the file list to a SCAResult
+// inline keeps the test data dense.
+func withProcessedFiles(r ecosystems.SCAResult, files ...string) ecosystems.SCAResult {
+	r.ProcessedFiles = files
+	return r
 }
 
 // LegacyHarness wraps a real `legacy.Plugin` whose underlying `legacycli` workflow is
@@ -297,18 +312,16 @@ func Test_callback_SBOMResolution(t *testing.T) {
 		expectedDepGraph := builder.Build()
 
 		mockPlugin := &mockScaPlugin{
-			result: &ecosystems.PluginResult{
-				Results: []ecosystems.SCAResult{
-					{
-						DepGraph: expectedDepGraph,
-						ProjectDescriptor: identity.ProjectDescriptor{
-							Identity: identity.ProjectIdentity{
-								TargetFile: stringPtr("pyproject.toml"),
-							},
+			results: []ecosystems.SCAResult{
+				{
+					DepGraph: expectedDepGraph,
+					ProjectDescriptor: identity.ProjectDescriptor{
+						Identity: identity.ProjectIdentity{
+							TargetFile: stringPtr("pyproject.toml"),
 						},
-						ResolverMetadata: &ecosystems.ResolverMetadata{
-							NormalisedTargetFile: "pyproject.toml",
-						},
+					},
+					ResolverMetadata: &ecosystems.ResolverMetadata{
+						NormalisedTargetFile: "pyproject.toml",
 					},
 				},
 			},
@@ -380,29 +393,27 @@ func Test_callback_SBOMResolution(t *testing.T) {
 		ctx.config.Set(workflow.FlagAllProjects, true)
 
 		mockPlugin := &mockScaPlugin{
-			result: &ecosystems.PluginResult{
-				Results: []ecosystems.SCAResult{
-					{
-						DepGraph: createTestDepGraph(t, "pip", "test-project-1", "1.0.0"),
-						ProjectDescriptor: identity.ProjectDescriptor{
-							Identity: identity.ProjectIdentity{
-								TargetFile: stringPtr("pyproject.toml"),
-							},
-						},
-						ResolverMetadata: &ecosystems.ResolverMetadata{
-							NormalisedTargetFile: "pyproject.toml",
+			results: []ecosystems.SCAResult{
+				{
+					DepGraph: createTestDepGraph(t, "pip", "test-project-1", "1.0.0"),
+					ProjectDescriptor: identity.ProjectDescriptor{
+						Identity: identity.ProjectIdentity{
+							TargetFile: stringPtr("pyproject.toml"),
 						},
 					},
-					{
-						Error: fmt.Errorf("failed to convert SBOM: analysis of SBOM document failed due to error: 500"),
-						ProjectDescriptor: identity.ProjectDescriptor{
-							Identity: identity.ProjectIdentity{
-								TargetFile: stringPtr("uv.lock"),
-							},
+					ResolverMetadata: &ecosystems.ResolverMetadata{
+						NormalisedTargetFile: "pyproject.toml",
+					},
+				},
+				{
+					Error: fmt.Errorf("failed to convert SBOM: analysis of SBOM document failed due to error: 500"),
+					ProjectDescriptor: identity.ProjectDescriptor{
+						Identity: identity.ProjectIdentity{
+							TargetFile: stringPtr("uv.lock"),
 						},
-						ResolverMetadata: &ecosystems.ResolverMetadata{
-							NormalisedTargetFile: "uv.lock",
-						},
+					},
+					ResolverMetadata: &ecosystems.ResolverMetadata{
+						NormalisedTargetFile: "uv.lock",
 					},
 				},
 			},
@@ -430,29 +441,27 @@ func Test_callback_SBOMResolution(t *testing.T) {
 
 		// Create mock plugin that returns multiple findings, all with conversion errors
 		mockPlugin := &mockScaPlugin{
-			result: &ecosystems.PluginResult{
-				Results: []ecosystems.SCAResult{
-					{
-						Error: fmt.Errorf("failed to convert SBOM: analysis of SBOM document failed due to error: 500"),
-						ProjectDescriptor: identity.ProjectDescriptor{
-							Identity: identity.ProjectIdentity{
-								TargetFile: stringPtr("project1/uv.lock"),
-							},
-						},
-						ResolverMetadata: &ecosystems.ResolverMetadata{
-							NormalisedTargetFile: "project1/uv.lock",
+			results: []ecosystems.SCAResult{
+				{
+					Error: fmt.Errorf("failed to convert SBOM: analysis of SBOM document failed due to error: 500"),
+					ProjectDescriptor: identity.ProjectDescriptor{
+						Identity: identity.ProjectIdentity{
+							TargetFile: stringPtr("project1/uv.lock"),
 						},
 					},
-					{
-						Error: fmt.Errorf("failed to convert SBOM: analysis of SBOM document failed due to error: 500"),
-						ProjectDescriptor: identity.ProjectDescriptor{
-							Identity: identity.ProjectIdentity{
-								TargetFile: stringPtr("project2/uv.lock"),
-							},
+					ResolverMetadata: &ecosystems.ResolverMetadata{
+						NormalisedTargetFile: "project1/uv.lock",
+					},
+				},
+				{
+					Error: fmt.Errorf("failed to convert SBOM: analysis of SBOM document failed due to error: 500"),
+					ProjectDescriptor: identity.ProjectDescriptor{
+						Identity: identity.ProjectIdentity{
+							TargetFile: stringPtr("project2/uv.lock"),
 						},
-						ResolverMetadata: &ecosystems.ResolverMetadata{
-							NormalisedTargetFile: "project2/uv.lock",
-						},
+					},
+					ResolverMetadata: &ecosystems.ResolverMetadata{
+						NormalisedTargetFile: "project2/uv.lock",
 					},
 				},
 			},
@@ -488,18 +497,16 @@ func Test_callback_SBOMResolution(t *testing.T) {
 		ctx.config.Set(configuration.API_URL, mockSBOMService.URL)
 
 		mockPlugin := &mockScaPlugin{
-			result: &ecosystems.PluginResult{
-				Results: []ecosystems.SCAResult{
-					{
-						DepGraph: createTestDepGraph(t, "pip", "test-project", "1.0.0"),
-						ProjectDescriptor: identity.ProjectDescriptor{
-							Identity: identity.ProjectIdentity{
-								TargetFile: stringPtr("pyproject.toml"),
-							},
+			results: []ecosystems.SCAResult{
+				{
+					DepGraph: createTestDepGraph(t, "pip", "test-project", "1.0.0"),
+					ProjectDescriptor: identity.ProjectDescriptor{
+						Identity: identity.ProjectIdentity{
+							TargetFile: stringPtr("pyproject.toml"),
 						},
-						ResolverMetadata: &ecosystems.ResolverMetadata{
-							NormalisedTargetFile: "pyproject.toml",
-						},
+					},
+					ResolverMetadata: &ecosystems.ResolverMetadata{
+						NormalisedTargetFile: "pyproject.toml",
 					},
 				},
 			},
@@ -582,11 +589,9 @@ func Test_callback_SBOMResolution(t *testing.T) {
 				initialExclude: "",
 				plugins: []ecosystems.SCAPlugin{
 					&mockScaPlugin{
-						result: &ecosystems.PluginResult{
-							Results: []ecosystems.SCAResult{
-								finding1,
-								finding2,
-							},
+						results: []ecosystems.SCAResult{
+							finding1,
+							finding2,
 						},
 					},
 				},
@@ -601,9 +606,9 @@ func Test_callback_SBOMResolution(t *testing.T) {
 				initialExclude: "",
 				plugins: []ecosystems.SCAPlugin{
 					&mockScaPlugin{
-						result: &ecosystems.PluginResult{
-							Results:        []ecosystems.SCAResult{finding1, finding2},
-							ProcessedFiles: []string{"uv.lock", "pyproject.toml", "requirements.txt", "setup.py"},
+						results: []ecosystems.SCAResult{
+							withProcessedFiles(finding1, "uv.lock", "pyproject.toml", "requirements.txt", "setup.py"),
+							finding2,
 						},
 					},
 				},
@@ -620,9 +625,7 @@ func Test_callback_SBOMResolution(t *testing.T) {
 				plugins: []ecosystems.SCAPlugin{
 					&mockScaPlugin{},
 					&mockScaPlugin{
-						result: &ecosystems.PluginResult{
-							Results: []ecosystems.SCAResult{finding1},
-						},
+						results: []ecosystems.SCAResult{finding1},
 					},
 				},
 				expectedWorkflowDataLen:          1,
@@ -636,14 +639,10 @@ func Test_callback_SBOMResolution(t *testing.T) {
 				initialExclude: "",
 				plugins: []ecosystems.SCAPlugin{
 					&mockScaPlugin{
-						result: &ecosystems.PluginResult{
-							Results: []ecosystems.SCAResult{finding1, finding2},
-						},
+						results: []ecosystems.SCAResult{finding1, finding2},
 					},
 					&mockScaPlugin{
-						result: &ecosystems.PluginResult{
-							Results: []ecosystems.SCAResult{finding3, finding4},
-						},
+						results: []ecosystems.SCAResult{finding3, finding4},
 					},
 				},
 				expectedWorkflowDataLen:          2,
@@ -658,15 +657,15 @@ func Test_callback_SBOMResolution(t *testing.T) {
 				initialExclude: "",
 				plugins: []ecosystems.SCAPlugin{
 					&mockScaPlugin{
-						result: &ecosystems.PluginResult{
-							Results:        []ecosystems.SCAResult{finding1, finding2},
-							ProcessedFiles: []string{"uv.lock", "pyproject.toml", "requirements.txt", "setup.py"},
+						results: []ecosystems.SCAResult{
+							withProcessedFiles(finding1, "uv.lock", "pyproject.toml", "requirements.txt", "setup.py"),
+							finding2,
 						},
 					},
 					&mockScaPlugin{
-						result: &ecosystems.PluginResult{
-							Results:        []ecosystems.SCAResult{finding3, finding4},
-							ProcessedFiles: []string{"package.json", "go.mod"},
+						results: []ecosystems.SCAResult{
+							withProcessedFiles(finding3, "package.json", "go.mod"),
+							finding4,
 						},
 					},
 				},
@@ -695,9 +694,9 @@ func Test_callback_SBOMResolution(t *testing.T) {
 				initialExclude: "existing-file.txt,another-file.py",
 				plugins: []ecosystems.SCAPlugin{
 					&mockScaPlugin{
-						result: &ecosystems.PluginResult{
-							Results:        []ecosystems.SCAResult{finding1, finding2},
-							ProcessedFiles: []string{"uv.lock", "pyproject.toml", "requirements.txt", "setup.py"},
+						results: []ecosystems.SCAResult{
+							withProcessedFiles(finding1, "uv.lock", "pyproject.toml", "requirements.txt", "setup.py"),
+							finding2,
 						},
 					},
 				},
@@ -772,21 +771,18 @@ func Test_callback_SBOMResolution(t *testing.T) {
 
 		// Create mock plugin that returns a finding
 		mockPlugin := &mockScaPlugin{
-			result: &ecosystems.PluginResult{
-				Results: []ecosystems.SCAResult{
-					{
-						DepGraph: createTestDepGraph(t, "pip", "test-project", "1.0.0"),
-						ProjectDescriptor: identity.ProjectDescriptor{
-							Identity: identity.ProjectIdentity{
-								TargetFile: stringPtr("pyproject.toml"),
-							},
-						},
-						ResolverMetadata: &ecosystems.ResolverMetadata{
-							NormalisedTargetFile: "pyproject.toml",
+			results: []ecosystems.SCAResult{
+				withProcessedFiles(ecosystems.SCAResult{
+					DepGraph: createTestDepGraph(t, "pip", "test-project", "1.0.0"),
+					ProjectDescriptor: identity.ProjectDescriptor{
+						Identity: identity.ProjectIdentity{
+							TargetFile: stringPtr("pyproject.toml"),
 						},
 					},
-				},
-				ProcessedFiles: []string{"uv.lock"},
+					ResolverMetadata: &ecosystems.ResolverMetadata{
+						NormalisedTargetFile: "pyproject.toml",
+					},
+				}, "uv.lock"),
 			},
 		}
 
@@ -852,21 +848,18 @@ func Test_callback_SBOMResolution(t *testing.T) {
 
 		// Create mock plugin that returns a finding
 		mockPlugin := &mockScaPlugin{
-			result: &ecosystems.PluginResult{
-				Results: []ecosystems.SCAResult{
-					{
-						DepGraph: createTestDepGraph(t, "pip", "test-project", "1.0.0"),
-						ProjectDescriptor: identity.ProjectDescriptor{
-							Identity: identity.ProjectIdentity{
-								TargetFile: stringPtr("pyproject.toml"),
-							},
-						},
-						ResolverMetadata: &ecosystems.ResolverMetadata{
-							NormalisedTargetFile: "pyproject.toml",
+			results: []ecosystems.SCAResult{
+				withProcessedFiles(ecosystems.SCAResult{
+					DepGraph: createTestDepGraph(t, "pip", "test-project", "1.0.0"),
+					ProjectDescriptor: identity.ProjectDescriptor{
+						Identity: identity.ProjectIdentity{
+							TargetFile: stringPtr("pyproject.toml"),
 						},
 					},
-				},
-				ProcessedFiles: []string{"uv.lock"},
+					ResolverMetadata: &ecosystems.ResolverMetadata{
+						NormalisedTargetFile: "pyproject.toml",
+					},
+				}, "uv.lock"),
 			},
 		}
 
@@ -901,33 +894,30 @@ func Test_callback_SBOMResolution(t *testing.T) {
 		legacyMock := NewLegacyHarness(ctx)
 
 		mockPlugin := &mockScaPlugin{
-			result: &ecosystems.PluginResult{
-				Results: []ecosystems.SCAResult{
-					{
-						DepGraph: createTestDepGraph(t, "pip", "test-project-1", "1.0.0"),
-						ProjectDescriptor: identity.ProjectDescriptor{
-							Identity: identity.ProjectIdentity{
-								TargetFile: stringPtr("project1/pyproject.toml"),
-							},
+			results: []ecosystems.SCAResult{
+				withProcessedFiles(ecosystems.SCAResult{
+					DepGraph: createTestDepGraph(t, "pip", "test-project-1", "1.0.0"),
+					ProjectDescriptor: identity.ProjectDescriptor{
+						Identity: identity.ProjectIdentity{
+							TargetFile: stringPtr("project1/pyproject.toml"),
 						},
-						ResolverMetadata: &ecosystems.ResolverMetadata{
-							NormalisedTargetFile: "project1/pyproject.toml",
-						},
-						Error: nil,
 					},
-					{
-						ProjectDescriptor: identity.ProjectDescriptor{
-							Identity: identity.ProjectIdentity{
-								TargetFile: stringPtr("project2/uv.lock"),
-							},
-						},
-						ResolverMetadata: &ecosystems.ResolverMetadata{
-							NormalisedTargetFile: "project2/uv.lock",
-						},
-						Error: fmt.Errorf("failed to generate SBOM"),
+					ResolverMetadata: &ecosystems.ResolverMetadata{
+						NormalisedTargetFile: "project1/pyproject.toml",
 					},
+					Error: nil,
+				}, "project1/uv.lock", "project2/uv.lock"),
+				{
+					ProjectDescriptor: identity.ProjectDescriptor{
+						Identity: identity.ProjectIdentity{
+							TargetFile: stringPtr("project2/uv.lock"),
+						},
+					},
+					ResolverMetadata: &ecosystems.ResolverMetadata{
+						NormalisedTargetFile: "project2/uv.lock",
+					},
+					Error: fmt.Errorf("failed to generate SBOM"),
 				},
-				ProcessedFiles: []string{"project1/uv.lock", "project2/uv.lock"},
 			},
 		}
 
@@ -957,21 +947,18 @@ func Test_callback_SBOMResolution(t *testing.T) {
 		}
 
 		mockPlugin := &mockScaPlugin{
-			result: &ecosystems.PluginResult{
-				Results: []ecosystems.SCAResult{
-					{
-						ProjectDescriptor: identity.ProjectDescriptor{
-							Identity: identity.ProjectIdentity{
-								TargetFile: stringPtr("uv.lock"),
-							},
+			results: []ecosystems.SCAResult{
+				withProcessedFiles(ecosystems.SCAResult{
+					ProjectDescriptor: identity.ProjectDescriptor{
+						Identity: identity.ProjectIdentity{
+							TargetFile: stringPtr("uv.lock"),
 						},
-						ResolverMetadata: &ecosystems.ResolverMetadata{
-							NormalisedTargetFile: "uv.lock",
-						},
-						Error: snykErr,
 					},
-				},
-				ProcessedFiles: []string{"uv.lock"},
+					ResolverMetadata: &ecosystems.ResolverMetadata{
+						NormalisedTargetFile: "uv.lock",
+					},
+					Error: snykErr,
+				}, "uv.lock"),
 			},
 		}
 
@@ -1008,18 +995,16 @@ func Test_callback_SBOMResolution(t *testing.T) {
 		ctx.config.Set(configuration.API_URL, mockSBOMService.URL)
 
 		mockPlugin := &mockScaPlugin{
-			result: &ecosystems.PluginResult{
-				Results: []ecosystems.SCAResult{
-					{
-						DepGraph: createTestDepGraph(t, "pip", "test-project", "1.0.0"),
-						ProjectDescriptor: identity.ProjectDescriptor{
-							Identity: identity.ProjectIdentity{
-								TargetFile: stringPtr("pyproject.toml"),
-							},
+			results: []ecosystems.SCAResult{
+				{
+					DepGraph: createTestDepGraph(t, "pip", "test-project", "1.0.0"),
+					ProjectDescriptor: identity.ProjectDescriptor{
+						Identity: identity.ProjectIdentity{
+							TargetFile: stringPtr("pyproject.toml"),
 						},
-						ResolverMetadata: &ecosystems.ResolverMetadata{
-							NormalisedTargetFile: "pyproject.toml",
-						},
+					},
+					ResolverMetadata: &ecosystems.ResolverMetadata{
+						NormalisedTargetFile: "pyproject.toml",
 					},
 				},
 			},
@@ -1045,18 +1030,16 @@ func Test_callback_SBOMResolution(t *testing.T) {
 		ctx.config.Set(configuration.API_URL, mockSBOMService.URL)
 
 		mockPlugin := &mockScaPlugin{
-			result: &ecosystems.PluginResult{
-				Results: []ecosystems.SCAResult{
-					{
-						DepGraph: createTestDepGraph(t, "pip", "test-project", "1.0.0"),
-						ProjectDescriptor: identity.ProjectDescriptor{
-							Identity: identity.ProjectIdentity{
-								TargetFile: stringPtr("pyproject.toml"),
-							},
+			results: []ecosystems.SCAResult{
+				{
+					DepGraph: createTestDepGraph(t, "pip", "test-project", "1.0.0"),
+					ProjectDescriptor: identity.ProjectDescriptor{
+						Identity: identity.ProjectIdentity{
+							TargetFile: stringPtr("pyproject.toml"),
 						},
-						ResolverMetadata: &ecosystems.ResolverMetadata{
-							NormalisedTargetFile: "pyproject.toml",
-						},
+					},
+					ResolverMetadata: &ecosystems.ResolverMetadata{
+						NormalisedTargetFile: "pyproject.toml",
 					},
 				},
 			},
@@ -1080,18 +1063,16 @@ func Test_callback_SBOMResolution(t *testing.T) {
 		ctx.config.Set(workflow.FlagStrictOutOfSync, "invalid")
 
 		mockPlugin := &mockScaPlugin{
-			result: &ecosystems.PluginResult{
-				Results: []ecosystems.SCAResult{
-					{
-						DepGraph: createTestDepGraph(t, "pip", "test-project", "1.0.0"),
-						ProjectDescriptor: identity.ProjectDescriptor{
-							Identity: identity.ProjectIdentity{
-								TargetFile: stringPtr("pyproject.toml"),
-							},
+			results: []ecosystems.SCAResult{
+				{
+					DepGraph: createTestDepGraph(t, "pip", "test-project", "1.0.0"),
+					ProjectDescriptor: identity.ProjectDescriptor{
+						Identity: identity.ProjectIdentity{
+							TargetFile: stringPtr("pyproject.toml"),
 						},
-						ResolverMetadata: &ecosystems.ResolverMetadata{
-							NormalisedTargetFile: "pyproject.toml",
-						},
+					},
+					ResolverMetadata: &ecosystems.ResolverMetadata{
+						NormalisedTargetFile: "pyproject.toml",
 					},
 				},
 			},
@@ -1122,18 +1103,16 @@ func Test_callback_SBOMResolution(t *testing.T) {
 		ctx.config.Set(configuration.API_URL, mockSBOMService.URL)
 
 		mockPlugin := &mockScaPlugin{
-			result: &ecosystems.PluginResult{
-				Results: []ecosystems.SCAResult{
-					{
-						DepGraph: createTestDepGraph(t, "pip", "test-project", "1.0.0"),
-						ProjectDescriptor: identity.ProjectDescriptor{
-							Identity: identity.ProjectIdentity{
-								TargetFile: stringPtr("pyproject.toml"),
-							},
+			results: []ecosystems.SCAResult{
+				{
+					DepGraph: createTestDepGraph(t, "pip", "test-project", "1.0.0"),
+					ProjectDescriptor: identity.ProjectDescriptor{
+						Identity: identity.ProjectIdentity{
+							TargetFile: stringPtr("pyproject.toml"),
 						},
-						ResolverMetadata: &ecosystems.ResolverMetadata{
-							NormalisedTargetFile: "pyproject.toml",
-						},
+					},
+					ResolverMetadata: &ecosystems.ResolverMetadata{
+						NormalisedTargetFile: "pyproject.toml",
 					},
 				},
 			},
@@ -1162,18 +1141,16 @@ func Test_callback_SBOMResolution(t *testing.T) {
 		ctx.config.Set(configuration.API_URL, mockSBOMService.URL)
 
 		mockPlugin := &mockScaPlugin{
-			result: &ecosystems.PluginResult{
-				Results: []ecosystems.SCAResult{
-					{
-						DepGraph: createTestDepGraph(t, "pip", "test-project", "1.0.0"),
-						ProjectDescriptor: identity.ProjectDescriptor{
-							Identity: identity.ProjectIdentity{
-								TargetFile: stringPtr("pyproject.toml"),
-							},
+			results: []ecosystems.SCAResult{
+				{
+					DepGraph: createTestDepGraph(t, "pip", "test-project", "1.0.0"),
+					ProjectDescriptor: identity.ProjectDescriptor{
+						Identity: identity.ProjectIdentity{
+							TargetFile: stringPtr("pyproject.toml"),
 						},
-						ResolverMetadata: &ecosystems.ResolverMetadata{
-							NormalisedTargetFile: "pyproject.toml",
-						},
+					},
+					ResolverMetadata: &ecosystems.ResolverMetadata{
+						NormalisedTargetFile: "pyproject.toml",
 					},
 				},
 			},
@@ -1202,18 +1179,16 @@ func Test_callback_SBOMResolution(t *testing.T) {
 		ctx.config.Set(configuration.API_URL, mockSBOMService.URL)
 
 		mockPlugin := &mockScaPlugin{
-			result: &ecosystems.PluginResult{
-				Results: []ecosystems.SCAResult{
-					{
-						DepGraph: createTestDepGraph(t, "pip", "test-project", "1.0.0"),
-						ProjectDescriptor: identity.ProjectDescriptor{
-							Identity: identity.ProjectIdentity{
-								TargetFile: stringPtr("pyproject.toml"),
-							},
+			results: []ecosystems.SCAResult{
+				{
+					DepGraph: createTestDepGraph(t, "pip", "test-project", "1.0.0"),
+					ProjectDescriptor: identity.ProjectDescriptor{
+						Identity: identity.ProjectIdentity{
+							TargetFile: stringPtr("pyproject.toml"),
 						},
-						ResolverMetadata: &ecosystems.ResolverMetadata{
-							NormalisedTargetFile: "pyproject.toml",
-						},
+					},
+					ResolverMetadata: &ecosystems.ResolverMetadata{
+						NormalisedTargetFile: "pyproject.toml",
 					},
 				},
 			},
@@ -1290,21 +1265,18 @@ func Test_callback_SBOMResolution(t *testing.T) {
 		}
 
 		mockPlugin := &mockScaPlugin{
-			result: &ecosystems.PluginResult{
-				Results: []ecosystems.SCAResult{
-					{
-						ProjectDescriptor: identity.ProjectDescriptor{
-							Identity: identity.ProjectIdentity{
-								TargetFile: stringPtr("uv.lock"),
-							},
+			results: []ecosystems.SCAResult{
+				withProcessedFiles(ecosystems.SCAResult{
+					ProjectDescriptor: identity.ProjectDescriptor{
+						Identity: identity.ProjectIdentity{
+							TargetFile: stringPtr("uv.lock"),
 						},
-						ResolverMetadata: &ecosystems.ResolverMetadata{
-							NormalisedTargetFile: "uv.lock",
-						},
-						Error: snykErr,
 					},
-				},
-				ProcessedFiles: []string{"uv.lock"},
+					ResolverMetadata: &ecosystems.ResolverMetadata{
+						NormalisedTargetFile: "uv.lock",
+					},
+					Error: snykErr,
+				}, "uv.lock"),
 			},
 		}
 
@@ -1340,44 +1312,41 @@ func Test_callback_SBOMResolution(t *testing.T) {
 		}
 
 		mockPlugin := &mockScaPlugin{
-			result: &ecosystems.PluginResult{
-				Results: []ecosystems.SCAResult{
-					{
-						DepGraph: createTestDepGraph(t, "pip", "test-project-1", "1.0.0"),
-						ProjectDescriptor: identity.ProjectDescriptor{
-							Identity: identity.ProjectIdentity{
-								TargetFile: stringPtr("valid-project/pyproject.toml"),
-							},
+			results: []ecosystems.SCAResult{
+				withProcessedFiles(ecosystems.SCAResult{
+					DepGraph: createTestDepGraph(t, "pip", "test-project-1", "1.0.0"),
+					ProjectDescriptor: identity.ProjectDescriptor{
+						Identity: identity.ProjectIdentity{
+							TargetFile: stringPtr("valid-project/pyproject.toml"),
 						},
-						ResolverMetadata: &ecosystems.ResolverMetadata{
-							NormalisedTargetFile: "valid-project/pyproject.toml",
-						},
-						Error: nil,
 					},
-					{
-						ProjectDescriptor: identity.ProjectDescriptor{
-							Identity: identity.ProjectIdentity{
-								TargetFile: stringPtr("project1/uv.lock"),
-							},
-						},
-						ResolverMetadata: &ecosystems.ResolverMetadata{
-							NormalisedTargetFile: "project1/uv.lock",
-						},
-						Error: snykErr,
+					ResolverMetadata: &ecosystems.ResolverMetadata{
+						NormalisedTargetFile: "valid-project/pyproject.toml",
 					},
-					{
-						ProjectDescriptor: identity.ProjectDescriptor{
-							Identity: identity.ProjectIdentity{
-								TargetFile: stringPtr("project2/uv.lock"),
-							},
+					Error: nil,
+				}, "project1/uv.lock", "project2/uv.lock"),
+				{
+					ProjectDescriptor: identity.ProjectDescriptor{
+						Identity: identity.ProjectIdentity{
+							TargetFile: stringPtr("project1/uv.lock"),
 						},
-						ResolverMetadata: &ecosystems.ResolverMetadata{
-							NormalisedTargetFile: "project2/uv.lock",
-						},
-						Error: fmt.Errorf("This should not be processed"),
 					},
+					ResolverMetadata: &ecosystems.ResolverMetadata{
+						NormalisedTargetFile: "project1/uv.lock",
+					},
+					Error: snykErr,
 				},
-				ProcessedFiles: []string{"project1/uv.lock", "project2/uv.lock"},
+				{
+					ProjectDescriptor: identity.ProjectDescriptor{
+						Identity: identity.ProjectIdentity{
+							TargetFile: stringPtr("project2/uv.lock"),
+						},
+					},
+					ResolverMetadata: &ecosystems.ResolverMetadata{
+						NormalisedTargetFile: "project2/uv.lock",
+					},
+					Error: fmt.Errorf("This should not be processed"),
+				},
 			},
 		}
 
@@ -1411,21 +1380,18 @@ func Test_callback_SBOMResolution(t *testing.T) {
 		}
 
 		mockPlugin := &mockScaPlugin{
-			result: &ecosystems.PluginResult{
-				Results: []ecosystems.SCAResult{
-					{
-						ProjectDescriptor: identity.ProjectDescriptor{
-							Identity: identity.ProjectIdentity{
-								TargetFile: stringPtr("project1/uv.lock"),
-							},
+			results: []ecosystems.SCAResult{
+				withProcessedFiles(ecosystems.SCAResult{
+					ProjectDescriptor: identity.ProjectDescriptor{
+						Identity: identity.ProjectIdentity{
+							TargetFile: stringPtr("project1/uv.lock"),
 						},
-						ResolverMetadata: &ecosystems.ResolverMetadata{
-							NormalisedTargetFile: "project1/uv.lock",
-						},
-						Error: snykErr,
 					},
-				},
-				ProcessedFiles: []string{"project1/uv.lock"},
+					ResolverMetadata: &ecosystems.ResolverMetadata{
+						NormalisedTargetFile: "project1/uv.lock",
+					},
+					Error: snykErr,
+				}, "project1/uv.lock"),
 			},
 		}
 
@@ -1459,33 +1425,30 @@ func Test_callback_SBOMResolution(t *testing.T) {
 		}
 
 		mockPlugin := &mockScaPlugin{
-			result: &ecosystems.PluginResult{
-				Results: []ecosystems.SCAResult{
-					{
-						DepGraph: createTestDepGraph(t, "pip", "test-project-1", "1.0.0"),
-						ProjectDescriptor: identity.ProjectDescriptor{
-							Identity: identity.ProjectIdentity{
-								TargetFile: stringPtr("valid-project/pyproject.toml"),
-							},
+			results: []ecosystems.SCAResult{
+				withProcessedFiles(ecosystems.SCAResult{
+					DepGraph: createTestDepGraph(t, "pip", "test-project-1", "1.0.0"),
+					ProjectDescriptor: identity.ProjectDescriptor{
+						Identity: identity.ProjectIdentity{
+							TargetFile: stringPtr("valid-project/pyproject.toml"),
 						},
-						ResolverMetadata: &ecosystems.ResolverMetadata{
-							NormalisedTargetFile: "valid-project/pyproject.toml",
-						},
-						Error: nil,
 					},
-					{
-						ProjectDescriptor: identity.ProjectDescriptor{
-							Identity: identity.ProjectIdentity{
-								TargetFile: stringPtr("project1/uv.lock"),
-							},
-						},
-						ResolverMetadata: &ecosystems.ResolverMetadata{
-							NormalisedTargetFile: "project1/uv.lock",
-						},
-						Error: snykErr,
+					ResolverMetadata: &ecosystems.ResolverMetadata{
+						NormalisedTargetFile: "valid-project/pyproject.toml",
 					},
+					Error: nil,
+				}, "project1/uv.lock"),
+				{
+					ProjectDescriptor: identity.ProjectDescriptor{
+						Identity: identity.ProjectIdentity{
+							TargetFile: stringPtr("project1/uv.lock"),
+						},
+					},
+					ResolverMetadata: &ecosystems.ResolverMetadata{
+						NormalisedTargetFile: "project1/uv.lock",
+					},
+					Error: snykErr,
 				},
-				ProcessedFiles: []string{"project1/uv.lock"},
 			},
 		}
 
@@ -1525,21 +1488,18 @@ func Test_callback_SBOMResolution(t *testing.T) {
 		}
 
 		mockPlugin := &mockScaPlugin{
-			result: &ecosystems.PluginResult{
-				Results: []ecosystems.SCAResult{
-					{
-						ProjectDescriptor: identity.ProjectDescriptor{
-							Identity: identity.ProjectIdentity{
-								TargetFile: stringPtr("uv.lock"),
-							},
+			results: []ecosystems.SCAResult{
+				withProcessedFiles(ecosystems.SCAResult{
+					ProjectDescriptor: identity.ProjectDescriptor{
+						Identity: identity.ProjectIdentity{
+							TargetFile: stringPtr("uv.lock"),
 						},
-						ResolverMetadata: &ecosystems.ResolverMetadata{
-							NormalisedTargetFile: "uv.lock",
-						},
-						Error: snykErr,
 					},
-				},
-				ProcessedFiles: []string{"uv.lock"},
+					ResolverMetadata: &ecosystems.ResolverMetadata{
+						NormalisedTargetFile: "uv.lock",
+					},
+					Error: snykErr,
+				}, "uv.lock"),
 			},
 		}
 
@@ -1566,18 +1526,16 @@ func Test_callback_SBOMResolution(t *testing.T) {
 		ctx.config.Set(workflow.FlagFailFast, true)
 
 		mockPlugin := &mockScaPlugin{
-			result: &ecosystems.PluginResult{
-				Results: []ecosystems.SCAResult{
-					{
-						DepGraph: createTestDepGraph(t, "pip", "test-project", "1.0.0"),
-						ProjectDescriptor: identity.ProjectDescriptor{
-							Identity: identity.ProjectIdentity{
-								TargetFile: stringPtr("pyproject.toml"),
-							},
+			results: []ecosystems.SCAResult{
+				{
+					DepGraph: createTestDepGraph(t, "pip", "test-project", "1.0.0"),
+					ProjectDescriptor: identity.ProjectDescriptor{
+						Identity: identity.ProjectIdentity{
+							TargetFile: stringPtr("pyproject.toml"),
 						},
-						ResolverMetadata: &ecosystems.ResolverMetadata{
-							NormalisedTargetFile: "pyproject.toml",
-						},
+					},
+					ResolverMetadata: &ecosystems.ResolverMetadata{
+						NormalisedTargetFile: "pyproject.toml",
 					},
 				},
 			},
@@ -1612,44 +1570,41 @@ func Test_callback_SBOMResolution(t *testing.T) {
 		regularErr := fmt.Errorf("Failure message should not be shown to the user")
 
 		mockPlugin := &mockScaPlugin{
-			result: &ecosystems.PluginResult{
-				Results: []ecosystems.SCAResult{
-					{
-						DepGraph: createTestDepGraph(t, "pip", "test-project-1", "1.0.0"),
-						ProjectDescriptor: identity.ProjectDescriptor{
-							Identity: identity.ProjectIdentity{
-								TargetFile: stringPtr("valid-project/pyproject.toml"),
-							},
+			results: []ecosystems.SCAResult{
+				withProcessedFiles(ecosystems.SCAResult{
+					DepGraph: createTestDepGraph(t, "pip", "test-project-1", "1.0.0"),
+					ProjectDescriptor: identity.ProjectDescriptor{
+						Identity: identity.ProjectIdentity{
+							TargetFile: stringPtr("valid-project/pyproject.toml"),
 						},
-						ResolverMetadata: &ecosystems.ResolverMetadata{
-							NormalisedTargetFile: "valid-project/pyproject.toml",
-						},
-						Error: nil,
 					},
-					{
-						ProjectDescriptor: identity.ProjectDescriptor{
-							Identity: identity.ProjectIdentity{
-								TargetFile: stringPtr("project1/uv.lock"),
-							},
-						},
-						ResolverMetadata: &ecosystems.ResolverMetadata{
-							NormalisedTargetFile: "project1/uv.lock",
-						},
-						Error: snykErr,
+					ResolverMetadata: &ecosystems.ResolverMetadata{
+						NormalisedTargetFile: "valid-project/pyproject.toml",
 					},
-					{
-						ProjectDescriptor: identity.ProjectDescriptor{
-							Identity: identity.ProjectIdentity{
-								TargetFile: stringPtr("project2/uv.lock"),
-							},
+					Error: nil,
+				}, "project1/uv.lock", "project2/uv.lock"),
+				{
+					ProjectDescriptor: identity.ProjectDescriptor{
+						Identity: identity.ProjectIdentity{
+							TargetFile: stringPtr("project1/uv.lock"),
 						},
-						ResolverMetadata: &ecosystems.ResolverMetadata{
-							NormalisedTargetFile: "project2/uv.lock",
-						},
-						Error: regularErr,
 					},
+					ResolverMetadata: &ecosystems.ResolverMetadata{
+						NormalisedTargetFile: "project1/uv.lock",
+					},
+					Error: snykErr,
 				},
-				ProcessedFiles: []string{"project1/uv.lock", "project2/uv.lock"},
+				{
+					ProjectDescriptor: identity.ProjectDescriptor{
+						Identity: identity.ProjectIdentity{
+							TargetFile: stringPtr("project2/uv.lock"),
+						},
+					},
+					ResolverMetadata: &ecosystems.ResolverMetadata{
+						NormalisedTargetFile: "project2/uv.lock",
+					},
+					Error: regularErr,
+				},
 			},
 		}
 
@@ -1744,18 +1699,16 @@ func Test_parseExcludeFlag(t *testing.T) {
 func Test_processedFilesFlowFromPluginsToExcludeConfig(t *testing.T) {
 	pluginWithProcessedFiles := func(targetFile, name string, processedFiles []string) *mockScaPlugin {
 		return &mockScaPlugin{
-			result: &ecosystems.PluginResult{
-				Results: []ecosystems.SCAResult{{
-					DepGraph: createTestDepGraph(t, "pip", name, "1.0.0"),
-					ProjectDescriptor: identity.ProjectDescriptor{
-						Identity: identity.ProjectIdentity{TargetFile: stringPtr(targetFile)},
-					},
-					ResolverMetadata: &ecosystems.ResolverMetadata{
-						NormalisedTargetFile: targetFile,
-					},
-				}},
+			results: []ecosystems.SCAResult{{
+				DepGraph: createTestDepGraph(t, "pip", name, "1.0.0"),
+				ProjectDescriptor: identity.ProjectDescriptor{
+					Identity: identity.ProjectIdentity{TargetFile: stringPtr(targetFile)},
+				},
+				ResolverMetadata: &ecosystems.ResolverMetadata{
+					NormalisedTargetFile: targetFile,
+				},
 				ProcessedFiles: processedFiles,
-			},
+			}},
 		}
 	}
 
@@ -1789,7 +1742,7 @@ func Test_processedFilesFlowFromPluginsToExcludeConfig(t *testing.T) {
 			name:             "user --exclude-paths value alone when no plugin produced ProcessedFiles",
 			userExcludePaths: "user-supplied.txt",
 			plugins: func() []ecosystems.SCAPlugin {
-				return []ecosystems.SCAPlugin{&mockScaPlugin{result: &ecosystems.PluginResult{}}}
+				return []ecosystems.SCAPlugin{&mockScaPlugin{results: nil}}
 			},
 			expectedExcludePaths: "user-supplied.txt",
 		},
@@ -1829,18 +1782,16 @@ func Test_uvWorkspacePackages_passesOptionToPlugin(t *testing.T) {
 	ctx.config.Set(workflow.FlagFile, "uv.lock")
 
 	mockPlugin := &mockScaPlugin{
-		result: &ecosystems.PluginResult{
-			Results: []ecosystems.SCAResult{
-				{
-					DepGraph: createTestDepGraph(t, "uv", "pkg-a", "1.0.0"),
-					ProjectDescriptor: identity.ProjectDescriptor{
-						Identity: identity.ProjectIdentity{
-							TargetFile: stringPtr("pyproject.toml"),
-						},
+		results: []ecosystems.SCAResult{
+			{
+				DepGraph: createTestDepGraph(t, "uv", "pkg-a", "1.0.0"),
+				ProjectDescriptor: identity.ProjectDescriptor{
+					Identity: identity.ProjectIdentity{
+						TargetFile: stringPtr("pyproject.toml"),
 					},
-					ResolverMetadata: &ecosystems.ResolverMetadata{
-						NormalisedTargetFile: "pyproject.toml",
-					},
+				},
+				ResolverMetadata: &ecosystems.ResolverMetadata{
+					NormalisedTargetFile: "pyproject.toml",
 				},
 			},
 		},
@@ -1870,29 +1821,27 @@ func Test_uvWorkspacePackages_combinesMultipleDepGraphsAsJSONL(t *testing.T) {
 
 	mockPlugin := &mockScaPlugin{
 		name: uv.PluginName,
-		result: &ecosystems.PluginResult{
-			Results: []ecosystems.SCAResult{
-				{
-					DepGraph: createTestDepGraph(t, "uv", "pkg-a", "1.0.0"),
-					ProjectDescriptor: identity.ProjectDescriptor{
-						Identity: identity.ProjectIdentity{
-							TargetFile: stringPtr("pyproject.toml"),
-						},
-					},
-					ResolverMetadata: &ecosystems.ResolverMetadata{
-						NormalisedTargetFile: "pyproject.toml",
+		results: []ecosystems.SCAResult{
+			{
+				DepGraph: createTestDepGraph(t, "uv", "pkg-a", "1.0.0"),
+				ProjectDescriptor: identity.ProjectDescriptor{
+					Identity: identity.ProjectIdentity{
+						TargetFile: stringPtr("pyproject.toml"),
 					},
 				},
-				{
-					DepGraph: createTestDepGraph(t, "uv", "pkg-b", "2.0.0"),
-					ProjectDescriptor: identity.ProjectDescriptor{
-						Identity: identity.ProjectIdentity{
-							TargetFile: stringPtr("packages/pkg-b/pyproject.toml"),
-						},
+				ResolverMetadata: &ecosystems.ResolverMetadata{
+					NormalisedTargetFile: "pyproject.toml",
+				},
+			},
+			{
+				DepGraph: createTestDepGraph(t, "uv", "pkg-b", "2.0.0"),
+				ProjectDescriptor: identity.ProjectDescriptor{
+					Identity: identity.ProjectIdentity{
+						TargetFile: stringPtr("packages/pkg-b/pyproject.toml"),
 					},
-					ResolverMetadata: &ecosystems.ResolverMetadata{
-						NormalisedTargetFile: "packages/pkg-b/pyproject.toml",
-					},
+				},
+				ResolverMetadata: &ecosystems.ResolverMetadata{
+					NormalisedTargetFile: "packages/pkg-b/pyproject.toml",
 				},
 			},
 		},
@@ -1960,19 +1909,17 @@ func Test_uvWorkspacePackages_returnsErrorWhenFindingHasError(t *testing.T) {
 
 	mockPlugin := &mockScaPlugin{
 		name: uv.PluginName,
-		result: &ecosystems.PluginResult{
-			Results: []ecosystems.SCAResult{
-				{
-					ProjectDescriptor: identity.ProjectDescriptor{
-						Identity: identity.ProjectIdentity{
-							TargetFile: stringPtr("uv.lock"),
-						},
+		results: []ecosystems.SCAResult{
+			{
+				ProjectDescriptor: identity.ProjectDescriptor{
+					Identity: identity.ProjectIdentity{
+						TargetFile: stringPtr("uv.lock"),
 					},
-					ResolverMetadata: &ecosystems.ResolverMetadata{
-						NormalisedTargetFile: "uv.lock",
-					},
-					Error: snykErr,
 				},
+				ResolverMetadata: &ecosystems.ResolverMetadata{
+					NormalisedTargetFile: "uv.lock",
+				},
+				Error: snykErr,
 			},
 		},
 	}
@@ -2003,29 +1950,27 @@ func Test_uvWorkspacePackages_legacyResultsAppendedIndividually(t *testing.T) {
 
 	mockPlugin := &mockScaPlugin{
 		name: uv.PluginName,
-		result: &ecosystems.PluginResult{
-			Results: []ecosystems.SCAResult{
-				{
-					DepGraph: createTestDepGraph(t, "uv", "pkg-a", "1.0.0"),
-					ProjectDescriptor: identity.ProjectDescriptor{
-						Identity: identity.ProjectIdentity{
-							TargetFile: stringPtr("pyproject.toml"),
-						},
-					},
-					ResolverMetadata: &ecosystems.ResolverMetadata{
-						NormalisedTargetFile: "pyproject.toml",
+		results: []ecosystems.SCAResult{
+			{
+				DepGraph: createTestDepGraph(t, "uv", "pkg-a", "1.0.0"),
+				ProjectDescriptor: identity.ProjectDescriptor{
+					Identity: identity.ProjectIdentity{
+						TargetFile: stringPtr("pyproject.toml"),
 					},
 				},
-				{
-					DepGraph: createTestDepGraph(t, "uv", "pkg-b", "2.0.0"),
-					ProjectDescriptor: identity.ProjectDescriptor{
-						Identity: identity.ProjectIdentity{
-							TargetFile: stringPtr("packages/pkg-b/pyproject.toml"),
-						},
+				ResolverMetadata: &ecosystems.ResolverMetadata{
+					NormalisedTargetFile: "pyproject.toml",
+				},
+			},
+			{
+				DepGraph: createTestDepGraph(t, "uv", "pkg-b", "2.0.0"),
+				ProjectDescriptor: identity.ProjectDescriptor{
+					Identity: identity.ProjectIdentity{
+						TargetFile: stringPtr("packages/pkg-b/pyproject.toml"),
 					},
-					ResolverMetadata: &ecosystems.ResolverMetadata{
-						NormalisedTargetFile: "packages/pkg-b/pyproject.toml",
-					},
+				},
+				ResolverMetadata: &ecosystems.ResolverMetadata{
+					NormalisedTargetFile: "packages/pkg-b/pyproject.toml",
 				},
 			},
 		},
@@ -2079,26 +2024,24 @@ func Test_uvWorkspacePackages_legacyResultsAppendedIndividually(t *testing.T) {
 func Test_handleSBOMResolutionDI_perResultErrorMatrix(t *testing.T) {
 	pluginErroredResult := func() *mockScaPlugin {
 		return &mockScaPlugin{
-			result: &ecosystems.PluginResult{
-				Results: []ecosystems.SCAResult{
-					{
-						DepGraph: createTestDepGraph(t, "pip", "good", "1.0.0"),
-						ProjectDescriptor: identity.ProjectDescriptor{
-							Identity: identity.ProjectIdentity{TargetFile: stringPtr("good/requirements.txt")},
-						},
-						ResolverMetadata: &ecosystems.ResolverMetadata{
-							NormalisedTargetFile: "good/requirements.txt",
-						},
+			results: []ecosystems.SCAResult{
+				{
+					DepGraph: createTestDepGraph(t, "pip", "good", "1.0.0"),
+					ProjectDescriptor: identity.ProjectDescriptor{
+						Identity: identity.ProjectIdentity{TargetFile: stringPtr("good/requirements.txt")},
 					},
-					{
-						ProjectDescriptor: identity.ProjectDescriptor{
-							Identity: identity.ProjectIdentity{TargetFile: stringPtr("broken/requirements.txt")},
-						},
-						ResolverMetadata: &ecosystems.ResolverMetadata{
-							NormalisedTargetFile: "broken/requirements.txt",
-						},
-						Error: snyk_errors.Error{Title: "Resolution failed", Detail: "missing dep"},
+					ResolverMetadata: &ecosystems.ResolverMetadata{
+						NormalisedTargetFile: "good/requirements.txt",
 					},
+				},
+				{
+					ProjectDescriptor: identity.ProjectDescriptor{
+						Identity: identity.ProjectIdentity{TargetFile: stringPtr("broken/requirements.txt")},
+					},
+					ResolverMetadata: &ecosystems.ResolverMetadata{
+						NormalisedTargetFile: "broken/requirements.txt",
+					},
+					Error: snyk_errors.Error{Title: "Resolution failed", Detail: "missing dep"},
 				},
 			},
 		}
@@ -2156,8 +2099,8 @@ func Test_handleSBOMResolutionDI_perResultErrorMatrix(t *testing.T) {
 func Test_handleSBOMResolutionDI_noSupportedProjectsDetectedWhenAllPluginsReturnZero(t *testing.T) {
 	t.Run("two plugins both empty", func(t *testing.T) {
 		ctx := setupTestContext(t, true)
-		emptyPlugin1 := &mockScaPlugin{result: &ecosystems.PluginResult{}}
-		emptyPlugin2 := &mockScaPlugin{result: &ecosystems.PluginResult{}}
+		emptyPlugin1 := &mockScaPlugin{results: nil}
+		emptyPlugin2 := &mockScaPlugin{results: nil}
 
 		workflowData, err := handleSBOMResolutionDI(
 			ctx.invocationContext,
@@ -2176,7 +2119,7 @@ func Test_handleSBOMResolutionDI_noSupportedProjectsDetectedWhenAllPluginsReturn
 
 	t.Run("single empty plugin", func(t *testing.T) {
 		ctx := setupTestContext(t, true)
-		emptyPlugin := &mockScaPlugin{result: &ecosystems.PluginResult{}}
+		emptyPlugin := &mockScaPlugin{results: nil}
 
 		workflowData, err := handleSBOMResolutionDI(
 			ctx.invocationContext,
@@ -2197,21 +2140,19 @@ func Test_handleSBOMResolutionDI_noSupportedProjectsDetectedWhenAllPluginsReturn
 		ctx := setupTestContext(t, true)
 		ctx.config.Set(workflow.FlagAllProjects, true)
 		erroredPlugin := &mockScaPlugin{
-			result: &ecosystems.PluginResult{
-				Results: []ecosystems.SCAResult{
-					{
-						ProjectDescriptor: identity.ProjectDescriptor{
-							Identity: identity.ProjectIdentity{TargetFile: stringPtr("broken/pom.xml")},
-						},
-						ResolverMetadata: &ecosystems.ResolverMetadata{
-							NormalisedTargetFile: "broken/pom.xml",
-						},
-						Error: fmt.Errorf("module failed to resolve"),
+			results: []ecosystems.SCAResult{
+				{
+					ProjectDescriptor: identity.ProjectDescriptor{
+						Identity: identity.ProjectIdentity{TargetFile: stringPtr("broken/pom.xml")},
 					},
+					ResolverMetadata: &ecosystems.ResolverMetadata{
+						NormalisedTargetFile: "broken/pom.xml",
+					},
+					Error: fmt.Errorf("module failed to resolve"),
 				},
 			},
 		}
-		emptyPlugin := &mockScaPlugin{result: &ecosystems.PluginResult{}}
+		emptyPlugin := &mockScaPlugin{results: nil}
 
 		workflowData, err := handleSBOMResolutionDI(
 			ctx.invocationContext,

--- a/pkg/ecosystems/bazel/go_integration_test.go
+++ b/pkg/ecosystems/bazel/go_integration_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
 	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/logger"
+	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/scatest"
 )
 
 func assertGoProcessedFiles(t *testing.T, files []string) {
@@ -47,15 +48,24 @@ func runGoIntegrationSnapshot(t *testing.T, fixtures []string) {
 
 			opts := ecosystems.NewPluginOptions().WithBazelGo(true)
 			plugin := Plugin{}
-			result, err := plugin.BuildDepGraphsFromDir(ctx, logger.Nop(), root, opts)
+			results, err := scatest.Run(ctx, plugin, logger.Nop(), root, opts)
 			require.NoError(t, err)
 
-			// Paths differ by machine; assert filenames only, snapshot dep-graphs only.
-			assertGoProcessedFiles(t, result.ProcessedFiles)
+			// Paths differ by machine; assert filenames only, snapshot
+			// dep-graphs only. Bazel attaches the resolver-scope file list
+			// (WORKSPACE, MODULE.bazel, etc.) to every emitted result —
+			// any one of them carries the full list.
+			require.NotEmpty(t, results)
+			assertGoProcessedFiles(t, results[0].ProcessedFiles)
 
+			// ProcessedFiles is asserted above; null it out so the
+			// JSON snapshot doesn't capture host-specific paths.
+			for i := range results {
+				results[i].ProcessedFiles = nil
+			}
 			snaps.WithConfig(snaps.Dir(root)).MatchJSON(t, struct {
 				Results []ecosystems.SCAResult `json:"results"`
-			}{Results: result.Results})
+			}{Results: results})
 		})
 	}
 }

--- a/pkg/ecosystems/bazel/jvm_integration_test.go
+++ b/pkg/ecosystems/bazel/jvm_integration_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
 	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/logger"
+	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/scatest"
 )
 
 // Only run when BAZEL_JVM_INTEGRATION_TESTS=1 (needs Bazel on PATH; Android fixture needs ANDROID_HOME / SDK).
@@ -40,10 +41,10 @@ func TestPlugin_BuildDepGraphsFromDir_MatchJSON(t *testing.T) {
 
 			opts := ecosystems.NewPluginOptions().WithBazelJvm(true)
 			plugin := Plugin{}
-			result, err := plugin.BuildDepGraphsFromDir(ctx, logger.Nop(), root, opts)
+			results, err := scatest.Run(ctx, plugin, logger.Nop(), root, opts)
 			require.NoError(t, err)
 
-			snaps.WithConfig(snaps.Dir(root)).MatchJSON(t, result)
+			snaps.WithConfig(snaps.Dir(root)).MatchJSON(t, snapshotResults(results))
 		})
 	}
 }
@@ -56,10 +57,10 @@ func TestPlugin_BuildDepGraphsFromDir_NoOption_EmptyResult(t *testing.T) {
 
 	opts := ecosystems.NewPluginOptions() // no bazel option used
 	plugin := Plugin{}
-	result, err := plugin.BuildDepGraphsFromDir(ctx, logger.Nop(), "./", opts)
+	results, err := scatest.Run(ctx, plugin, logger.Nop(), "./", opts)
 
 	require.NoError(t, err)
-	require.Equal(t, &ecosystems.PluginResult{}, result)
+	require.Empty(t, results)
 }
 
 func TestPlugin_BuildDepGraphsFromDir_AndriodBinary_MatchJSON(t *testing.T) {
@@ -77,10 +78,10 @@ func TestPlugin_BuildDepGraphsFromDir_AndriodBinary_MatchJSON(t *testing.T) {
 		WithBazelTargetQuery("kind('android_binary', //...)") // override the default
 
 	plugin := Plugin{}
-	result, err := plugin.BuildDepGraphsFromDir(ctx, logger.Nop(), root, opts)
+	results, err := scatest.Run(ctx, plugin, logger.Nop(), root, opts)
 	require.NoError(t, err)
 
-	snaps.WithConfig(snaps.Dir(root)).MatchJSON(t, result)
+	snaps.WithConfig(snaps.Dir(root)).MatchJSON(t, snapshotResults(results))
 }
 
 func TestPlugin_BuildDepGraphsFromDir_JavaExport_MatchJSON(t *testing.T) {
@@ -98,10 +99,10 @@ func TestPlugin_BuildDepGraphsFromDir_JavaExport_MatchJSON(t *testing.T) {
 		WithBazelTargetQuery("kind('java_library', //...)") // override the default
 
 	plugin := Plugin{}
-	result, err := plugin.BuildDepGraphsFromDir(ctx, logger.Nop(), root, opts)
+	results, err := scatest.Run(ctx, plugin, logger.Nop(), root, opts)
 	require.NoError(t, err)
 
-	snaps.WithConfig(snaps.Dir(root)).MatchJSON(t, result)
+	snaps.WithConfig(snaps.Dir(root)).MatchJSON(t, snapshotResults(results))
 }
 
 func TestPlugin_BuildDepGraphsFromDir_ScalaBinary_MatchJSON(t *testing.T) {
@@ -119,8 +120,8 @@ func TestPlugin_BuildDepGraphsFromDir_ScalaBinary_MatchJSON(t *testing.T) {
 		WithBazelTargetQuery("kind('scala_binary', //...)") // override the default
 
 	plugin := Plugin{}
-	result, err := plugin.BuildDepGraphsFromDir(ctx, logger.Nop(), root, opts)
+	results, err := scatest.Run(ctx, plugin, logger.Nop(), root, opts)
 	require.NoError(t, err)
 
-	snaps.WithConfig(snaps.Dir(root)).MatchJSON(t, result)
+	snaps.WithConfig(snaps.Dir(root)).MatchJSON(t, snapshotResults(results))
 }

--- a/pkg/ecosystems/bazel/plugin.go
+++ b/pkg/ecosystems/bazel/plugin.go
@@ -32,7 +32,8 @@ func (p Plugin) BuildDepGraphsFromDir(
 	log logger.Logger,
 	dir string,
 	options *ecosystems.SCAPluginOptions,
-) (*ecosystems.PluginResult, error) {
+	onGraph func(ecosystems.SCAResult) error,
+) error {
 	if log == nil {
 		log = logger.Nop()
 	}
@@ -41,23 +42,28 @@ func (p Plugin) BuildDepGraphsFromDir(
 	if err != nil {
 		if errors.Is(err, errNoBazelOptionFound) {
 			log.Debug(ctx, "no bazel option found, skipping bazel dependency graph resolution")
-			return &ecosystems.PluginResult{}, nil
+			return nil
 		}
-		return nil, fmt.Errorf("failed to initialize bazel resolver: %w", err)
+		return fmt.Errorf("failed to initialize bazel resolver: %w", err)
 	}
 	log.Debug(ctx, "using bazel resolver", logger.Attr("type", resolver.packageManagerName()))
 
 	targets, err := resolver.findTargets(ctx, options)
 	if err != nil {
-		return nil, fmt.Errorf(errQueryBazelTargetsFmt, err)
+		return fmt.Errorf(errQueryBazelTargetsFmt, err)
 	}
 	log.Debug(ctx, "found bazel targets", logger.Attr("targets", targets))
 
 	if err := checkTargetLimit(len(targets), options); err != nil {
-		return nil, err
+		return err
 	}
 
-	var results []ecosystems.SCAResult
+	// processedFiles for the bazel resolver is computed at the resolver
+	// scope (WORKSPACE, MODULE.bazel, etc.), not per target. Attach to
+	// every emitted result; downstream consumers dedup.
+	processed := resolver.processedFiles()
+
+	emitted := 0
 	for _, target := range targets {
 		graph, err := resolver.buildDepGraph(ctx, target)
 		if err != nil {
@@ -66,7 +72,7 @@ func (p Plugin) BuildDepGraphsFromDir(
 		}
 		log.Debug(ctx, "resolved dep-graph for bazel target", logger.Attr("target", target))
 
-		results = append(results, ecosystems.SCAResult{
+		if err := onGraph(ecosystems.SCAResult{
 			DepGraph: graph,
 			ProjectDescriptor: identity.ProjectDescriptor{
 				Identity: identity.ProjectIdentity{
@@ -78,18 +84,18 @@ func (p Plugin) BuildDepGraphsFromDir(
 				PluginName:           pluginName,
 				NormalisedTargetFile: target,
 			},
-			Error: err,
-		})
+			ProcessedFiles: processed,
+		}); err != nil {
+			return err
+		}
+		emitted++
 	}
 
-	if len(results) == 0 {
+	if emitted == 0 {
 		log.Debug(ctx, "no bazel dependency graphs resolved")
 	}
 
-	return &ecosystems.PluginResult{
-		Results:        results,
-		ProcessedFiles: resolver.processedFiles(),
-	}, nil
+	return nil
 }
 
 // checkTargetLimit returns an error when the number of discovered targets

--- a/pkg/ecosystems/bazel/plugin.go
+++ b/pkg/ecosystems/bazel/plugin.go
@@ -32,7 +32,7 @@ func (p Plugin) BuildDepGraphsFromDir(
 	log logger.Logger,
 	dir string,
 	options *ecosystems.SCAPluginOptions,
-	onGraph func(ecosystems.SCAResult) error,
+	onGraph ecosystems.OnGraphFunc,
 ) error {
 	if log == nil {
 		log = logger.Nop()

--- a/pkg/ecosystems/bazel/testhelpers_test.go
+++ b/pkg/ecosystems/bazel/testhelpers_test.go
@@ -1,0 +1,24 @@
+package bazel
+
+import (
+	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
+)
+
+// snapshotResults wraps results in the shape JSON snapshot tests
+// compare against. ProcessedFiles is asserted by tests that care
+// (assertGoProcessedFiles, etc.); the snapshot keeps an empty list
+// so host-specific paths don't leak into the golden file.
+func snapshotResults(results []ecosystems.SCAResult) any {
+	cleaned := make([]ecosystems.SCAResult, len(results))
+	copy(cleaned, results)
+	for i := range cleaned {
+		cleaned[i].ProcessedFiles = nil
+	}
+	return struct {
+		Results        []ecosystems.SCAResult `json:"results"`
+		ProcessedFiles []string               `json:"processedFiles"`
+	}{
+		Results:        cleaned,
+		ProcessedFiles: []string{},
+	}
+}

--- a/pkg/ecosystems/gradle/plugin.go
+++ b/pkg/ecosystems/gradle/plugin.go
@@ -54,7 +54,7 @@ func (p Plugin) GetName() string {
 //     yields one SCAResult.  Use --gradle-sub-project to filter to a single one.
 func (p Plugin) BuildDepGraphsFromDir(
 	ctx context.Context, log logger.Logger, dir string, options *ecosystems.SCAPluginOptions,
-	onGraph func(ecosystems.SCAResult) error,
+	onGraph ecosystems.OnGraphFunc,
 ) error {
 	if log == nil {
 		log = logger.Nop()
@@ -126,7 +126,7 @@ func (p Plugin) processGradleFiles(
 	files []discovery.FindResult,
 	dir string,
 	options *ecosystems.SCAPluginOptions,
-	onGraph func(ecosystems.SCAResult) error,
+	onGraph ecosystems.OnGraphFunc,
 ) error {
 	// Create a copy to avoid mutating the original slice, then sort by path depth to process parent directories first
 	filesCopy := make([]discovery.FindResult, len(files))
@@ -189,7 +189,7 @@ func (p Plugin) processGradleFile(
 	dir, initScriptPath string,
 	extraArgs []string,
 	options *ecosystems.SCAPluginOptions,
-	onGraph func(ecosystems.SCAResult) error,
+	onGraph ecosystems.OnGraphFunc,
 ) ([]string, error) {
 	projectDir := filepath.Dir(discoveredFile.Path)
 
@@ -277,7 +277,7 @@ func (p Plugin) convertProjects(
 	dir string,
 	discoveredBuildFile string,
 	options *ecosystems.SCAPluginOptions,
-	onGraph func(ecosystems.SCAResult) error,
+	onGraph ecosystems.OnGraphFunc,
 ) ([]string, error) {
 	subProject := options.Gradle.SubProject
 

--- a/pkg/ecosystems/gradle/plugin.go
+++ b/pkg/ecosystems/gradle/plugin.go
@@ -54,33 +54,26 @@ func (p Plugin) GetName() string {
 //     yields one SCAResult.  Use --gradle-sub-project to filter to a single one.
 func (p Plugin) BuildDepGraphsFromDir(
 	ctx context.Context, log logger.Logger, dir string, options *ecosystems.SCAPluginOptions,
-) (*ecosystems.PluginResult, error) {
+	onGraph func(ecosystems.SCAResult) error,
+) error {
 	if log == nil {
 		log = logger.Nop()
 	}
 
 	if err := ValidateOptions(dir, options); err != nil {
-		return nil, fmt.Errorf("gradle: invalid options: %w", err)
+		return fmt.Errorf("gradle: invalid options: %w", err)
 	}
 
 	files, err := p.discoverGradleFiles(ctx, dir, options)
 	if err != nil {
-		return nil, fmt.Errorf("gradle: failed to discover files: %w", err)
+		return fmt.Errorf("gradle: failed to discover files: %w", err)
 	}
 	if len(files) == 0 {
 		log.Debug(ctx, "No Gradle files found, skipping", logger.Attr("dir", dir))
-		return &ecosystems.PluginResult{}, nil
+		return nil
 	}
 
-	allResults, allProcessedFiles, err := p.processGradleFiles(ctx, log, files, dir, options)
-	if err != nil {
-		return nil, err
-	}
-
-	return &ecosystems.PluginResult{
-		Results:        allResults,
-		ProcessedFiles: allProcessedFiles,
-	}, nil
+	return p.processGradleFiles(ctx, log, files, dir, options, onGraph)
 }
 
 // discoverGradleFiles discovers Gradle build files based on the provided options.
@@ -133,7 +126,8 @@ func (p Plugin) processGradleFiles(
 	files []discovery.FindResult,
 	dir string,
 	options *ecosystems.SCAPluginOptions,
-) ([]ecosystems.SCAResult, []string, error) {
+	onGraph func(ecosystems.SCAResult) error,
+) error {
 	// Create a copy to avoid mutating the original slice, then sort by path depth to process parent directories first
 	filesCopy := make([]discovery.FindResult, len(files))
 	copy(filesCopy, files)
@@ -143,13 +137,11 @@ func (p Plugin) processGradleFiles(
 		return depthI < depthJ
 	})
 
-	var allResults []ecosystems.SCAResult
-	var allProcessedFiles []string
 	processedDirs := make(map[string]bool)
 
 	initScriptPath, cleanup, err := resolveInitScript()
 	if err != nil {
-		return nil, nil, fmt.Errorf("gradle: failed to prepare init script: %w", err)
+		return fmt.Errorf("gradle: failed to prepare init script: %w", err)
 	}
 	defer cleanup()
 
@@ -167,13 +159,10 @@ func (p Plugin) processGradleFiles(
 			continue
 		}
 
-		results, processedFiles, err := p.processGradleFile(ctx, log, discoveredFile, dir, initScriptPath, extraArgs, options)
+		processedFiles, err := p.processGradleFile(ctx, log, discoveredFile, dir, initScriptPath, extraArgs, options, onGraph)
 		if err != nil {
-			return nil, nil, err
+			return err
 		}
-
-		allResults = append(allResults, results...)
-		allProcessedFiles = append(allProcessedFiles, processedFiles...)
 
 		// Mark all directories that were processed by this Gradle run
 		for _, processedFile := range processedFiles {
@@ -185,12 +174,14 @@ func (p Plugin) processGradleFiles(
 		processedDirs[relativeProjectDir] = true
 	}
 
-	return allResults, allProcessedFiles, nil
+	return nil
 }
 
-// processGradleFile processes a single discovered Gradle file.
-// Returns the SCA results, processed file paths, and any fatal error.
-// Soft errors (binary resolution, gradle execution) are returned as SCAResult with Error field.
+// processGradleFile processes a single discovered Gradle file. Soft
+// errors (binary resolution, gradle execution) are emitted as
+// SCAResult with Error field via onGraph; fatal errors are returned.
+// Returns the list of processed file paths so the caller can dedup
+// future Gradle runs against directories we've already covered.
 func (p Plugin) processGradleFile(
 	ctx context.Context,
 	log logger.Logger,
@@ -198,7 +189,8 @@ func (p Plugin) processGradleFile(
 	dir, initScriptPath string,
 	extraArgs []string,
 	options *ecosystems.SCAPluginOptions,
-) ([]ecosystems.SCAResult, []string, error) {
+	onGraph func(ecosystems.SCAResult) error,
+) ([]string, error) {
 	projectDir := filepath.Dir(discoveredFile.Path)
 
 	// Try to resolve Gradle binary first - if it fails, add error result
@@ -207,9 +199,8 @@ func (p Plugin) processGradleFile(
 		log.Error(ctx, "Gradle binary resolution failed",
 			logger.Attr(logAttrProjectDir, projectDir),
 			logger.Err(err))
-		// Return error result - not a fatal error
-		errResult := gradleErrorResult(dir, discoveredFile.Path, fmt.Errorf("binary resolution failed: %w", err))
-		return []ecosystems.SCAResult{errResult}, nil, nil
+		// Soft error — emit as a result with Error set.
+		return nil, onGraph(gradleErrorResult(dir, discoveredFile.Path, fmt.Errorf("binary resolution failed: %w", err)))
 	}
 
 	// Check if we discovered a settings file (project root) vs build file (scan target)
@@ -226,15 +217,14 @@ func (p Plugin) processGradleFile(
 		log.Error(ctx, "Gradle execution failed",
 			logger.Attr(logAttrProjectDir, projectDir),
 			logger.Err(err))
-		// Return error result - not a fatal error
-		errResult := gradleErrorResult(dir, discoveredFile.Path, err)
-		return []ecosystems.SCAResult{errResult}, nil, nil
+		// Soft error — emit as a result with Error set.
+		return nil, onGraph(gradleErrorResult(dir, discoveredFile.Path, err))
 	}
 	defer reader.Close()
 
 	parsed, err := parseDependencyGraphJSON(reader)
 	if err != nil {
-		return nil, nil, fmt.Errorf("gradle: failed to parse init script output: %w", err)
+		return nil, fmt.Errorf("gradle: failed to parse init script output: %w", err)
 	}
 
 	// For settings files, don't pass them as build file fallback since they're not scan targets
@@ -243,8 +233,7 @@ func (p Plugin) processGradleFile(
 		buildFileForFallback = "" // Let Gradle init script determine actual build files
 	}
 
-	results, processedFiles := p.convertProjects(ctx, log, parsed, dir, buildFileForFallback, options)
-	return results, processedFiles, nil
+	return p.convertProjects(ctx, log, parsed, dir, buildFileForFallback, options, onGraph)
 }
 
 // discoverAllGradleProjects finds all Gradle files recursively for --all-projects.
@@ -273,8 +262,10 @@ func (p Plugin) discoverAllGradleProjects(ctx context.Context, dir string, optio
 	return files, nil
 }
 
-// convertProjects maps every gradleProject from the parsed JSON into an
-// SCAResult, optionally filtering by --gradle-sub-project.
+// convertProjects maps every gradleProject from the parsed JSON to an
+// SCAResult (optionally filtering by --gradle-sub-project), emitting
+// each via onGraph. Returns the list of relative file paths actually
+// emitted so the caller's directory-dedup map stays accurate.
 //
 // dir is the original scan root used to compute relative target file paths,
 // matching the behavior of the legacy snyk-gradle-plugin in --all-sub-projects
@@ -286,7 +277,8 @@ func (p Plugin) convertProjects(
 	dir string,
 	discoveredBuildFile string,
 	options *ecosystems.SCAPluginOptions,
-) (results []ecosystems.SCAResult, processedFiles []string) {
+	onGraph func(ecosystems.SCAResult) error,
+) ([]string, error) {
 	subProject := options.Gradle.SubProject
 
 	// Convert target file to absolute path for comparison when filtering
@@ -298,6 +290,8 @@ func (p Plugin) convertProjects(
 			targetFileAbs = filepath.Join(dir, *options.Global.TargetFile)
 		}
 	}
+
+	var processedFiles []string
 
 	// Iterate projects in Gradle evaluation order (preserved by the array format).
 	// The init script outputs projects via root.allprojects.each, which visits
@@ -345,7 +339,7 @@ func (p Plugin) convertProjects(
 			log.Error(ctx, "Failed to build dep graph for Gradle project",
 				logger.Attr("project_path", proj.Path),
 				logger.Err(err))
-			results = append(results, ecosystems.SCAResult{
+			if emitErr := onGraph(ecosystems.SCAResult{
 				ProjectDescriptor: identity.ProjectDescriptor{
 					Identity: identity.ProjectIdentity{
 						ProjectType: "gradle",
@@ -354,8 +348,9 @@ func (p Plugin) convertProjects(
 				},
 				Error:            err,
 				ResolverMetadata: &resolverMetadata,
-			})
-
+			}); emitErr != nil {
+				return processedFiles, emitErr
+			}
 			continue
 		}
 
@@ -367,7 +362,7 @@ func (p Plugin) convertProjects(
 			rootName = rootPkg.Info.Name
 		}
 
-		results = append(results, ecosystems.SCAResult{
+		if emitErr := onGraph(ecosystems.SCAResult{
 			DepGraph: depGraph,
 			ProjectDescriptor: identity.ProjectDescriptor{
 				Identity: identity.ProjectIdentity{
@@ -377,11 +372,14 @@ func (p Plugin) convertProjects(
 				},
 			},
 			ResolverMetadata: &resolverMetadata,
-		})
+			ProcessedFiles:   []string{relFile},
+		}); emitErr != nil {
+			return processedFiles, emitErr
+		}
 		processedFiles = append(processedFiles, relFile)
 	}
 
-	return results, processedFiles
+	return processedFiles, nil
 }
 
 // relativeTargetFile returns absFile as a path relative to dir.

--- a/pkg/ecosystems/gradle/plugin_integration_test.go
+++ b/pkg/ecosystems/gradle/plugin_integration_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
 	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/logger"
 	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/metadata"
+	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/scatest"
 )
 
 // updateFixturesEnvVar, when set to a truthy value, causes the integration tests
@@ -266,16 +267,16 @@ func TestGradleWrapper_BinaryResolution(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result, err := plugin.BuildDepGraphsFromDir(ctx, logger.Nop(), absFixture, tc.options)
+			results, err := scatest.Run(ctx, plugin, logger.Nop(), absFixture, tc.options)
 
 			require.NoError(t, err, "gradle execution should succeed")
-			require.Len(t, result.Results, 1, "should process one project")
+			require.Len(t, results, 1, "should process one project")
 
 			// Assert gradle version from ResolverMetadata
-			require.NotNil(t, result.Results[0].ResolverMetadata, "metadata should be populated")
-			require.NotNil(t, result.Results[0].ResolverMetadata.VersionBuildInfo, "version build info should be populated")
+			require.NotNil(t, results[0].ResolverMetadata, "metadata should be populated")
+			require.NotNil(t, results[0].ResolverMetadata.VersionBuildInfo, "version build info should be populated")
 
-			actualGradleVersion := result.Results[0].ResolverMetadata.VersionBuildInfo[metadata.GradleVersion]
+			actualGradleVersion := results[0].ResolverMetadata.VersionBuildInfo[metadata.GradleVersion]
 			expectedVersion := tc.expectedVersionFunc()
 			if expectedVersion == "" {
 				t.Fatalf("failed to get expected gradle version for test case %q", tc.name)
@@ -283,8 +284,8 @@ func TestGradleWrapper_BinaryResolution(t *testing.T) {
 			assert.Equal(t, expectedVersion, actualGradleVersion, tc.versionDescription)
 
 			// Ensure basic execution works
-			assert.Equal(t, "com.snyk.fixtures:with-wrapper", result.Results[0].ProjectDescriptor.Identity.RootComponentName)
-			require.NotNil(t, result.Results[0].DepGraph, "dependency graph should be built")
+			assert.Equal(t, "com.snyk.fixtures:with-wrapper", results[0].ProjectDescriptor.Identity.RootComponentName)
+			require.NotNil(t, results[0].DepGraph, "dependency graph should be built")
 		})
 	}
 }
@@ -320,12 +321,12 @@ func TestPlugin_BuildDepGraphsFromDir(t *testing.T) {
 			defer cancel()
 
 			plugin := Plugin{}
-			result, err := plugin.BuildDepGraphsFromDir(ctx, logger.Nop(), absFixture, testCase.Options)
+			results, err := scatest.Run(ctx, plugin, logger.Nop(), absFixture, testCase.Options)
 			require.NoError(t, err, "BuildDepGraphsFromDir should not return error")
-			require.NotNil(t, result, "plugin result should not be nil")
+			require.NotEmpty(t, results, "plugin must emit at least one result")
 
 			if updateFixtures {
-				writeExpectedSnapshot(t, filepath.Join(fixturePath, defaultExpectedFileName(testCase)), result.Results)
+				writeExpectedSnapshot(t, filepath.Join(fixturePath, defaultExpectedFileName(testCase)), results)
 				return
 			}
 
@@ -333,7 +334,7 @@ func TestPlugin_BuildDepGraphsFromDir(t *testing.T) {
 			require.NoErrorf(t, err, "no expected snapshot for fixture %q; run with %s=1 to generate", testCase.Fixture, updateFixturesEnvVar)
 
 			expected := loadExpectedResults(t, expectedPath)
-			assertResultsMatchExpected(t, result.Results, expected, testCase.Fixture)
+			assertResultsMatchExpected(t, results, expected, testCase.Fixture)
 		})
 	}
 }
@@ -441,6 +442,9 @@ func assertResultsMatchExpected(t *testing.T, actual, expected []ecosystems.SCAR
 		sortedActual[i].Error = nil
 		// ResolverMetadata contains runtime-specific info and is not part of the snapshot format.
 		sortedActual[i].ResolverMetadata = nil
+		// ProcessedFiles is implementation detail; per-graph attribution
+		// is verified separately.
+		sortedActual[i].ProcessedFiles = nil
 	}
 
 	actualJSON, err := json.Marshal(sortedActual)

--- a/pkg/ecosystems/gradle/plugin_test.go
+++ b/pkg/ecosystems/gradle/plugin_test.go
@@ -478,7 +478,7 @@ func TestTargetFileFiltering_MockedOutput(t *testing.T) {
 			Global: ecosystems.GlobalOptions{},
 		}
 
-		allResults, allFiles := p.convertProjects(ctx, log, parsed, "/project", "", optsAll)
+		allResults, allFiles := collectConvert(ctx, p, log, parsed, "/project", "", optsAll)
 		assert.Len(t, allResults, 3, "Without target file, should return all projects")
 		assert.Len(t, allFiles, 3)
 
@@ -507,7 +507,7 @@ func TestTargetFileFiltering_MockedOutput(t *testing.T) {
 			Global: ecosystems.GlobalOptions{TargetFile: &targetFile},
 		}
 
-		targetedResults, targetedFiles := p.convertProjects(ctx, log, parsed, "/project", "", optsTargeted)
+		targetedResults, targetedFiles := collectConvert(ctx, p, log, parsed, "/project", "", optsTargeted)
 		assert.Len(t, targetedResults, 1, "With target file, should return only matching project")
 		assert.Len(t, targetedFiles, 1)
 
@@ -554,7 +554,7 @@ func TestTargetFileFiltering_MockedOutput(t *testing.T) {
 			Global: ecosystems.GlobalOptions{TargetFile: &targetFile},
 		}
 
-		results, files := p.convertProjects(ctx, log, parsed, "/project", "", opts)
+		results, files := collectConvert(ctx, p, log, parsed, "/project", "", opts)
 		assert.Len(t, results, 1, "Should return only the lib project")
 		assert.Len(t, files, 1)
 
@@ -601,7 +601,7 @@ func TestTargetFileFiltering_MockedOutput(t *testing.T) {
 			Global: ecosystems.GlobalOptions{TargetFile: &targetFile},
 		}
 
-		results, files := p.convertProjects(ctx, log, parsed, "/project", "", opts)
+		results, files := collectConvert(ctx, p, log, parsed, "/project", "", opts)
 		assert.Len(t, results, 0, "Should return no results when no project matches")
 		assert.Len(t, files, 0)
 	})

--- a/pkg/ecosystems/gradle/testhelpers_test.go
+++ b/pkg/ecosystems/gradle/testhelpers_test.go
@@ -1,0 +1,32 @@
+package gradle
+
+import (
+	"context"
+
+	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
+	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/logger"
+)
+
+// collectConvert drains convertProjects's streaming emit into a slice.
+// Some unit tests bypass the public plugin interface to exercise
+// convertProjects directly.
+//
+//nolint:unused // used by !integration-tagged plugin_test.go.
+func collectConvert(
+	ctx context.Context,
+	p Plugin,
+	log logger.Logger,
+	parsed *dependencyGraphJSON,
+	dir, discoveredBuildFile string,
+	opts *ecosystems.SCAPluginOptions,
+) ([]ecosystems.SCAResult, []string) {
+	var results []ecosystems.SCAResult
+	files, err := p.convertProjects(ctx, log, parsed, dir, discoveredBuildFile, opts, func(r ecosystems.SCAResult) error {
+		results = append(results, r)
+		return nil
+	})
+	if err != nil {
+		panic(err) // unreachable: the collector never returns an error.
+	}
+	return results, files
+}

--- a/pkg/ecosystems/gradle/validation_test.go
+++ b/pkg/ecosystems/gradle/validation_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
 	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/logger"
+	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/scatest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -233,9 +234,9 @@ func TestValidateOptions_Integration_BuildDepGraphsFromDir(t *testing.T) {
 		plugin := Plugin{}
 
 		// This should fail fast during validation, before any file discovery or Gradle execution
-		result, err := plugin.BuildDepGraphsFromDir(ctx, log, dir, options)
+		results, err := scatest.Run(ctx, plugin, log, dir, options)
 		require.Error(t, err)
-		assert.Nil(t, result)
+		assert.Empty(t, results)
 		assert.Contains(t, err.Error(), "gradle: invalid options:")
 		assert.Contains(t, err.Error(), "invalid --configuration-matching regex pattern")
 		assert.Contains(t, err.Error(), "[invalid-regex")
@@ -254,9 +255,9 @@ func TestValidateOptions_Integration_BuildDepGraphsFromDir(t *testing.T) {
 		plugin := Plugin{}
 
 		// This should fail fast during validation, before any file discovery
-		result, err := plugin.BuildDepGraphsFromDir(ctx, log, dir, options)
+		results, err := scatest.Run(ctx, plugin, log, dir, options)
 		require.Error(t, err)
-		assert.Nil(t, result)
+		assert.Empty(t, results)
 		assert.Contains(t, err.Error(), "gradle: invalid options:")
 		assert.Contains(t, err.Error(), "user init script not found")
 	})
@@ -274,9 +275,9 @@ func TestValidateOptions_Integration_BuildDepGraphsFromDir(t *testing.T) {
 		plugin := Plugin{}
 
 		// This should fail fast during validation, before any file discovery or Gradle execution
-		result, err := plugin.BuildDepGraphsFromDir(ctx, log, dir, options)
+		results, err := scatest.Run(ctx, plugin, log, dir, options)
 		require.Error(t, err)
-		assert.Nil(t, result)
+		assert.Empty(t, results)
 		assert.Contains(t, err.Error(), "gradle: invalid options:")
 		assert.Contains(t, err.Error(), "--configuration-attributes")
 		assert.Contains(t, err.Error(), "has empty value")

--- a/pkg/ecosystems/javascript/bun/acceptance_test.go
+++ b/pkg/ecosystems/javascript/bun/acceptance_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
 	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/javascript/bun"
 	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/logger"
+	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/scatest"
 )
 
 type acceptanceFixture struct {
@@ -91,13 +92,13 @@ func runAcceptanceSuite(t *testing.T, fixtureDir string, opts *ecosystems.SCAPlu
 		}
 
 		t.Run(fx.name, func(t *testing.T) {
-			result, err := plugin.BuildDepGraphsFromDir(t.Context(), nil, fx.dir, opts)
+			results, err := scatest.Run(t.Context(), plugin, nil, fx.dir, opts)
 			require.NoError(t, err)
-			require.Len(t, result.Results, 1)
-			require.NoError(t, result.Results[0].Error)
+			require.Len(t, results, 1)
+			require.NoError(t, results[0].Error)
 
 			if *updateGolden {
-				data, writeErr := json.MarshalIndent(result.Results[0].DepGraph, "", "  ")
+				data, writeErr := json.MarshalIndent(results[0].DepGraph, "", "  ")
 				require.NoError(t, writeErr, "marshaling dep graph")
 				writeErr = os.WriteFile(filepath.Join(fx.dir, "expected.json"), append(data, '\n'), 0o600)
 				require.NoError(t, writeErr, "writing expected.json")
@@ -111,11 +112,11 @@ func runAcceptanceSuite(t *testing.T, fixtureDir string, opts *ecosystems.SCAPlu
 			expected, err := depgraph.UnmarshalJSON(raw)
 			require.NoError(t, err, "parsing expected.json")
 
-			assert.Equal(t, normalizedJSON(expected), normalizedJSON(result.Results[0].DepGraph))
+			assert.Equal(t, normalizedJSON(expected), normalizedJSON(results[0].DepGraph))
 
 			// Every package in bun.lock must appear across all dep graphs.
 			// Workspace packages appear in their own dep graph, not the root's.
-			allPkgs := allResultPkgs(result.Results)
+			allPkgs := allResultPkgs(results)
 			assertLockfileCompleteness(t, fx.dir, allPkgs)
 		})
 	}
@@ -192,18 +193,18 @@ func TestAcceptance_Workspaces(t *testing.T) {
 		t.Run(tt.fixture, func(t *testing.T) {
 			dir := filepath.Join("testdata", "acceptance", tt.fixture)
 
-			result, err := plugin.BuildDepGraphsFromDir(t.Context(), nil, dir, &ecosystems.SCAPluginOptions{})
+			results, err := scatest.Run(t.Context(), plugin, nil, dir, &ecosystems.SCAPluginOptions{})
 			require.NoError(t, err)
-			require.Greater(t, len(result.Results), 1)
-			require.Len(t, result.Results, len(tt.graphs))
+			require.Greater(t, len(results), 1)
+			require.Len(t, results, len(tt.graphs))
 
-			for _, r := range result.Results {
+			for _, r := range results {
 				require.NoError(t, r.Error)
 			}
 
 			// Index results by root package name for golden-file lookup.
-			byRoot := make(map[string]*depgraph.DepGraph, len(result.Results))
-			for _, r := range result.Results {
+			byRoot := make(map[string]*depgraph.DepGraph, len(results))
+			for _, r := range results {
 				byRoot[r.DepGraph.GetRootPkg().Info.Name] = r.DepGraph
 			}
 
@@ -219,7 +220,7 @@ func TestAcceptance_Workspaces(t *testing.T) {
 					t.Logf("updated %s/%s", tt.fixture, gc.golden)
 				}
 
-				assertLockfileCompleteness(t, dir, allResultPkgs(result.Results))
+				assertLockfileCompleteness(t, dir, allResultPkgs(results))
 				return
 			}
 
@@ -236,7 +237,7 @@ func TestAcceptance_Workspaces(t *testing.T) {
 				assert.Equal(t, normalizedJSON(expected), normalizedJSON(dg), "mismatch in %s", gc.golden)
 			}
 
-			assertLockfileCompleteness(t, dir, allResultPkgs(result.Results))
+			assertLockfileCompleteness(t, dir, allResultPkgs(results))
 		})
 	}
 }
@@ -251,9 +252,9 @@ func TestInvalidPackageJSON(t *testing.T) {
 
 	dir := filepath.Join("testdata", "acceptance", "invalid-pkg-json")
 
-	result, err := plugin.BuildDepGraphsFromDir(t.Context(), nil, dir, opts)
+	results, err := scatest.Run(t.Context(), plugin, nil, dir, opts)
 	require.NoError(t, err)
-	assert.Empty(t, result.Results)
+	assert.Empty(t, results)
 }
 
 // assertLockfileCompleteness verifies that every package resolved in bun.lock
@@ -331,12 +332,12 @@ func TestBundledDepsVisibleInBunWhy(t *testing.T) {
 	plugin := bun.Plugin{}
 	dir := filepath.Join("testdata", "bundled-deps")
 
-	result, err := plugin.BuildDepGraphsFromDir(t.Context(), nil, dir, &ecosystems.SCAPluginOptions{})
+	results, err := scatest.Run(t.Context(), plugin, nil, dir, &ecosystems.SCAPluginOptions{})
 	require.NoError(t, err)
-	require.Len(t, result.Results, 1)
-	require.NoError(t, result.Results[0].Error)
+	require.Len(t, results, 1)
+	require.NoError(t, results[0].Error)
 
-	missing := lockfilePackagesMissingFromGraph(t, dir, allResultPkgs(result.Results))
+	missing := lockfilePackagesMissingFromGraph(t, dir, allResultPkgs(results))
 	if len(missing) == 0 {
 		// bun has fixed the bug — remove the t.Skipf below and close the issue.
 		return
@@ -409,7 +410,7 @@ func TestAcceptanceNoUnrecognizedLines(t *testing.T) {
 	for _, fx := range discoverFixtures(t, filepath.Join("testdata", "acceptance")) {
 		t.Run(fx.name, func(t *testing.T) {
 			log := &recordingLogger{}
-			_, err := plugin.BuildDepGraphsFromDir(t.Context(), log, fx.dir, &ecosystems.SCAPluginOptions{})
+			_, err := scatest.Run(t.Context(), plugin, log, fx.dir, &ecosystems.SCAPluginOptions{})
 			require.NoError(t, err)
 			log.assertNoUnrecognizedLines(t)
 		})

--- a/pkg/ecosystems/javascript/bun/plugin.go
+++ b/pkg/ecosystems/javascript/bun/plugin.go
@@ -35,58 +35,60 @@ func (p Plugin) GetName() string {
 // BuildDepGraphsFromDir discovers bun.lock files under dir and produces dep
 // graphs for each one. Workspace projects yield one SCAResult per workspace
 // package plus one for the root; non-workspace projects yield a single result.
+//
+// Each result is emitted via onGraph as soon as it's built — the plugin
+// holds at most one lockfile's worth of results in memory at any time.
 func (p Plugin) BuildDepGraphsFromDir(
 	ctx context.Context,
 	log logger.Logger,
 	dir string,
 	options *ecosystems.SCAPluginOptions,
-) (*ecosystems.PluginResult, error) {
+	onGraph func(ecosystems.SCAResult) error,
+) error {
 	if log == nil {
 		log = logger.Nop()
 	}
 
 	files, err := p.discoverLockFiles(ctx, dir, options)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	if len(files) == 0 {
 		log.Debug(ctx, "No bun.lock files found", logger.Attr("dir", dir))
-		return &ecosystems.PluginResult{}, nil
+		return nil
 	}
 
 	log.Debug(ctx, "Discovered bun.lock files", logger.Attr("count", len(files)))
 
 	exec := p.getExecutor()
 
-	var results []ecosystems.SCAResult
-	var processedFiles []string
-
 	for _, file := range files {
 		lockFileAbsDir := filepath.Dir(file.Path)
 
 		fileResults := p.buildResults(ctx, log, file.RelPath, lockFileAbsDir, exec)
-		for _, r := range fileResults {
+		// All results from one lockfile share the lockfile in their
+		// ProcessedFiles list; per-result entries also include their
+		// own target file when known.
+		for i := range fileResults {
+			r := &fileResults[i]
 			if r.Error != nil {
 				log.Error(ctx, "Failed to build bun dependency graph",
 					logger.Attr(logFieldLockFile, file.RelPath),
 					logger.Err(r.Error),
 				)
 			}
-		}
-		results = append(results, fileResults...)
-		processedFiles = append(processedFiles, file.RelPath)
-		for _, r := range fileResults {
-			if tf := r.ProjectDescriptor.GetTargetFile(); tf != "" {
-				processedFiles = append(processedFiles, tf)
+			r.ProcessedFiles = append(r.ProcessedFiles, file.RelPath)
+			if tf := r.ProjectDescriptor.GetTargetFile(); tf != "" && tf != file.RelPath {
+				r.ProcessedFiles = append(r.ProcessedFiles, tf)
+			}
+			if err := onGraph(*r); err != nil {
+				return err
 			}
 		}
 	}
 
-	return &ecosystems.PluginResult{
-		Results:        results,
-		ProcessedFiles: processedFiles,
-	}, nil
+	return nil
 }
 
 func (p Plugin) buildResults(

--- a/pkg/ecosystems/javascript/bun/plugin.go
+++ b/pkg/ecosystems/javascript/bun/plugin.go
@@ -43,7 +43,7 @@ func (p Plugin) BuildDepGraphsFromDir(
 	log logger.Logger,
 	dir string,
 	options *ecosystems.SCAPluginOptions,
-	onGraph func(ecosystems.SCAResult) error,
+	onGraph ecosystems.OnGraphFunc,
 ) error {
 	if log == nil {
 		log = logger.Nop()

--- a/pkg/ecosystems/javascript/bun/plugin_test.go
+++ b/pkg/ecosystems/javascript/bun/plugin_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
 	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/logger"
+	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/scatest"
 )
 
 // testFindResultByRoot finds the SCAResult whose root package name equals rootName.
@@ -60,12 +61,13 @@ func TestPlugin_Simple(t *testing.T) {
 	plugin := newPlugin(&fakeExecutor{outputFile: "testdata/simple/why_output.txt"})
 	opts := ecosystems.NewPluginOptions()
 
-	result, err := plugin.BuildDepGraphsFromDir(context.Background(), logger.Nop(), "testdata/simple", opts)
+	results, err := scatest.Run(context.Background(), plugin, logger.Nop(), "testdata/simple", opts)
 	require.NoError(t, err)
-	require.Len(t, result.Results, 1)
-	assert.ElementsMatch(t, []string{"bun.lock", "package.json"}, result.ProcessedFiles)
+	require.Len(t, results, 1)
 
-	scaResult := result.Results[0]
+	scaResult := results[0]
+	assert.ElementsMatch(t, []string{"bun.lock", "package.json"}, scaResult.ProcessedFiles,
+		"single result lists both the lockfile and its own package.json")
 	require.NoError(t, scaResult.Error)
 	require.NotNil(t, scaResult.DepGraph)
 	assert.Equal(t, "my-app", scaResult.DepGraph.GetRootPkg().Info.Name)
@@ -95,12 +97,12 @@ func TestPlugin_Workspace_MultipleDepGraphs(t *testing.T) {
 	plugin := newPlugin(&fakeExecutor{outputFile: "testdata/workspace/why_output.txt"})
 	opts := ecosystems.NewPluginOptions()
 
-	result, err := plugin.BuildDepGraphsFromDir(context.Background(), logger.Nop(), "testdata/workspace", opts)
+	results, err := scatest.Run(context.Background(), plugin, logger.Nop(), "testdata/workspace", opts)
 	require.NoError(t, err)
 
 	// Root graph + one per workspace package (logger + utils).
-	require.Len(t, result.Results, 3)
-	for _, r := range result.Results {
+	require.Len(t, results, 3)
+	for _, r := range results {
 		require.NoError(t, r.Error)
 		require.NotNil(t, r.DepGraph)
 
@@ -109,23 +111,20 @@ func TestPlugin_Workspace_MultipleDepGraphs(t *testing.T) {
 		assert.Equal(t, "bun", r.ResolverMetadata.PluginName)
 	}
 
-	rootResult := testFindResultByRoot(t, result.Results, "my-workspace")
-	loggerResult := testFindResultByRoot(t, result.Results, "@workspace/logger")
-	utilsResult := testFindResultByRoot(t, result.Results, "@workspace/utils")
+	rootResult := testFindResultByRoot(t, results, "my-workspace")
+	loggerResult := testFindResultByRoot(t, results, "@workspace/logger")
+	utilsResult := testFindResultByRoot(t, results, "@workspace/utils")
 
 	// Each dep graph's TargetFile should be the package.json for that workspace package.
 	assert.Equal(t, "package.json", rootResult.ProjectDescriptor.GetTargetFile())
 	assert.Equal(t, "packages/logger/package.json", loggerResult.ProjectDescriptor.GetTargetFile())
 	assert.Equal(t, "packages/utils/package.json", utilsResult.ProjectDescriptor.GetTargetFile())
 
-	// All package.jsons (root + workspace members) plus bun.lock must be marked processed
-	// so that other plugins (npm/yarn) don't re-scan them.
-	assert.ElementsMatch(t, []string{
-		"bun.lock",
-		"package.json",
-		"packages/logger/package.json",
-		"packages/utils/package.json",
-	}, result.ProcessedFiles)
+	// Every result lists bun.lock + its own package.json. Other plugins
+	// (npm/yarn) see the union via the orchestrator and skip these files.
+	assert.ElementsMatch(t, []string{"bun.lock", "package.json"}, rootResult.ProcessedFiles)
+	assert.ElementsMatch(t, []string{"bun.lock", "packages/logger/package.json"}, loggerResult.ProcessedFiles)
+	assert.ElementsMatch(t, []string{"bun.lock", "packages/utils/package.json"}, utilsResult.ProcessedFiles)
 
 	// Root graph: workspace packages are leaves; their transitive deps absent.
 	rootGraph := rootResult.DepGraph
@@ -147,50 +146,49 @@ func TestPlugin_NoBunLock_ReturnsEmpty(t *testing.T) {
 	opts := ecosystems.NewPluginOptions()
 
 	// Point at a directory with no bun.lock.
-	result, err := plugin.BuildDepGraphsFromDir(context.Background(), logger.Nop(), t.TempDir(), opts)
+	results, err := scatest.Run(context.Background(), plugin, logger.Nop(), t.TempDir(), opts)
 	require.NoError(t, err)
-	assert.Empty(t, result.Results)
-	assert.Empty(t, result.ProcessedFiles)
+	assert.Empty(t, results)
 }
 
 func TestPlugin_BunNotFound_ReturnsErrorResult(t *testing.T) {
 	plugin := newPlugin(&fakeExecutor{err: errBunNotFound})
 	opts := ecosystems.NewPluginOptions()
 
-	result, err := plugin.BuildDepGraphsFromDir(context.Background(), logger.Nop(), "testdata/simple", opts)
+	results, err := scatest.Run(context.Background(), plugin, logger.Nop(), "testdata/simple", opts)
 	require.NoError(t, err) // plugin-level error is per-result, not fatal
-	require.Len(t, result.Results, 1)
-	assert.Error(t, result.Results[0].Error)
-	assert.ErrorIs(t, result.Results[0].Error, errBunNotFound)
+	require.Len(t, results, 1)
+	assert.Error(t, results[0].Error)
+	assert.ErrorIs(t, results[0].Error, errBunNotFound)
 }
 
 func TestPlugin_BunVersionTooLow_ReturnsErrorResult(t *testing.T) {
 	plugin := newPlugin(&fakeExecutor{err: errBunVersionTooLow})
 	opts := ecosystems.NewPluginOptions()
 
-	result, err := plugin.BuildDepGraphsFromDir(context.Background(), logger.Nop(), "testdata/simple", opts)
+	results, err := scatest.Run(context.Background(), plugin, logger.Nop(), "testdata/simple", opts)
 	require.NoError(t, err)
-	require.Len(t, result.Results, 1)
-	assert.ErrorIs(t, result.Results[0].Error, errBunVersionTooLow)
+	require.Len(t, results, 1)
+	assert.ErrorIs(t, results[0].Error, errBunVersionTooLow)
 }
 
 func TestPlugin_BunWhyError_ReturnsErrorResult(t *testing.T) {
 	plugin := newPlugin(&fakeExecutor{err: errors.New("bun why failed: exit status 1")})
 	opts := ecosystems.NewPluginOptions()
 
-	result, err := plugin.BuildDepGraphsFromDir(context.Background(), logger.Nop(), "testdata/simple", opts)
+	results, err := scatest.Run(context.Background(), plugin, logger.Nop(), "testdata/simple", opts)
 	require.NoError(t, err)
-	require.Len(t, result.Results, 1)
-	assert.Error(t, result.Results[0].Error)
+	require.Len(t, results, 1)
+	assert.Error(t, results[0].Error)
 }
 
 func TestPlugin_TargetFileNotBunLock_ReturnsEmpty(t *testing.T) {
 	plugin := newPlugin(&fakeExecutor{outputFile: "testdata/simple/why_output.txt"})
 	opts := ecosystems.NewPluginOptions().WithTargetFile("package.json")
 
-	result, err := plugin.BuildDepGraphsFromDir(context.Background(), logger.Nop(), "testdata/simple", opts)
+	results, err := scatest.Run(context.Background(), plugin, logger.Nop(), "testdata/simple", opts)
 	require.NoError(t, err)
-	assert.Empty(t, result.Results)
+	assert.Empty(t, results)
 }
 
 // TestPlugin_StreamingError verifies that an error surfaced mid-stream from the
@@ -209,10 +207,10 @@ func TestPlugin_StreamingError(t *testing.T) {
 	plugin := newPlugin(&streamExecutor{r: pr})
 	opts := ecosystems.NewPluginOptions()
 
-	result, err := plugin.BuildDepGraphsFromDir(context.Background(), logger.Nop(), "testdata/simple", opts)
+	results, err := scatest.Run(context.Background(), plugin, logger.Nop(), "testdata/simple", opts)
 	require.NoError(t, err)
-	require.Len(t, result.Results, 1)
-	assert.Error(t, result.Results[0].Error)
+	require.Len(t, results, 1)
+	assert.Error(t, results[0].Error)
 }
 
 // streamExecutor injects an already-prepared io.Reader.
@@ -299,11 +297,11 @@ func TestPlugin_AllProjects_WorkspacesWithSubpackages(t *testing.T) {
 	plugin := newPlugin(exec)
 	opts := ecosystems.NewPluginOptions().WithAllProjects(true)
 
-	result, err := plugin.BuildDepGraphsFromDir(context.Background(), logger.Nop(), tmp, opts)
+	results, err := scatest.Run(context.Background(), plugin, logger.Nop(), tmp, opts)
 	require.NoError(t, err)
-	require.Len(t, result.Results, 8, "4 dep graphs per workspace (root + 3 sub-packages) × 2 workspaces")
+	require.Len(t, results, 8, "4 dep graphs per workspace (root + 3 sub-packages) × 2 workspaces")
 
-	for i, r := range result.Results {
+	for i, r := range results {
 		require.NoError(t, r.Error, "result[%d] must not carry an error", i)
 		require.NotNil(t, r.DepGraph, "result[%d] must have a dep graph", i)
 
@@ -323,8 +321,8 @@ func TestPlugin_AllProjects_WorkspacesWithSubpackages(t *testing.T) {
 		"frontend/5/package.json",
 	}
 
-	gotTargetFiles := make([]string, len(result.Results))
-	for i, r := range result.Results {
+	gotTargetFiles := make([]string, len(results))
+	for i, r := range results {
 		gotTargetFiles[i] = r.ProjectDescriptor.GetTargetFile()
 	}
 
@@ -350,11 +348,11 @@ func TestPlugin_NoName_ReturnsError(t *testing.T) {
 	))
 
 	plugin := newPlugin(&fakeExecutor{}) // executor is never reached
-	result, err := plugin.BuildDepGraphsFromDir(context.Background(), logger.Nop(), tmp, ecosystems.NewPluginOptions())
+	results, err := scatest.Run(context.Background(), plugin, logger.Nop(), tmp, ecosystems.NewPluginOptions())
 	require.NoError(t, err)
-	require.Len(t, result.Results, 1)
-	assert.Error(t, result.Results[0].Error)
-	assert.Contains(t, result.Results[0].Error.Error(), `"name"`)
+	require.Len(t, results, 1)
+	assert.Error(t, results[0].Error)
+	assert.Contains(t, results[0].Error.Error(), `"name"`)
 }
 
 // TestParseWhyOutput_ReaderInterface confirms parseWhyOutput works with strings.NewReader.

--- a/pkg/ecosystems/javascript/bun/stability_test.go
+++ b/pkg/ecosystems/javascript/bun/stability_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
 	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/javascript/bun"
+	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/scatest"
 )
 
 // TestBunWhyOutputStability runs the plugin against every fixture directory
@@ -60,11 +61,11 @@ func TestBunWhyOutputStability(t *testing.T) {
 
 		t.Run(entry.Name(), func(t *testing.T) {
 			log := &recordingLogger{}
-			result, err := plugin.BuildDepGraphsFromDir(t.Context(), log, dir, opts)
+			results, err := scatest.Run(t.Context(), plugin, log, dir, opts)
 			require.NoError(t, err, "BuildDepGraphsFromDir returned an unexpected error")
-			require.NotEmpty(t, result.Results, "plugin produced no results for %s", entry.Name())
+			require.NotEmpty(t, results, "plugin produced no results for %s", entry.Name())
 
-			for i, r := range result.Results {
+			for i, r := range results {
 				assert.NoError(t, r.Error, "result[%d] for %s contains an error", i, entry.Name())
 			}
 
@@ -72,7 +73,7 @@ func TestBunWhyOutputStability(t *testing.T) {
 
 			// Verify every package in bun.lock is present in some dep graph.
 			// A non-empty missing list is the primary signal of a parser regression.
-			missing := lockfilePackagesMissingFromGraph(t, dir, allResultPkgs(result.Results))
+			missing := lockfilePackagesMissingFromGraph(t, dir, allResultPkgs(results))
 			for _, id := range missing {
 				t.Errorf("bun.lock package %q missing from dep graph — possible bun why format regression", id)
 			}

--- a/pkg/ecosystems/legacy/plugin.go
+++ b/pkg/ecosystems/legacy/plugin.go
@@ -46,7 +46,7 @@ func (l *Resolver) BuildDepGraphsFromDir(
 	log logger.Logger,
 	_ string,
 	opts *ecosystems.SCAPluginOptions,
-	onGraph func(ecosystems.SCAResult) error,
+	onGraph ecosystems.OnGraphFunc,
 ) error {
 	if opts == nil {
 		return fmt.Errorf("cannot resolve dependencies without options")

--- a/pkg/ecosystems/legacy/plugin.go
+++ b/pkg/ecosystems/legacy/plugin.go
@@ -36,18 +36,20 @@ func (l *Resolver) GetName() string {
 
 var _ ecosystems.SCAPlugin = (*Resolver)(nil)
 
-// BuildDepGraphsFromDir invokes the legacy CLI workflow and returns its dep graphs as SCAResults.
-// Empty results from the legacy CLI (exit code 3, or successful invocation producing no graphs)
-// are returned as an empty PluginResult with no error; callers decide what to do based on the
-// totals across all plugins.
+// BuildDepGraphsFromDir invokes the legacy CLI workflow and emits one
+// SCAResult per dep-graph via onGraph. Empty results from the legacy
+// CLI (exit code 3, or successful invocation producing no graphs)
+// return nil with no callback invocations; callers decide what to do
+// based on totals across all plugins.
 func (l *Resolver) BuildDepGraphsFromDir(
 	ctx context.Context,
 	log logger.Logger,
 	_ string,
 	opts *ecosystems.SCAPluginOptions,
-) (*ecosystems.PluginResult, error) {
+	onGraph func(ecosystems.SCAResult) error,
+) error {
 	if opts == nil {
-		return nil, fmt.Errorf("cannot resolve dependencies without options")
+		return fmt.Errorf("cannot resolve dependencies without options")
 	}
 
 	legacyConfig := buildLegacyConfig(l.ictx.GetConfiguration(), opts)
@@ -56,23 +58,22 @@ func (l *Resolver) BuildDepGraphsFromDir(
 	if err != nil {
 		if errors.Is(err, legacycli.ErrNoDepGraphsFound) || legacycli.IsNoProjectFoundError(err) {
 			log.Debug(ctx, "No projects found in legacy CLI call")
-			return nil, nil //nolint:nilnil // no dep-graphs found, no error
+			return nil
 		}
-		return nil, fmt.Errorf("error handling legacy workflow: %w", err)
+		return fmt.Errorf("error handling legacy workflow: %w", err)
 	}
 
-	results := make([]ecosystems.SCAResult, 0, len(depGraphs))
-	processedFiles := make([]string, 0, len(depGraphs))
 	for i := range depGraphs {
 		result := depGraphOutputToSCAResult(ctx, log, &depGraphs[i])
-		results = append(results, result)
-		processedFiles = append(processedFiles, result.ResolverMetadata.NormalisedTargetFile)
+		if result.ResolverMetadata != nil && result.ResolverMetadata.NormalisedTargetFile != "" {
+			result.ProcessedFiles = []string{result.ResolverMetadata.NormalisedTargetFile}
+		}
+		if err := onGraph(result); err != nil {
+			return err
+		}
 	}
 
-	return &ecosystems.PluginResult{
-		Results:        results,
-		ProcessedFiles: processedFiles,
-	}, nil
+	return nil
 }
 
 // buildLegacyConfig clones the live config and applies legacy-CLI-specific transformations.

--- a/pkg/ecosystems/legacy/plugin_test.go
+++ b/pkg/ecosystems/legacy/plugin_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
 	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/legacy"
 	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/logger"
+	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/scatest"
 )
 
 func TestPlugin_GetName(t *testing.T) {
@@ -30,22 +31,22 @@ func TestPlugin_MapsProjectType(t *testing.T) {
 	ictx, _ := setupLegacyCLI(t, `{"depGraph":{"pkgManager":{"name":"npm"}},"normalisedTargetFile":"package.json","targetFileFromPlugin":"package.json","target":{}}`, nil)
 	plugin := legacy.NewPlugin(ictx)
 
-	results, err := plugin.BuildDepGraphsFromDir(t.Context(), logger.Nop(), "", ecosystems.NewPluginOptions())
+	results, err := scatest.Run(t.Context(), plugin, logger.Nop(), "", ecosystems.NewPluginOptions())
 	require.NoError(t, err)
 
-	require.Len(t, results.Results, 1)
-	assert.Equal(t, "npm", results.Results[0].ProjectDescriptor.Identity.ProjectType)
+	require.Len(t, results, 1)
+	assert.Equal(t, "npm", results[0].ProjectDescriptor.Identity.ProjectType)
 }
 
 func TestPlugin_MapsTargetFramework(t *testing.T) {
 	ictx, _ := setupLegacyCLI(t, `{"depGraph":{"pkgManager":{"name":"nuget"}},"normalisedTargetFile":"project.assets.json","targetFileFromPlugin":"project.assets.json","target":{},"targetRuntime":"net6.0"}`, nil)
 	plugin := legacy.NewPlugin(ictx)
 
-	results, err := plugin.BuildDepGraphsFromDir(t.Context(), logger.Nop(), "", ecosystems.NewPluginOptions())
+	results, err := scatest.Run(t.Context(), plugin, logger.Nop(), "", ecosystems.NewPluginOptions())
 	require.NoError(t, err)
 
-	require.Len(t, results.Results, 1)
-	assert.Equal(t, "net6.0", *results.Results[0].ProjectDescriptor.Identity.TargetRuntime)
+	require.Len(t, results, 1)
+	assert.Equal(t, "net6.0", *results[0].ProjectDescriptor.Identity.TargetRuntime)
 }
 
 // TestPlugin_TargetFileForwarding verifies the plugin forwards the legacy CLI's
@@ -86,20 +87,20 @@ func TestPlugin_TargetFileForwarding(t *testing.T) {
 			ictx, _ := setupLegacyCLI(t, tc.body, nil)
 			plugin := legacy.NewPlugin(ictx)
 
-			res, err := plugin.BuildDepGraphsFromDir(t.Context(), logger.Nop(), "", ecosystems.NewPluginOptions())
+			results, err := scatest.Run(t.Context(), plugin, logger.Nop(), "", ecosystems.NewPluginOptions())
 			require.NoError(t, err)
-			require.Len(t, res.Results, 1)
+			require.Len(t, results, 1)
 
-			require.NotNil(t, res.Results[0].ResolverMetadata, "legacy plugin must always populate ResolverMetadata")
-			assert.Equal(t, tc.wantNormalisedTarget, res.Results[0].ResolverMetadata.NormalisedTargetFile,
+			require.NotNil(t, results[0].ResolverMetadata, "legacy plugin must always populate ResolverMetadata")
+			assert.Equal(t, tc.wantNormalisedTarget, results[0].ResolverMetadata.NormalisedTargetFile,
 				"ResolverMetadata.NormalisedTargetFile must mirror the legacy CLI's normalisedTargetFile verbatim")
 
 			if tc.wantPluginTargetFile == nil {
-				assert.Nil(t, res.Results[0].ProjectDescriptor.Identity.TargetFile,
+				assert.Nil(t, results[0].ProjectDescriptor.Identity.TargetFile,
 					"Identity.TargetFile must be nil when the legacy CLI omitted targetFileFromPlugin")
 			} else {
-				require.NotNil(t, res.Results[0].ProjectDescriptor.Identity.TargetFile)
-				assert.Equal(t, *tc.wantPluginTargetFile, *res.Results[0].ProjectDescriptor.Identity.TargetFile)
+				require.NotNil(t, results[0].ProjectDescriptor.Identity.TargetFile)
+				assert.Equal(t, *tc.wantPluginTargetFile, *results[0].ProjectDescriptor.Identity.TargetFile)
 			}
 		})
 	}
@@ -111,23 +112,23 @@ func TestPlugin_MapsRootComponentName(t *testing.T) {
 	ictx, _ := setupLegacyCLI(t, `{"depGraph":{"pkgManager":{"name":"nuget"},"pkgs":[{"id":"my-project@","info":{"name":"my-project"}}],"graph":{"rootNodeId":"root","nodes":[{"nodeId":"root","pkgId":"my-project@"}]}},"normalisedTargetFile":"project.assets.json","targetFileFromPlugin":"project.assets.json","target":{}}`, nil)
 	plugin := legacy.NewPlugin(ictx)
 
-	res, err := plugin.BuildDepGraphsFromDir(t.Context(), logger.Nop(), "", ecosystems.NewPluginOptions())
+	results, err := scatest.Run(t.Context(), plugin, logger.Nop(), "", ecosystems.NewPluginOptions())
 	require.NoError(t, err)
 
-	require.Len(t, res.Results, 1)
-	assert.Equal(t, "my-project", res.Results[0].ProjectDescriptor.Identity.RootComponentName)
+	require.Len(t, results, 1)
+	assert.Equal(t, "my-project", results[0].ProjectDescriptor.Identity.RootComponentName)
 }
 
 func TestPlugin_PopulatesResolverMetadata(t *testing.T) {
 	ictx, _ := setupLegacyCLI(t, `{"depGraph":{"pkgManager":{"name":"npm"}},"normalisedTargetFile":"package.json","target":{}}`, nil)
 	plugin := legacy.NewPlugin(ictx)
 
-	res, err := plugin.BuildDepGraphsFromDir(t.Context(), logger.Nop(), "", ecosystems.NewPluginOptions())
+	results, err := scatest.Run(t.Context(), plugin, logger.Nop(), "", ecosystems.NewPluginOptions())
 	require.NoError(t, err)
 
-	require.Len(t, res.Results, 1)
-	require.NotNil(t, res.Results[0].ResolverMetadata)
-	assert.Equal(t, "legacycli", res.Results[0].ResolverMetadata.PluginName)
+	require.Len(t, results, 1)
+	require.NotNil(t, results[0].ResolverMetadata)
+	assert.Equal(t, "legacycli", results[0].ResolverMetadata.PluginName)
 }
 
 func TestPlugin_ReturnsProcessedFiles(t *testing.T) {
@@ -135,10 +136,12 @@ func TestPlugin_ReturnsProcessedFiles(t *testing.T) {
 
 	plugin := legacy.NewPlugin(ictx)
 
-	res, err := plugin.BuildDepGraphsFromDir(t.Context(), logger.Nop(), "", ecosystems.NewPluginOptions())
+	results, err := scatest.Run(t.Context(), plugin, logger.Nop(), "", ecosystems.NewPluginOptions())
 	require.NoError(t, err)
 
-	assert.Equal(t, []string{"project.assets.json"}, res.ProcessedFiles)
+	require.Len(t, results, 1)
+	assert.Equal(t, []string{"project.assets.json"}, results[0].ProcessedFiles,
+		"each result carries the lockfile it was derived from")
 }
 
 func TestPlugin_PerResultErrorPopulatesSCAResultError(t *testing.T) {
@@ -146,13 +149,13 @@ func TestPlugin_PerResultErrorPopulatesSCAResultError(t *testing.T) {
 	ictx, _ := setupLegacyCLI(t, body, nil)
 	plugin := legacy.NewPlugin(ictx)
 
-	res, err := plugin.BuildDepGraphsFromDir(t.Context(), logger.Nop(), "", ecosystems.NewPluginOptions())
+	results, err := scatest.Run(t.Context(), plugin, logger.Nop(), "", ecosystems.NewPluginOptions())
 	require.NoError(t, err)
-	require.Len(t, res.Results, 1)
+	require.Len(t, results, 1)
 
-	require.Error(t, res.Results[0].Error)
+	require.Error(t, results[0].Error)
 	var snykErr snyk_errors.Error
-	require.True(t, errors.As(res.Results[0].Error, &snykErr))
+	require.True(t, errors.As(results[0].Error, &snykErr))
 	assert.Equal(t, "SNYK-LEGACY-MOD-001", snykErr.ErrorCode)
 	assert.Equal(t, "Module failed", snykErr.Title)
 }
@@ -164,13 +167,13 @@ func TestPlugin_PerResultCLIErrorIsPreservedWhenDepGraphIsMalformed(t *testing.T
 	ictx, _ := setupLegacyCLI(t, body, nil)
 	plugin := legacy.NewPlugin(ictx)
 
-	res, err := plugin.BuildDepGraphsFromDir(t.Context(), logger.Nop(), "", ecosystems.NewPluginOptions())
+	results, err := scatest.Run(t.Context(), plugin, logger.Nop(), "", ecosystems.NewPluginOptions())
 	require.NoError(t, err)
-	require.Len(t, res.Results, 1)
+	require.Len(t, results, 1)
 
-	require.Error(t, res.Results[0].Error)
+	require.Error(t, results[0].Error)
 	var snykErr snyk_errors.Error
-	require.True(t, errors.As(res.Results[0].Error, &snykErr), "upstream CLI error should be preserved, not overwritten by depgraph unmarshal failure")
+	require.True(t, errors.As(results[0].Error, &snykErr), "upstream CLI error should be preserved, not overwritten by depgraph unmarshal failure")
 	assert.Equal(t, "SNYK-LEGACY-MOD-002", snykErr.ErrorCode)
 }
 
@@ -178,18 +181,18 @@ func TestPlugin_ExitCode3ReturnsNilSuccess(t *testing.T) {
 	ictx := setupLegacyCLIWithError(t, exitCodeError{code: 3})
 	plugin := legacy.NewPlugin(ictx)
 
-	res, err := plugin.BuildDepGraphsFromDir(t.Context(), logger.Nop(), "", ecosystems.NewPluginOptions())
+	results, err := scatest.Run(t.Context(), plugin, logger.Nop(), "", ecosystems.NewPluginOptions())
 	require.NoError(t, err)
-	assert.Nil(t, res, "no-projects-found is signaled by a nil PluginResult, not an empty one")
+	assert.Empty(t, results, "no-projects-found surfaces as no callback invocations")
 }
 
 func TestPlugin_ErrNoDepGraphsFoundReturnsNilSuccess(t *testing.T) {
 	ictx := setupLegacyCLIWithEmptyData(t)
 	plugin := legacy.NewPlugin(ictx)
 
-	res, err := plugin.BuildDepGraphsFromDir(t.Context(), logger.Nop(), "", ecosystems.NewPluginOptions())
+	results, err := scatest.Run(t.Context(), plugin, logger.Nop(), "", ecosystems.NewPluginOptions())
 	require.NoError(t, err)
-	assert.Nil(t, res, "no-projects-found is signaled by a nil PluginResult, not an empty one")
+	assert.Empty(t, results, "no-projects-found surfaces as no callback invocations")
 }
 
 func TestPlugin_NonExitCode3ErrorIsWrapped(t *testing.T) {
@@ -197,17 +200,17 @@ func TestPlugin_NonExitCode3ErrorIsWrapped(t *testing.T) {
 	ictx := setupLegacyCLIWithError(t, underlying)
 	plugin := legacy.NewPlugin(ictx)
 
-	res, err := plugin.BuildDepGraphsFromDir(t.Context(), logger.Nop(), "", ecosystems.NewPluginOptions())
+	results, err := scatest.Run(t.Context(), plugin, logger.Nop(), "", ecosystems.NewPluginOptions())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "error handling legacy workflow")
 	assert.ErrorIs(t, err, underlying, "underlying error should remain in the chain via the snyk_errors.WithCause wrap")
-	assert.Nil(t, res)
+	assert.Empty(t, results)
 }
 
 func TestPlugin_NilOptionsReturnsError(t *testing.T) {
 	plugin := legacy.NewPlugin(nil)
 
-	_, err := plugin.BuildDepGraphsFromDir(t.Context(), logger.Nop(), "", nil)
+	_, err := scatest.Run(t.Context(), plugin, logger.Nop(), "", nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "options")
 }
@@ -218,7 +221,7 @@ func TestPlugin_ExcludeBehaviour(t *testing.T) {
 		plugin := legacy.NewPlugin(ictx)
 
 		opts := ecosystems.NewPluginOptions().WithExclude([]string{"a.lock", "b.lock"})
-		_, err := plugin.BuildDepGraphsFromDir(t.Context(), logger.Nop(), "", opts)
+		_, err := scatest.Run(t.Context(), plugin, logger.Nop(), "", opts)
 		require.NoError(t, err)
 
 		assert.Equal(t, "", (*capturedConfig).GetString(workflow.FlagExclude),
@@ -231,7 +234,7 @@ func TestPlugin_ExcludeBehaviour(t *testing.T) {
 		plugin := legacy.NewPlugin(ictx)
 
 		opts := ecosystems.NewPluginOptions().WithExclude([]string{"a.lock"})
-		_, err := plugin.BuildDepGraphsFromDir(t.Context(), logger.Nop(), "", opts)
+		_, err := scatest.Run(t.Context(), plugin, logger.Nop(), "", opts)
 		require.NoError(t, err)
 
 		assert.Equal(t, "user-exclude.txt", (*capturedConfig).GetString(workflow.FlagExclude),
@@ -245,7 +248,7 @@ func TestPlugin_DoesNotMutateLiveConfig(t *testing.T) {
 	plugin := legacy.NewPlugin(ictx)
 
 	opts := ecosystems.NewPluginOptions().WithExclude([]string{"a.lock"})
-	_, err := plugin.BuildDepGraphsFromDir(t.Context(), logger.Nop(), "", opts)
+	_, err := scatest.Run(t.Context(), plugin, logger.Nop(), "", opts)
 	require.NoError(t, err)
 
 	assert.Equal(t, "user-exclude.txt", ictx.GetConfiguration().GetString(workflow.FlagExclude),
@@ -256,7 +259,7 @@ func TestPlugin_ForcesEffectiveGraphWithErrorsByDefault(t *testing.T) {
 	ictx, capturedConfig := setupLegacyCLI(t, `{"depGraph":{"pkgManager":{"name":"npm"}},"normalisedTargetFile":"package.json","target":{}}`, nil)
 	plugin := legacy.NewPlugin(ictx)
 
-	_, err := plugin.BuildDepGraphsFromDir(t.Context(), logger.Nop(), "", ecosystems.NewPluginOptions())
+	_, err := scatest.Run(t.Context(), plugin, logger.Nop(), "", ecosystems.NewPluginOptions())
 	require.NoError(t, err)
 
 	assert.True(t, (*capturedConfig).GetBool(workflow.FlagPrintEffectiveGraphWithErrors))
@@ -267,7 +270,7 @@ func TestPlugin_DisablesEffectiveGraphWithErrorsWhenJSONLWithErrorsRequested(t *
 	ictx, capturedConfig := setupLegacyCLI(t, `{"depGraph":{"pkgManager":{"name":"npm"}},"normalisedTargetFile":"package.json","target":{}}`, preexisting)
 	plugin := legacy.NewPlugin(ictx)
 
-	_, err := plugin.BuildDepGraphsFromDir(t.Context(), logger.Nop(), "", ecosystems.NewPluginOptions())
+	_, err := scatest.Run(t.Context(), plugin, logger.Nop(), "", ecosystems.NewPluginOptions())
 	require.NoError(t, err)
 
 	assert.False(t, (*capturedConfig).GetBool(workflow.FlagPrintEffectiveGraphWithErrors))
@@ -331,7 +334,7 @@ func TestPlugin_BuildLegacyConfig_WritesExcludePathsFromOpts(t *testing.T) {
 			if len(tc.optsExcludePaths) > 0 {
 				opts = opts.WithExcludePaths(tc.optsExcludePaths)
 			}
-			_, err := plugin.BuildDepGraphsFromDir(t.Context(), logger.Nop(), "", opts)
+			_, err := scatest.Run(t.Context(), plugin, logger.Nop(), "", opts)
 			require.NoError(t, err)
 
 			assert.Equal(t, tc.expectedExcludePaths, (*capturedConfig).GetString(workflow.FlagExcludePaths))
@@ -347,7 +350,7 @@ func TestPlugin_BuildLegacyConfig_DoesNotMutateLiveConfigExcludePaths(t *testing
 	plugin := legacy.NewPlugin(ictx)
 
 	opts := ecosystems.NewPluginOptions().WithExcludePaths([]string{"processed.lock"})
-	_, err := plugin.BuildDepGraphsFromDir(t.Context(), logger.Nop(), "", opts)
+	_, err := scatest.Run(t.Context(), plugin, logger.Nop(), "", opts)
 	require.NoError(t, err)
 
 	assert.Equal(t, "user-supplied.lock", ictx.GetConfiguration().GetString(workflow.FlagExcludePaths),

--- a/pkg/ecosystems/orchestrator/registry.go
+++ b/pkg/ecosystems/orchestrator/registry.go
@@ -174,23 +174,33 @@ func executePluginWithResults(
 	resultsChan chan ecosystems.SCAResult,
 ) []string {
 	enhancedLogger.Info().Msg(fmt.Sprintf("Executing %s plugin", plugin.GetName()))
-	results, err := plugin.BuildDepGraphsFromDir(ctx, logger.NewFromZerolog(enhancedLogger), dir, opts)
+
+	// processedFiles is the deduped union across every emitted result.
+	// Plugins attach per-result file lists on SCAResult.ProcessedFiles;
+	// the orchestrator unions them here so callers see one flat list
+	// per plugin run.
+	seen := make(map[string]struct{})
+	var processedFiles []string
+
+	err := plugin.BuildDepGraphsFromDir(ctx, logger.NewFromZerolog(enhancedLogger), dir, opts, func(result ecosystems.SCAResult) error {
+		for _, p := range result.ProcessedFiles {
+			if _, ok := seen[p]; ok {
+				continue
+			}
+			seen[p] = struct{}{}
+			processedFiles = append(processedFiles, p)
+		}
+		select {
+		case resultsChan <- result:
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	})
 	if err != nil {
 		enhancedLogger.Warn().Err(err).Msg(fmt.Sprintf("%s plugin failed", plugin.GetName()))
-		return nil
+		return processedFiles
 	}
 
-	if results != nil {
-		for _, result := range results.Results {
-			select {
-			case resultsChan <- result:
-			case <-ctx.Done():
-				return nil
-			}
-		}
-
-		return results.ProcessedFiles
-	}
-
-	return nil
+	return processedFiles
 }

--- a/pkg/ecosystems/orchestrator/registry_test.go
+++ b/pkg/ecosystems/orchestrator/registry_test.go
@@ -18,9 +18,8 @@ import (
 )
 
 type mockPlugin struct {
-	name           string
-	processedFiles []string
-	results        []ecosystems.SCAResult
+	name    string
+	results []ecosystems.SCAResult
 
 	// capturedExclude / capturedExcludePaths snapshot opts.Global.{Exclude,ExcludePaths}
 	// at the moment BuildDepGraphsFromDir is called, so tests can assert on what each
@@ -34,15 +33,23 @@ func (m *mockPlugin) GetName() string {
 	return m.name
 }
 
-func (m *mockPlugin) BuildDepGraphsFromDir(_ context.Context, _ logger.Logger, _ string, opts *ecosystems.SCAPluginOptions) (*ecosystems.PluginResult, error) {
+func (m *mockPlugin) BuildDepGraphsFromDir(
+	_ context.Context,
+	_ logger.Logger,
+	_ string,
+	opts *ecosystems.SCAPluginOptions,
+	onGraph func(ecosystems.SCAResult) error,
+) error {
 	if opts != nil {
 		m.capturedExclude = append([]string(nil), opts.Global.Exclude...)
 		m.capturedExcludePaths = append([]string(nil), opts.Global.ExcludePaths...)
 	}
-	return &ecosystems.PluginResult{
-		ProcessedFiles: m.processedFiles,
-		Results:        m.results,
-	}, nil
+	for _, r := range m.results {
+		if err := onGraph(r); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func TestPluginRegistry_OrderPreservedWithoutDependencies(t *testing.T) {
@@ -226,14 +233,18 @@ func TestPluginRegistry_ResolveDepgraphs_AllProjectsMode(t *testing.T) {
 	}
 
 	require.NoError(t, r.register(&mockPlugin{
-		name:           "plugin-a",
-		processedFiles: []string{"file-a.txt"},
-		results:        []ecosystems.SCAResult{{ProjectDescriptor: identity.ProjectDescriptor{Identity: identity.ProjectIdentity{ProjectType: "type-a"}}}},
+		name: "plugin-a",
+		results: []ecosystems.SCAResult{{
+			ProjectDescriptor: identity.ProjectDescriptor{Identity: identity.ProjectIdentity{ProjectType: "type-a"}},
+			ProcessedFiles:    []string{"file-a.txt"},
+		}},
 	}))
 	require.NoError(t, r.register(&mockPlugin{
-		name:           "plugin-b",
-		processedFiles: []string{"file-b.txt"},
-		results:        []ecosystems.SCAResult{{ProjectDescriptor: identity.ProjectDescriptor{Identity: identity.ProjectIdentity{ProjectType: "type-b"}}}},
+		name: "plugin-b",
+		results: []ecosystems.SCAResult{{
+			ProjectDescriptor: identity.ProjectDescriptor{Identity: identity.ProjectIdentity{ProjectType: "type-b"}},
+			ProcessedFiles:    []string{"file-b.txt"},
+		}},
 	}))
 
 	opts := ecosystems.NewPluginOptions()
@@ -254,14 +265,18 @@ func TestPluginRegistry_ResolveDepgraphs_StopsAfterFirstResult(t *testing.T) {
 	}
 
 	require.NoError(t, r.register(&mockPlugin{
-		name:           "plugin-a",
-		processedFiles: []string{"file-a.txt"},
-		results:        []ecosystems.SCAResult{{ProjectDescriptor: identity.ProjectDescriptor{Identity: identity.ProjectIdentity{ProjectType: "type-a"}}}},
+		name: "plugin-a",
+		results: []ecosystems.SCAResult{{
+			ProjectDescriptor: identity.ProjectDescriptor{Identity: identity.ProjectIdentity{ProjectType: "type-a"}},
+			ProcessedFiles:    []string{"file-a.txt"},
+		}},
 	}))
 	require.NoError(t, r.register(&mockPlugin{
-		name:           "plugin-b",
-		processedFiles: []string{"file-b.txt"},
-		results:        []ecosystems.SCAResult{{ProjectDescriptor: identity.ProjectDescriptor{Identity: identity.ProjectIdentity{ProjectType: "type-b"}}}},
+		name: "plugin-b",
+		results: []ecosystems.SCAResult{{
+			ProjectDescriptor: identity.ProjectDescriptor{Identity: identity.ProjectIdentity{ProjectType: "type-b"}},
+			ProcessedFiles:    []string{"file-b.txt"},
+		}},
 	}))
 
 	opts := ecosystems.NewPluginOptions()
@@ -283,14 +298,15 @@ func TestPluginRegistry_ResolveDepgraphs_ContinuesWhenNoResults(t *testing.T) {
 	}
 
 	require.NoError(t, r.register(&mockPlugin{
-		name:           "plugin-a",
-		processedFiles: []string{},
-		results:        []ecosystems.SCAResult{},
+		name: "plugin-a",
+		// No results — plugin emits nothing through the callback.
 	}))
 	require.NoError(t, r.register(&mockPlugin{
-		name:           "plugin-b",
-		processedFiles: []string{"file-b.txt"},
-		results:        []ecosystems.SCAResult{{ProjectDescriptor: identity.ProjectDescriptor{Identity: identity.ProjectIdentity{ProjectType: "type-b"}}}},
+		name: "plugin-b",
+		results: []ecosystems.SCAResult{{
+			ProjectDescriptor: identity.ProjectDescriptor{Identity: identity.ProjectIdentity{ProjectType: "type-b"}},
+			ProcessedFiles:    []string{"file-b.txt"},
+		}},
 	}))
 
 	opts := ecosystems.NewPluginOptions()
@@ -317,14 +333,18 @@ func TestPluginRegistry_ResolveDepgraphs_PropagatesProcessedFilesAsExcludePaths(
 	}
 
 	pluginA := &mockPlugin{
-		name:           "plugin-a",
-		processedFiles: []string{"a/lock.json", "a/sub/lock.json"},
-		results:        []ecosystems.SCAResult{{ProjectDescriptor: identity.ProjectDescriptor{Identity: identity.ProjectIdentity{ProjectType: "type-a"}}}},
+		name: "plugin-a",
+		results: []ecosystems.SCAResult{{
+			ProjectDescriptor: identity.ProjectDescriptor{Identity: identity.ProjectIdentity{ProjectType: "type-a"}},
+			ProcessedFiles:    []string{"a/lock.json", "a/sub/lock.json"},
+		}},
 	}
 	pluginB := &mockPlugin{
-		name:           "plugin-b",
-		processedFiles: []string{"b/lock.json"},
-		results:        []ecosystems.SCAResult{{ProjectDescriptor: identity.ProjectDescriptor{Identity: identity.ProjectIdentity{ProjectType: "type-b"}}}},
+		name: "plugin-b",
+		results: []ecosystems.SCAResult{{
+			ProjectDescriptor: identity.ProjectDescriptor{Identity: identity.ProjectIdentity{ProjectType: "type-b"}},
+			ProcessedFiles:    []string{"b/lock.json"},
+		}},
 	}
 	require.NoError(t, r.register(pluginA))
 	require.NoError(t, r.register(pluginB))

--- a/pkg/ecosystems/orchestrator/registry_test.go
+++ b/pkg/ecosystems/orchestrator/registry_test.go
@@ -38,7 +38,7 @@ func (m *mockPlugin) BuildDepGraphsFromDir(
 	_ logger.Logger,
 	_ string,
 	opts *ecosystems.SCAPluginOptions,
-	onGraph func(ecosystems.SCAResult) error,
+	onGraph ecosystems.OnGraphFunc,
 ) error {
 	if opts != nil {
 		m.capturedExclude = append([]string(nil), opts.Global.Exclude...)

--- a/pkg/ecosystems/plugin_interface.go
+++ b/pkg/ecosystems/plugin_interface.go
@@ -15,23 +15,45 @@ type ResolverMetadata struct {
 	NormalisedTargetFile string            `json:"normalisedTargetFile,omitempty"`
 }
 
-// SCAResult represents the result of a Software Composition Analysis (SCA),
-// containing the dependency graph and associated project descriptor.
+// SCAResult represents one Software Composition Analysis result —
+// either a successfully-built dep-graph for one project, or an error
+// surfaced against the project's descriptor.
+//
+// ProcessedFiles lists the files this result was derived from
+// (lockfile + any manifests consulted). Per-graph attribution; if a
+// consumer wants a deduped union across all results, it computes it
+// itself.
 type SCAResult struct {
 	DepGraph          *depgraph.DepGraph         `json:"depGraph,omitempty"`
 	ProjectDescriptor identity.ProjectDescriptor `json:"projectDescriptor"`
 	ResolverMetadata  *ResolverMetadata          `json:"meta,omitempty"`
+	ProcessedFiles    []string                   `json:"processedFiles,omitempty"`
 	Error             error                      `json:"error,omitempty"`
 }
 
-type PluginResult struct {
-	Results        []SCAResult `json:"results"`
-	ProcessedFiles []string    `json:"processedFiles"`
-}
-
-// SCAPlugin defines the interface for SCA plugins that build dependency graphs
-// from a directory containing project files.
+// SCAPlugin builds dependency graphs from a directory containing
+// project files. Results are emitted one at a time via onGraph as the
+// plugin produces them — there is no aggregated return value. This
+// lets consumers stream graphs to disk / network without holding the
+// full set in memory.
+//
+// onGraph is invoked exactly once per produced SCAResult. Calls are
+// serialized — onGraph need not be goroutine-safe. A non-nil onGraph
+// return aborts the run and BuildDepGraphsFromDir returns that error
+// to the caller.
+//
+// Setup-time failures (cannot access dir, options invalid, etc.) are
+// returned directly from BuildDepGraphsFromDir without ever invoking
+// onGraph. Per-graph build failures are emitted as
+// SCAResult{Descriptor: ..., Error: err} via onGraph — the run
+// continues so the caller sees every project the plugin attempted.
 type SCAPlugin interface {
-	BuildDepGraphsFromDir(ctx context.Context, log logger.Logger, dir string, options *SCAPluginOptions) (*PluginResult, error)
+	BuildDepGraphsFromDir(
+		ctx context.Context,
+		log logger.Logger,
+		dir string,
+		options *SCAPluginOptions,
+		onGraph func(SCAResult) error,
+	) error
 	GetName() string
 }

--- a/pkg/ecosystems/plugin_interface.go
+++ b/pkg/ecosystems/plugin_interface.go
@@ -31,6 +31,10 @@ type SCAResult struct {
 	Error             error                      `json:"error,omitempty"`
 }
 
+// OnGraphFunc is the per-graph callback BuildDepGraphsFromDir invokes
+// for each emitted SCAResult. See SCAPlugin for the contract.
+type OnGraphFunc func(SCAResult) error
+
 // SCAPlugin builds dependency graphs from a directory containing
 // project files. Results are emitted one at a time via onGraph as the
 // plugin produces them — there is no aggregated return value. This
@@ -53,7 +57,7 @@ type SCAPlugin interface {
 		log logger.Logger,
 		dir string,
 		options *SCAPluginOptions,
-		onGraph func(SCAResult) error,
+		onGraph OnGraphFunc,
 	) error
 	GetName() string
 }

--- a/pkg/ecosystems/python/pip/plugin.go
+++ b/pkg/ecosystems/python/pip/plugin.go
@@ -37,10 +37,15 @@ func (p Plugin) GetName() string {
 // Compile-time check to ensure Plugin implements SCAPlugin interface.
 var _ ecosystems.SCAPlugin = (*Plugin)(nil)
 
-// BuildDepGraphsFromDir discovers and builds dependency graphs for Python pip projects.
+// BuildDepGraphsFromDir discovers and builds dependency graphs for
+// Python pip projects. Build work runs concurrently (bounded by
+// maxConcurrentInstalls) but onGraph invocations are serialized under
+// a mutex to satisfy the SCAPlugin contract — callbacks need not be
+// goroutine-safe.
 func (p Plugin) BuildDepGraphsFromDir(
 	ctx context.Context, log logger.Logger, dir string, options *ecosystems.SCAPluginOptions,
-) (*ecosystems.PluginResult, error) {
+	onGraph func(ecosystems.SCAResult) error,
+) error {
 	if log == nil {
 		log = logger.Nop()
 	}
@@ -48,24 +53,23 @@ func (p Plugin) BuildDepGraphsFromDir(
 	// Discover requirements.txt files
 	files, err := p.discoverRequirementsFiles(ctx, dir, options)
 	if err != nil {
-		return nil, fmt.Errorf("failed to discover requirements files: %w", err)
+		return fmt.Errorf("failed to discover requirements files: %w", err)
 	}
 
 	if len(files) == 0 {
 		log.Info(ctx, "No requirements.txt files found", logger.Attr("dir", dir))
-		return &ecosystems.PluginResult{}, nil
+		return nil
 	}
 
 	// Get Python runtime version
 	pythonVersion, err := GetPythonVersion()
 	if err != nil {
-		return nil, fmt.Errorf("failed to detect Python version: %w", err)
+		return fmt.Errorf("failed to detect Python version: %w", err)
 	}
 
-	// Build dependency graphs concurrently for each requirements file
-	// Limit concurrency to avoid overwhelming the system
-	var mu sync.Mutex
-	results := make([]ecosystems.SCAResult, 0, len(files))
+	// emitMu serializes onGraph calls; the first non-nil onGraph error
+	// is captured and surfaced to errgroup to cancel sibling builds.
+	var emitMu sync.Mutex
 
 	g, ctx := errgroup.WithContext(ctx)
 	g.SetLimit(maxConcurrentInstalls)
@@ -96,27 +100,18 @@ func (p Plugin) BuildDepGraphsFromDir(
 					Error: err,
 				}
 			}
+			result.ProcessedFiles = []string{file.RelPath}
 
-			mu.Lock()
-			results = append(results, result)
-			mu.Unlock()
-			return nil
+			emitMu.Lock()
+			defer emitMu.Unlock()
+			return onGraph(result)
 		})
 	}
 
 	if err := g.Wait(); err != nil {
-		return nil, fmt.Errorf("error building dependency graphs: %w", err)
+		return fmt.Errorf("error building dependency graphs: %w", err)
 	}
-
-	processedFiles := make([]string, 0, len(files))
-	for _, file := range files {
-		processedFiles = append(processedFiles, file.RelPath)
-	}
-
-	return &ecosystems.PluginResult{
-		Results:        results,
-		ProcessedFiles: processedFiles,
-	}, nil
+	return nil
 }
 
 // discoverRequirementsFiles finds requirements.txt files based on the provided options.

--- a/pkg/ecosystems/python/pip/plugin.go
+++ b/pkg/ecosystems/python/pip/plugin.go
@@ -44,7 +44,7 @@ var _ ecosystems.SCAPlugin = (*Plugin)(nil)
 // goroutine-safe.
 func (p Plugin) BuildDepGraphsFromDir(
 	ctx context.Context, log logger.Logger, dir string, options *ecosystems.SCAPluginOptions,
-	onGraph func(ecosystems.SCAResult) error,
+	onGraph ecosystems.OnGraphFunc,
 ) error {
 	if log == nil {
 		log = logger.Nop()

--- a/pkg/ecosystems/python/pip/plugin_integration_test.go
+++ b/pkg/ecosystems/python/pip/plugin_integration_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
 	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/logger"
 	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/metadata"
+	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/scatest"
 )
 
 // PluginTestCase defines a test case for the plugin
@@ -66,7 +67,7 @@ func TestPlugin_BuildDepGraphsFromDir(t *testing.T) {
 
 			// Run plugin
 			plugin := Plugin{}
-			result, err := plugin.BuildDepGraphsFromDir(ctx, logger.Nop(), absPath, tc.Options)
+			results, err := scatest.Run(ctx, plugin, logger.Nop(), absPath, tc.Options)
 			require.NoError(t, err, "BuildDepGraphsFromDir should not return error")
 
 			// Load and compare expected output
@@ -76,7 +77,7 @@ func TestPlugin_BuildDepGraphsFromDir(t *testing.T) {
 			expected, err := loadExpectedResults(expectedPath)
 			require.NoError(t, err, "failed to load expected output from %s", expectedPath)
 
-			assertResultsMatchExpected(t, result.Results, expected, tc.Fixture)
+			assertResultsMatchExpected(t, results, expected, tc.Fixture)
 		})
 	}
 }
@@ -108,9 +109,9 @@ func TestPlugin_Concurrency(t *testing.T) {
 
 	// Run multiple times to test race conditions
 	for i := 0; i < 5; i++ {
-		result, err := plugin.BuildDepGraphsFromDir(ctx, logger.Nop(), absPath, options)
+		results, err := scatest.Run(ctx, plugin, logger.Nop(), absPath, options)
 		require.NoError(t, err, "iteration %d failed", i)
-		assertResultsMatchExpected(t, result.Results, expected, "multi-requirements")
+		assertResultsMatchExpected(t, results, expected, "multi-requirements")
 	}
 }
 
@@ -151,11 +152,11 @@ func TestPlugin_BuildDepGraphsFromDir_PipErrors(t *testing.T) {
 			require.NoError(t, err, "failed to get absolute path for fixture")
 
 			plugin := Plugin{}
-			result, err := plugin.BuildDepGraphsFromDir(ctx, logger.Nop(), absPath, ecosystems.NewPluginOptions())
+			results, err := scatest.Run(ctx, plugin, logger.Nop(), absPath, ecosystems.NewPluginOptions())
 			require.NoError(t, err, "BuildDepGraphsFromDir should not return error")
 
-			require.Len(t, result.Results, 1, "expected a single result for fixture %s", tc.fixture)
-			pipResult := result.Results[0]
+			require.Len(t, results, 1, "expected a single result for fixture %s", tc.fixture)
+			pipResult := results[0]
 
 			// Basic metadata expectations
 			if pythonVersion != "" && pipResult.ProjectDescriptor.Identity.TargetRuntime != nil {
@@ -183,7 +184,7 @@ func TestPlugin_ContextCancellation(t *testing.T) {
 	require.NoError(t, err)
 
 	plugin := Plugin{}
-	result, err := plugin.BuildDepGraphsFromDir(ctx, logger.Nop(), absPath, ecosystems.NewPluginOptions())
+	results, err := scatest.Run(ctx, plugin, logger.Nop(), absPath, ecosystems.NewPluginOptions())
 
 	// Should handle cancellation gracefully
 	if err != nil {
@@ -191,10 +192,10 @@ func TestPlugin_ContextCancellation(t *testing.T) {
 		assert.ErrorIs(t, err, context.Canceled)
 	} else {
 		// If results returned, they should contain error
-		assert.Len(t, result.Results, 1)
-		if result.Results[0].Error != nil {
+		assert.Len(t, results, 1)
+		if results[0].Error != nil {
 			// Error might be wrapped
-			assert.Contains(t, result.Results[0].Error.Error(), "context canceled")
+			assert.Contains(t, results[0].Error.Error(), "context canceled")
 		}
 	}
 }
@@ -254,8 +255,9 @@ func assertResultsMatchExpected(t *testing.T, actual, expected []ecosystems.SCAR
 			assert.NotEmpty(t, pythonVersion, "[%s] pythonVersion should not be empty if present", fixtureName)
 		}
 
-		// Null out ResolverMetadata for comparison (not part of golden files)
+		// Null out fields that aren't part of golden files.
 		sortActual[i].ResolverMetadata = nil
+		sortActual[i].ProcessedFiles = nil
 	}
 
 	// Sync fields that vary between pip and pipenv or by environment (allows sharing fixtures)

--- a/pkg/ecosystems/python/pipenv/plugin.go
+++ b/pkg/ecosystems/python/pipenv/plugin.go
@@ -40,10 +40,14 @@ func (p Plugin) GetName() string {
 	return PluginName
 }
 
-// BuildDepGraphsFromDir discovers and builds dependency graphs for Pipenv projects.
+// BuildDepGraphsFromDir discovers and builds dependency graphs for
+// Pipenv projects. Build work runs concurrently (bounded by
+// maxConcurrentInstalls); onGraph invocations are serialized under a
+// mutex to satisfy the SCAPlugin contract.
 func (p Plugin) BuildDepGraphsFromDir(
 	ctx context.Context, log logger.Logger, dir string, options *ecosystems.SCAPluginOptions,
-) (*ecosystems.PluginResult, error) {
+	onGraph func(ecosystems.SCAResult) error,
+) error {
 	if log == nil {
 		log = logger.Nop()
 	}
@@ -51,23 +55,21 @@ func (p Plugin) BuildDepGraphsFromDir(
 	// Discover Pipfile files
 	files, err := p.discoverPipfiles(ctx, dir, options)
 	if err != nil {
-		return nil, fmt.Errorf("failed to discover Pipfiles: %w", err)
+		return fmt.Errorf("failed to discover Pipfiles: %w", err)
 	}
 
 	if len(files) == 0 {
 		log.Info(ctx, "No Pipfile files found", logger.Attr("dir", dir))
-		return &ecosystems.PluginResult{}, nil
+		return nil
 	}
 
 	// Get Python runtime version
 	pythonVersion, err := pip.GetPythonVersion()
 	if err != nil {
-		return nil, fmt.Errorf("failed to detect Python version: %w", err)
+		return fmt.Errorf("failed to detect Python version: %w", err)
 	}
 
-	// Build dependency graphs concurrently for each Pipfile
-	var mu sync.Mutex
-	results := make([]ecosystems.SCAResult, 0, len(files))
+	var emitMu sync.Mutex
 
 	g, ctx := errgroup.WithContext(ctx)
 	g.SetLimit(maxConcurrentInstalls)
@@ -100,27 +102,20 @@ func (p Plugin) BuildDepGraphsFromDir(
 					Error: err,
 				}
 			}
+			if tf := result.ProjectDescriptor.GetTargetFile(); tf != "" {
+				result.ProcessedFiles = []string{tf}
+			}
 
-			mu.Lock()
-			results = append(results, result)
-			mu.Unlock()
-			return nil
+			emitMu.Lock()
+			defer emitMu.Unlock()
+			return onGraph(result)
 		})
 	}
 
 	if err := g.Wait(); err != nil {
-		return nil, fmt.Errorf("error building dependency graphs: %w", err)
+		return fmt.Errorf("error building dependency graphs: %w", err)
 	}
-
-	processedFiles := make([]string, 0, len(results))
-	for _, result := range results {
-		processedFiles = append(processedFiles, result.ProjectDescriptor.GetTargetFile())
-	}
-
-	return &ecosystems.PluginResult{
-		Results:        results,
-		ProcessedFiles: processedFiles,
-	}, nil
+	return nil
 }
 
 // discoverPipfiles finds Pipfile files based on the provided options.

--- a/pkg/ecosystems/python/pipenv/plugin.go
+++ b/pkg/ecosystems/python/pipenv/plugin.go
@@ -46,7 +46,7 @@ func (p Plugin) GetName() string {
 // mutex to satisfy the SCAPlugin contract.
 func (p Plugin) BuildDepGraphsFromDir(
 	ctx context.Context, log logger.Logger, dir string, options *ecosystems.SCAPluginOptions,
-	onGraph func(ecosystems.SCAResult) error,
+	onGraph ecosystems.OnGraphFunc,
 ) error {
 	if log == nil {
 		log = logger.Nop()

--- a/pkg/ecosystems/python/pipenv/plugin_integration_test.go
+++ b/pkg/ecosystems/python/pipenv/plugin_integration_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/logger"
 	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/metadata"
 	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/python/pip"
+	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/scatest"
 )
 
 // PluginTestCase defines a test case for the plugin.
@@ -63,7 +64,7 @@ func TestPipenvPlugin_BuildDepGraphsFromDir(t *testing.T) {
 
 			// Run plugin
 			plugin := Plugin{}
-			result, err := plugin.BuildDepGraphsFromDir(ctx, logger.Nop(), absPath, tc.Options)
+			results, err := scatest.Run(ctx, plugin, logger.Nop(), absPath, tc.Options)
 			require.NoError(t, err, "BuildDepGraphsFromDir should not return error")
 
 			// Load and compare expected output
@@ -73,7 +74,7 @@ func TestPipenvPlugin_BuildDepGraphsFromDir(t *testing.T) {
 			expected, err := loadExpectedResults(expectedPath)
 			require.NoError(t, err, "failed to load expected output from %s", expectedPath)
 
-			assertResultsMatchExpected(t, result.Results, expected, tc.Fixture)
+			assertResultsMatchExpected(t, results, expected, tc.Fixture)
 		})
 	}
 }
@@ -105,9 +106,9 @@ func TestPlugin_Concurrency(t *testing.T) {
 
 	// Run multiple times to test race conditions
 	for i := 0; i < 5; i++ {
-		result, err := plugin.BuildDepGraphsFromDir(ctx, logger.Nop(), absPath, options)
+		results, err := scatest.Run(ctx, plugin, logger.Nop(), absPath, options)
 		require.NoError(t, err, "iteration %d failed", i)
-		assertResultsMatchExpected(t, result.Results, expected, "multi-requirements")
+		assertResultsMatchExpected(t, results, expected, "multi-requirements")
 	}
 }
 
@@ -148,8 +149,8 @@ func TestPlugin_BuildDepGraphsFromDir_PipErrors(t *testing.T) {
 			require.NoError(t, err, "failed to get absolute path for fixture")
 
 			plugin := Plugin{}
-			result, err := plugin.BuildDepGraphsFromDir(ctx, logger.Nop(), absPath, ecosystems.NewPluginOptions())
-			results := result.Results
+			results, err := scatest.Run(ctx, plugin, logger.Nop(), absPath, ecosystems.NewPluginOptions())
+
 			require.NoError(t, err, "BuildDepGraphsFromDir should not return error")
 
 			require.Len(t, results, 1, "expected a single result for fixture %s", tc.fixture)
@@ -229,8 +230,9 @@ func assertResultsMatchExpected(t *testing.T, actual, expected []ecosystems.SCAR
 			assert.NotEmpty(t, pythonVersion, "[%s] pythonVersion should not be empty if present", fixtureName)
 		}
 
-		// Null out ResolverMetadata for comparison (not part of golden files)
+		// Null out fields that aren't part of golden files.
 		sortActual[i].ResolverMetadata = nil
+		sortActual[i].ProcessedFiles = nil
 	}
 
 	// Sync fields that vary between pip and pipenv (allows sharing fixtures)

--- a/pkg/ecosystems/python/uv/plugin.go
+++ b/pkg/ecosystems/python/uv/plugin.go
@@ -43,7 +43,7 @@ func (p Plugin) BuildDepGraphsFromDir(
 	log logger.Logger,
 	inputDir string,
 	options *scaecosystems.SCAPluginOptions,
-	onGraph func(scaecosystems.SCAResult) error,
+	onGraph scaecosystems.OnGraphFunc,
 ) error {
 	var targetFile string
 	if options.Global.TargetFile != nil {
@@ -114,7 +114,7 @@ func (p Plugin) buildResults(
 	lockFileDir string,
 	options *scaecosystems.SCAPluginOptions,
 	log logger.Logger,
-	onGraph func(scaecosystems.SCAResult) error,
+	onGraph scaecosystems.OnGraphFunc,
 ) (int, error) {
 	parsedSbom, err := parseAndValidateSBOM(sbom)
 	if err != nil {

--- a/pkg/ecosystems/python/uv/plugin.go
+++ b/pkg/ecosystems/python/uv/plugin.go
@@ -43,7 +43,8 @@ func (p Plugin) BuildDepGraphsFromDir(
 	log logger.Logger,
 	inputDir string,
 	options *scaecosystems.SCAPluginOptions,
-) (*scaecosystems.PluginResult, error) {
+	onGraph func(scaecosystems.SCAResult) error,
+) error {
 	var targetFile string
 	if options.Global.TargetFile != nil {
 		targetFile = *options.Global.TargetFile
@@ -51,18 +52,17 @@ func (p Plugin) BuildDepGraphsFromDir(
 
 	if targetFile != "" && filepath.Base(targetFile) != LockFileName {
 		log.Info(ctx, "Skipping processing uv plugin", logger.Attr("targetFile", targetFile), logger.Attr("reason", "not a 'uv.lock' file"))
-		return &scaecosystems.PluginResult{}, nil
+		return nil
 	}
 
 	files, err := p.discoverLockFiles(ctx, inputDir, targetFile, options)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	if len(files) == 0 {
-		return &scaecosystems.PluginResult{}, nil
+		return nil
 	}
 
-	combined := &scaecosystems.PluginResult{}
 	for _, file := range files {
 		lockFilePath := file.RelPath // e.g., "uv.lock" or "project1/uv.lock"
 		lockFileDir := filepath.Dir(lockFilePath)
@@ -73,7 +73,7 @@ func (p Plugin) BuildDepGraphsFromDir(
 			log.Error(ctx, "Failed to build dependency graph", logger.Attr("lockFile", lockFilePath), logger.Err(err))
 			wrappedErr := fmt.Errorf("failed to build dependency graph for %s: %w", lockFilePath, err)
 
-			errorResult := scaecosystems.SCAResult{
+			if emitErr := onGraph(scaecosystems.SCAResult{
 				ProjectDescriptor: identity.ProjectDescriptor{
 					Identity: identity.ProjectIdentity{
 						ProjectType: "uv",
@@ -85,26 +85,28 @@ func (p Plugin) BuildDepGraphsFromDir(
 					NormalisedTargetFile: lockFilePath,
 				},
 				Error: wrappedErr,
+			}); emitErr != nil {
+				return emitErr
 			}
-			combined.Results = append(combined.Results, errorResult)
 			continue
 		}
-		pluginResult, err := p.buildResults(ctx, sbom, lockFilePath, lockFileDir, options, log)
+		emitted, err := p.buildResults(ctx, sbom, lockFilePath, lockFileDir, options, log, onGraph)
 		if err != nil {
-			return nil, err
+			return err
 		}
-		combined.Results = append(combined.Results, pluginResult.Results...)
-		combined.ProcessedFiles = append(combined.ProcessedFiles, pluginResult.ProcessedFiles...)
 
-		if !options.Global.AllProjects {
+		if !options.Global.AllProjects && emitted > 0 {
 			// We don't want more than one project
 			break
 		}
 	}
 
-	return combined, nil
+	return nil
 }
 
+// buildResults parses + converts the SBOM and emits one result per
+// dep-graph via onGraph. Returns the number emitted so the caller can
+// decide whether to break out of the !AllProjects single-project loop.
 func (p Plugin) buildResults(
 	ctx context.Context,
 	sbom Sbom,
@@ -112,10 +114,11 @@ func (p Plugin) buildResults(
 	lockFileDir string,
 	options *scaecosystems.SCAPluginOptions,
 	log logger.Logger,
-) (*scaecosystems.PluginResult, error) {
+	onGraph func(scaecosystems.SCAResult) error,
+) (int, error) {
 	parsedSbom, err := parseAndValidateSBOM(sbom)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse and validate sbom for %s: %w", lockFilePath, err)
+		return 0, fmt.Errorf("failed to parse and validate sbom for %s: %w", lockFilePath, err)
 	}
 
 	if !options.Global.AllProjects && !options.Global.ForceIncludeWorkspacePackages && !hasProjectRoot(parsedSbom) {
@@ -123,21 +126,19 @@ func (p Plugin) buildResults(
 		noRootErr := ecosystems.NewUvNoProjectRootError(
 			"Found uv workspace with no root project. To scan all workspace members use the --all-projects flag.",
 		)
-		return &scaecosystems.PluginResult{
-			Results: []scaecosystems.SCAResult{{
-				ProjectDescriptor: identity.ProjectDescriptor{
-					Identity: identity.ProjectIdentity{
-						ProjectType: "uv",
-						TargetFile:  &lockFilePath,
-					},
+		return 1, onGraph(scaecosystems.SCAResult{
+			ProjectDescriptor: identity.ProjectDescriptor{
+				Identity: identity.ProjectIdentity{
+					ProjectType: "uv",
+					TargetFile:  &lockFilePath,
 				},
-				ResolverMetadata: &scaecosystems.ResolverMetadata{
-					PluginName:           PluginName,
-					NormalisedTargetFile: lockFilePath,
-				},
-				Error: noRootErr,
-			}},
-		}, nil
+			},
+			ResolverMetadata: &scaecosystems.ResolverMetadata{
+				PluginName:           PluginName,
+				NormalisedTargetFile: lockFilePath,
+			},
+			Error: noRootErr,
+		})
 	}
 
 	metadata := extractMetadata(parsedSbom)
@@ -145,11 +146,10 @@ func (p Plugin) buildResults(
 
 	depGraphs, err := p.convertWithFallback(ctx, sbom, metadata, options.Global.ForceSingleGraph, log)
 	if err != nil {
-		return nil, fmt.Errorf("failed to convert sbom to dep-graphs for %s: %w", lockFilePath, err)
+		return 0, fmt.Errorf("failed to convert sbom to dep-graphs for %s: %w", lockFilePath, err)
 	}
 
-	result := &scaecosystems.PluginResult{}
-
+	emitted := 0
 	for _, depGraph := range depGraphs {
 		workspacePackage := findWorkspacePackage(depGraph, workspacePackages)
 
@@ -167,8 +167,9 @@ func (p Plugin) buildResults(
 		if workspacePackage != nil {
 			packagePath = filepath.Join(packagePath, workspacePackage.Path)
 		}
+		processedFiles := make([]string, 0, 3)
 		for _, name := range []string{LockFileName, PyprojectTomlFileName, RequirementsTxtFileName} {
-			result.ProcessedFiles = append(result.ProcessedFiles, filepath.Join(packagePath, name))
+			processedFiles = append(processedFiles, filepath.Join(packagePath, name))
 		}
 
 		var rootName string
@@ -176,7 +177,7 @@ func (p Plugin) buildResults(
 			rootName = rootPkg.Info.Name
 		}
 
-		res := scaecosystems.SCAResult{
+		if emitErr := onGraph(scaecosystems.SCAResult{
 			DepGraph: depGraph,
 			ProjectDescriptor: identity.ProjectDescriptor{
 				Identity: identity.ProjectIdentity{
@@ -190,11 +191,14 @@ func (p Plugin) buildResults(
 				NormalisedTargetFile: manifestFile,
 				VersionBuildInfo:     map[string]string{},
 			},
+			ProcessedFiles: processedFiles,
+		}); emitErr != nil {
+			return emitted, emitErr
 		}
-		result.Results = append(result.Results, res)
+		emitted++
 	}
 
-	return result, nil
+	return emitted, nil
 }
 
 // sbomMetadata is the minimal metadata needed to construct an empty dep-graph

--- a/pkg/ecosystems/python/uv/plugin_test.go
+++ b/pkg/ecosystems/python/uv/plugin_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
 	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/logger"
+	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/scatest"
 )
 
 var testLogger = logger.Nop()
@@ -225,7 +226,7 @@ func TestPlugin_BuildDepGraphsFromDir(t *testing.T) {
 				WithAllProjects(tt.allProjects).
 				WithExclude(tt.exclude).
 				WithExcludePaths(tt.excludePaths)
-			pluginResult, err := plugin.BuildDepGraphsFromDir(ctx, testLogger, tmpDir, options)
+			results, err := scatest.Run(ctx, plugin, testLogger, tmpDir, options)
 
 			// Check error
 			if tt.expectedErr != "" {
@@ -234,7 +235,7 @@ func TestPlugin_BuildDepGraphsFromDir(t *testing.T) {
 				return
 			}
 
-			findings := pluginResult.Results
+			findings := results
 
 			// Verify correct directories were processed
 			gotDirs := mockClient.CalledDirs
@@ -270,8 +271,8 @@ func TestPlugin_ShouldNotSkipProcessingWhenNoTargetFileIsSet(t *testing.T) {
 	plugin := NewPlugin(mockClient, mockConverter(), "")
 
 	options := ecosystems.NewPluginOptions()
-	pluginResult, err := plugin.BuildDepGraphsFromDir(t.Context(), testLogger, tmpDir, options)
-	findings := pluginResult.Results
+	results, err := scatest.Run(t.Context(), plugin, testLogger, tmpDir, options)
+	findings := results
 	require.NoError(t, err)
 
 	require.Len(t, findings, 1, "Should return findings")
@@ -285,8 +286,8 @@ func TestPlugin_ShouldNotSkipProcessingWhenUvLockFile(t *testing.T) {
 	plugin := NewPlugin(mockClient, mockConverter(), "")
 
 	options := ecosystems.NewPluginOptions().WithTargetFile("uv.lock")
-	pluginResult, err := plugin.BuildDepGraphsFromDir(t.Context(), testLogger, tmpDir, options)
-	findings := pluginResult.Results
+	results, err := scatest.Run(t.Context(), plugin, testLogger, tmpDir, options)
+	findings := results
 	require.NoError(t, err)
 
 	require.Len(t, findings, 1, "Should return findings")
@@ -300,8 +301,8 @@ func TestPlugin_SkipsProcessingWhenTargetFileIsNotUVFile(t *testing.T) {
 	plugin := NewPlugin(mockClient, mockConverter(), "")
 
 	options := ecosystems.NewPluginOptions().WithTargetFile("package.json")
-	pluginResult, err := plugin.BuildDepGraphsFromDir(t.Context(), testLogger, tmpDir, options)
-	findings := pluginResult.Results
+	results, err := scatest.Run(t.Context(), plugin, testLogger, tmpDir, options)
+	findings := results
 	require.NoError(t, err)
 
 	require.Len(t, findings, 0, "Should return no findings")
@@ -315,8 +316,8 @@ func TestPlugin_SkipsProcessingWhenTargetFileIsAPyProjectTomlFile(t *testing.T) 
 	plugin := NewPlugin(mockClient, mockConverter(), "")
 
 	options := ecosystems.NewPluginOptions().WithTargetFile("pyproject.toml")
-	pluginResult, err := plugin.BuildDepGraphsFromDir(t.Context(), testLogger, tmpDir, options)
-	findings := pluginResult.Results
+	results, err := scatest.Run(t.Context(), plugin, testLogger, tmpDir, options)
+	findings := results
 	require.NoError(t, err)
 
 	require.Len(t, findings, 0, "Should return no findings")
@@ -335,8 +336,8 @@ func TestPlugin_ShouldNotSkipProcessingWhenTargetFileIsRelativeFolderPath(t *tes
 	plugin := NewPlugin(mockClient, mockConverter(), "")
 
 	options := ecosystems.NewPluginOptions().WithTargetFile("my-project/uv.lock")
-	pluginResult, err := plugin.BuildDepGraphsFromDir(t.Context(), testLogger, tmpDir, options)
-	findings := pluginResult.Results
+	results, err := scatest.Run(t.Context(), plugin, testLogger, tmpDir, options)
+	findings := results
 	require.NoError(t, err)
 
 	require.Len(t, findings, 1, "Should return findings for the specific uv.lock file")
@@ -356,8 +357,8 @@ func TestPlugin_ShouldSkipProcessingWhenTargetFileIsNotUvLockInRelativeFolderPat
 	plugin := NewPlugin(mockClient, mockConverter(), "")
 
 	options := ecosystems.NewPluginOptions().WithTargetFile("my-project/package.json")
-	pluginResult, err := plugin.BuildDepGraphsFromDir(t.Context(), testLogger, tmpDir, options)
-	findings := pluginResult.Results
+	results, err := scatest.Run(t.Context(), plugin, testLogger, tmpDir, options)
+	findings := results
 	require.NoError(t, err)
 
 	require.Len(t, findings, 0, "Should return no findings")
@@ -376,12 +377,12 @@ func TestPlugin_ShouldRaiseErrorWhenTargetFileIsUvLockInRelativeFolderButDoesNot
 	plugin := NewPlugin(mockClient, mockConverter(), "")
 
 	options := ecosystems.NewPluginOptions().WithTargetFile("my-project/uv.lock")
-	pluginResult, err := plugin.BuildDepGraphsFromDir(t.Context(), testLogger, tmpDir, options)
+	results, err := scatest.Run(t.Context(), plugin, testLogger, tmpDir, options)
 
 	require.Error(t, err)
 	require.ErrorContains(t, err, "failed to find uv lockfile(s)")
 
-	require.Nil(t, pluginResult, "Should return nil result on error")
+	require.Empty(t, results, "Should emit no results on error")
 	require.Empty(t, mockClient.CalledDirs, "Should not call the uv client")
 }
 
@@ -393,8 +394,8 @@ func TestPlugin_BuildDepGraphsFromDir_ErrorHandling(t *testing.T) {
 
 	ctx := context.Background()
 	options := ecosystems.NewPluginOptions()
-	pluginResult, err := plugin.BuildDepGraphsFromDir(ctx, testLogger, tmpDir, options)
-	findings := pluginResult.Results
+	results, err := scatest.Run(ctx, plugin, testLogger, tmpDir, options)
+	findings := results
 	require.NoError(t, err)
 
 	require.Len(t, findings, 1)
@@ -423,8 +424,8 @@ func TestPlugin_BuildDepGraphsFromDir_MixedSuccessAndFailure(t *testing.T) {
 	options := ecosystems.NewPluginOptions().WithAllProjects(true)
 	// project1 fails at ExportSBOM (before conversion), so the converter is only called for "." and "project2".
 	plugin := NewPlugin(mockClient, mockConverter(createTestDepGraph("mock-project", "1.0.0")), "")
-	pluginResult, err := plugin.BuildDepGraphsFromDir(ctx, testLogger, tmpDir, options)
-	findings := pluginResult.Results
+	results, err := scatest.Run(ctx, plugin, testLogger, tmpDir, options)
+	findings := results
 	require.NoError(t, err)
 
 	require.Len(t, findings, 3)
@@ -454,15 +455,15 @@ func TestBuildFindings_Success(t *testing.T) {
 	sbom := Sbom(validSBOMJSON)
 	plugin := NewPlugin(&MockClient{}, mockConverter(createTestDepGraph("test-package", "1.0.0")), "")
 
-	buildResult, err := plugin.buildResults(context.Background(), sbom, "uv.lock", ".", ecosystems.NewPluginOptions(), testLogger)
+	results, err := collectBuildResults(context.Background(), plugin, sbom, "uv.lock", ".", ecosystems.NewPluginOptions(), testLogger)
 
-	findings := buildResult.Results
+	findings := results
 	require.NoError(t, err)
 	require.Len(t, findings, 1)
 	assert.NotNil(t, findings[0].DepGraph)
 	assert.Equal(t, "pyproject.toml", findings[0].ResolverMetadata.NormalisedTargetFile)
 	assert.Nil(t, findings[0].Error)
-	assert.Equal(t, []string{"uv.lock", "pyproject.toml", "requirements.txt"}, buildResult.ProcessedFiles)
+	assert.Equal(t, []string{"uv.lock", "pyproject.toml", "requirements.txt"}, findings[0].ProcessedFiles)
 }
 
 func TestBuildFindings_NoProjectRoot_ReturnsErrorFinding(t *testing.T) {
@@ -505,8 +506,8 @@ func TestBuildFindings_NoProjectRoot_ReturnsErrorFinding(t *testing.T) {
 	sbom := Sbom(sbomJSON)
 	plugin := NewPlugin(&MockClient{}, mockConverter(), "")
 
-	buildResult, err := plugin.buildResults(context.Background(), sbom, "uv.lock", ".", ecosystems.NewPluginOptions(), testLogger)
-	findings := buildResult.Results
+	results, err := collectBuildResults(context.Background(), plugin, sbom, "uv.lock", ".", ecosystems.NewPluginOptions(), testLogger)
+	findings := results
 
 	require.NoError(t, err, "should not return an error, but rather an error finding")
 	require.Len(t, findings, 1)
@@ -553,9 +554,9 @@ func TestBuildFindings_NoProjectRoot_AllProjects_Succeeds(t *testing.T) {
 	sbom := Sbom(sbomJSON)
 	plugin := NewPlugin(&MockClient{}, mockConverter(createTestDepGraph("albatross", "0.1.0")), "")
 
-	buildResult, err := plugin.buildResults(context.Background(), sbom, "uv.lock", ".", ecosystems.NewPluginOptions().WithAllProjects(true), testLogger)
+	results, err := collectBuildResults(context.Background(), plugin, sbom, "uv.lock", ".", ecosystems.NewPluginOptions().WithAllProjects(true), testLogger)
 
-	findings := buildResult.Results
+	findings := results
 	require.NoError(t, err)
 	require.Len(t, findings, 1)
 	assert.NotNil(t, findings[0].DepGraph)
@@ -593,15 +594,16 @@ func TestBuildFindings_NoProjectRoot_UvWorkspacePackages_Succeeds(t *testing.T) 
 	sbom := Sbom(sbomJSON)
 	plugin := NewPlugin(&MockClient{}, mockConverter(createTestDepGraph("albatross", "0.1.0")), "")
 
-	buildResult, err := plugin.buildResults(
+	results, err := collectBuildResults(
 		context.Background(),
+		plugin,
 		sbom,
 		"uv.lock",
 		".",
 		ecosystems.NewPluginOptions().WithForceIncludeWorkspacePackages(true),
 		testLogger,
 	)
-	findings := buildResult.Results
+	findings := results
 
 	require.NoError(t, err)
 	require.Len(t, findings, 1)
@@ -614,10 +616,10 @@ func TestBuildFindings_InvalidSBOM(t *testing.T) {
 	sbom := Sbom(`{"invalid": "json"}`)
 	plugin := NewPlugin(&MockClient{}, mockConverter(), "")
 
-	buildResult, err := plugin.buildResults(context.Background(), sbom, "uv.lock", ".", ecosystems.NewPluginOptions(), testLogger)
+	results, err := collectBuildResults(context.Background(), plugin, sbom, "uv.lock", ".", ecosystems.NewPluginOptions(), testLogger)
 
 	assert.Error(t, err)
-	assert.Nil(t, buildResult)
+	assert.Empty(t, results)
 	assert.Contains(t, err.Error(), "failed to parse and validate sbom")
 }
 
@@ -629,10 +631,10 @@ func TestBuildFindings_MissingRootComponent(t *testing.T) {
 	sbom := Sbom(sbomJSON)
 	plugin := NewPlugin(&MockClient{}, mockConverter(), "")
 
-	buildResult, err := plugin.buildResults(context.Background(), sbom, "uv.lock", ".", ecosystems.NewPluginOptions(), testLogger)
+	results, err := collectBuildResults(context.Background(), plugin, sbom, "uv.lock", ".", ecosystems.NewPluginOptions(), testLogger)
 
 	assert.Error(t, err)
-	assert.Nil(t, buildResult)
+	assert.Empty(t, results)
 	assert.Contains(t, err.Error(), "failed to parse and validate sbom")
 }
 
@@ -640,10 +642,10 @@ func TestBuildFindings_ConversionError(t *testing.T) {
 	sbom := Sbom(validSBOMJSON)
 	plugin := NewPlugin(&MockClient{}, erroringConverter(errors.New("api request failed")), "")
 
-	buildResult, err := plugin.buildResults(context.Background(), sbom, "uv.lock", ".", ecosystems.NewPluginOptions(), testLogger)
+	results, err := collectBuildResults(context.Background(), plugin, sbom, "uv.lock", ".", ecosystems.NewPluginOptions(), testLogger)
 
 	assert.Error(t, err)
-	assert.Nil(t, buildResult)
+	assert.Empty(t, results)
 	assert.Contains(t, err.Error(), "failed to convert sbom to dep-graphs")
 }
 
@@ -653,11 +655,11 @@ func TestBuildFindings_EmptyDepGraphFallback_BuildsFromMetadata(t *testing.T) {
 	// The plugin should fall back to building an empty depgraph from the SBOM root metadata.
 	plugin := NewPlugin(&MockClient{}, mockConverter(), "")
 
-	buildResult, err := plugin.buildResults(context.Background(), sbom, "uv.lock", ".", ecosystems.NewPluginOptions(), testLogger)
+	results, err := collectBuildResults(context.Background(), plugin, sbom, "uv.lock", ".", ecosystems.NewPluginOptions(), testLogger)
 
 	require.NoError(t, err)
-	require.Len(t, buildResult.Results, 1)
-	finding := buildResult.Results[0]
+	require.Len(t, results, 1)
+	finding := results[0]
 	require.NotNil(t, finding.DepGraph)
 	rootPkg := finding.DepGraph.GetRootPkg()
 	assert.Equal(t, "test-package", rootPkg.Info.Name)
@@ -670,8 +672,9 @@ func TestBuildFindings_ForwardsForceSingleGraphToConverter(t *testing.T) {
 	converter := mockConverter(createTestDepGraph("test-package", "1.0.0"))
 	plugin := NewPlugin(&MockClient{}, converter, "")
 
-	_, err := plugin.buildResults(
+	_, err := collectBuildResults(
 		context.Background(),
+		plugin,
 		sbom,
 		"uv.lock",
 		".",
@@ -689,7 +692,7 @@ func TestBuildFindings_ForwardsRemoteRepoURLToConverter(t *testing.T) {
 	converter := mockConverter(createTestDepGraph("test-package", "1.0.0"))
 	plugin := NewPlugin(&MockClient{}, converter, "https://example.com/repo")
 
-	_, err := plugin.buildResults(context.Background(), sbom, "uv.lock", ".", ecosystems.NewPluginOptions(), testLogger)
+	_, err := collectBuildResults(context.Background(), plugin, sbom, "uv.lock", ".", ecosystems.NewPluginOptions(), testLogger)
 
 	require.NoError(t, err)
 	require.Len(t, converter.CalledOptions, 1)
@@ -703,9 +706,9 @@ func TestBuildFindings_MultipleDepGraphs(t *testing.T) {
 		createTestDepGraph("package2", "2.0.0"),
 	), "")
 
-	buildResult, err := plugin.buildResults(context.Background(), sbom, "uv.lock", ".", ecosystems.NewPluginOptions(), testLogger)
+	results, err := collectBuildResults(context.Background(), plugin, sbom, "uv.lock", ".", ecosystems.NewPluginOptions(), testLogger)
 
-	findings := buildResult.Results
+	findings := results
 	require.NoError(t, err)
 	require.Len(t, findings, 2)
 	assert.Equal(t, "package1", findings[0].DepGraph.GetRootPkg().Info.Name)
@@ -747,9 +750,9 @@ func TestBuildFindings_WorkspacePackage(t *testing.T) {
 	sbom := Sbom(sbomJSON)
 	plugin := NewPlugin(&MockClient{}, mockConverter(createTestDepGraph("workspace-package", "3.1.0")), "")
 
-	buildResult, err := plugin.buildResults(context.Background(), sbom, "uv.lock", ".", ecosystems.NewPluginOptions(), testLogger)
+	results, err := collectBuildResults(context.Background(), plugin, sbom, "uv.lock", ".", ecosystems.NewPluginOptions(), testLogger)
 
-	findings := buildResult.Results
+	findings := results
 	require.NoError(t, err)
 	require.Len(t, findings, 1)
 	assert.Equal(t, filepath.Join("packages", "my-package", "pyproject.toml"), findings[0].ResolverMetadata.NormalisedTargetFile)
@@ -759,9 +762,9 @@ func TestBuildFindings_PathConstruction_RootDir(t *testing.T) {
 	sbom := Sbom(validSBOMJSON)
 	plugin := NewPlugin(&MockClient{}, mockConverter(createTestDepGraph("test-package", "1.0.0")), "")
 
-	buildResult, err := plugin.buildResults(context.Background(), sbom, "uv.lock", ".", ecosystems.NewPluginOptions(), testLogger)
+	results, err := collectBuildResults(context.Background(), plugin, sbom, "uv.lock", ".", ecosystems.NewPluginOptions(), testLogger)
 
-	findings := buildResult.Results
+	findings := results
 	require.NoError(t, err)
 	require.Len(t, findings, 1)
 	assert.Equal(t, "pyproject.toml", findings[0].ResolverMetadata.NormalisedTargetFile)
@@ -771,9 +774,9 @@ func TestBuildFindings_PathConstruction_NestedDir(t *testing.T) {
 	sbom := Sbom(validSBOMJSON)
 	plugin := NewPlugin(&MockClient{}, mockConverter(createTestDepGraph("test-package", "1.0.0")), "")
 
-	buildResult, err := plugin.buildResults(context.Background(), sbom, "project1/uv.lock", "project1", ecosystems.NewPluginOptions(), testLogger)
+	results, err := collectBuildResults(context.Background(), plugin, sbom, "project1/uv.lock", "project1", ecosystems.NewPluginOptions(), testLogger)
 
-	findings := buildResult.Results
+	findings := results
 	require.NoError(t, err)
 	require.Len(t, findings, 1)
 	assert.Equal(t, filepath.Join("project1", "pyproject.toml"), findings[0].ResolverMetadata.NormalisedTargetFile)
@@ -814,9 +817,9 @@ func TestBuildFindings_PathConstruction_NestedWorkspacePackage(t *testing.T) {
 	sbom := Sbom(sbomJSON)
 	plugin := NewPlugin(&MockClient{}, mockConverter(createTestDepGraph("workspace-package", "3.1.0")), "")
 
-	buildResult, err := plugin.buildResults(context.Background(), sbom, "workspace/uv.lock", "workspace", ecosystems.NewPluginOptions(), testLogger)
+	results, err := collectBuildResults(context.Background(), plugin, sbom, "workspace/uv.lock", "workspace", ecosystems.NewPluginOptions(), testLogger)
 
-	findings := buildResult.Results
+	findings := results
 	require.NoError(t, err)
 	require.Len(t, findings, 1)
 	assert.Equal(t, filepath.Join("workspace", "packages", "my-package", "pyproject.toml"), findings[0].ResolverMetadata.NormalisedTargetFile)

--- a/pkg/ecosystems/python/uv/testhelpers_test.go
+++ b/pkg/ecosystems/python/uv/testhelpers_test.go
@@ -1,0 +1,27 @@
+package uv
+
+import (
+	"context"
+
+	scaecosystems "github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
+	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/logger"
+)
+
+// collectBuildResults drains plugin.buildResults's streaming emit
+// into a slice. Some unit tests bypass the public SCAPlugin
+// interface to exercise buildResults directly.
+func collectBuildResults(
+	ctx context.Context,
+	plugin Plugin,
+	sbom Sbom,
+	lockFilePath, lockFileDir string,
+	opts *scaecosystems.SCAPluginOptions,
+	log logger.Logger,
+) ([]scaecosystems.SCAResult, error) {
+	var results []scaecosystems.SCAResult
+	_, err := plugin.buildResults(ctx, sbom, lockFilePath, lockFileDir, opts, log, func(r scaecosystems.SCAResult) error {
+		results = append(results, r)
+		return nil
+	})
+	return results, err
+}

--- a/pkg/ecosystems/scatest/scatest.go
+++ b/pkg/ecosystems/scatest/scatest.go
@@ -1,0 +1,34 @@
+// Package scatest provides shared helpers for SCAPlugin tests across
+// pkg/ecosystems/* — chiefly Run, which drives a plugin's
+// BuildDepGraphsFromDir and returns every emitted SCAResult as a
+// slice for the test body to inspect.
+package scatest
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
+	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/logger"
+)
+
+// Run drives plugin.BuildDepGraphsFromDir and returns every emitted
+// SCAResult for the test to inspect. The callback is serialized
+// (single goroutine), matching the SCAPlugin concurrency contract.
+func Run(
+	ctx context.Context,
+	plugin ecosystems.SCAPlugin,
+	log logger.Logger,
+	dir string,
+	opts *ecosystems.SCAPluginOptions,
+) ([]ecosystems.SCAResult, error) {
+	var results []ecosystems.SCAResult
+	err := plugin.BuildDepGraphsFromDir(ctx, log, dir, opts, func(r ecosystems.SCAResult) error {
+		results = append(results, r)
+		return nil
+	})
+	if err != nil {
+		return results, fmt.Errorf("scatest.Run: %w", err)
+	}
+	return results, nil
+}


### PR DESCRIPTION
## Summary

To avoid issues in certain ecosystems where dependency graphs might be extremely large, this changes the interface to provide a callback function for when a dep graph is resolved. This allows consumers to determine their own processing pathway - aggregating results in memory if desired, or writing to disk as results arrive to avoid potentially huge memory consumption.

```go
// Before
BuildDepGraphsFromDir(ctx, log, dir, opts) (*PluginResult, error)

// After
BuildDepGraphsFromDir(ctx, log, dir, opts, onGraph func(SCAResult) error) error
```

⚠️ **This is a breaking API change.** All in-repo plugins (bun, bazel, gradle, legacy, pip, pipenv, uv) and consumers (`orchestrator/registry`, `depgraph/sbom_resolution`) are updated in this PR. External consumers will need to update their own consuming code.

## Concurrency contract

The plugin must invoke `onGraph` serially. Plugins that parallelise graph construction internally (pip, pipenv) wrap the call site in a `sync.Mutex` to ensure serial callback execution.

## Review order

Review this commit by commit.

I took the decision to NOT ensure compilation completeness per-commit, and optimised for reviewers readability. This does mean `git bisect` around these commits will not compile, but I think this is an acceptable tradeoff.