### PR TITLE
fix: [CMPA-542] Uses `packageurl-go` for PURL creation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -68,6 +68,7 @@ require (
 	github.com/mattn/go-runewidth v0.0.20 // indirect
 	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/oapi-codegen/runtime v1.1.1 // indirect
+	github.com/package-url/packageurl-go v0.1.3 // indirect
 	github.com/patrickmn/go-cache v2.1.0+incompatible // indirect
 	github.com/pelletier/go-toml/v2 v2.2.3 // indirect
 	github.com/pjbgf/sha1cd v0.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -142,6 +142,8 @@ github.com/oapi-codegen/runtime v1.1.1 h1:EXLHh0DXIJnWhdRPN2w4MXAzFyE4CskzhNLUmt
 github.com/oapi-codegen/runtime v1.1.1/go.mod h1:SK9X900oXmPWilYR5/WKPzt3Kqxn/uS/+lbpREv+eCg=
 github.com/onsi/gomega v1.34.1 h1:EUMJIKUjM8sKjYbtxQI9A4z2o+rruxnzNvpknOXie6k=
 github.com/onsi/gomega v1.34.1/go.mod h1:kU1QgUvBDLXBJq618Xvm2LUX6rSAfRaFRTcdOeDLwwY=
+github.com/package-url/packageurl-go v0.1.3 h1:4juMED3hHiz0set3Vq3KeQ75KD1avthoXLtmE3I0PLs=
+github.com/package-url/packageurl-go v0.1.3/go.mod h1:nKAWB8E6uk1MHqiS/lQb9pYBGH2+mdJ2PJc2s50dQY0=
 github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
 github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/pelletier/go-toml/v2 v2.2.3 h1:YmeHyLY8mFWbdkNWwpr+qIL2bEqT0o95WSdkNHvL12M=

--- a/pkg/ecosystems/gradle/depgraph.go
+++ b/pkg/ecosystems/gradle/depgraph.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/package-url/packageurl-go"
 	"github.com/snyk/dep-graph/go/pkg/depgraph"
 
 	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
@@ -302,18 +303,20 @@ func createPkgInfo(name, version string, provenanceEntry *allDepEntry, provenanc
 			group := parts[0]
 			artifact := parts[1]
 
-			// Create base PURL using pkg:maven for standard Maven coordinates
+			// Build qualifiers for checksum if provenance data is available
+			var qualifiers packageurl.Qualifiers
+			if provenanceEntry != nil && provenanceEntry.Checksum != "" {
+				qualifiers = packageurl.Qualifiers{
+					{Key: "checksum", Value: "sha1:" + provenanceEntry.Checksum},
+				}
+			}
+
+			// Create PURL using pkg:maven for standard Maven coordinates
 			// Note: This assumes all dependencies use Maven coordinate format (group:artifact:version).
 			// If we later need to surface actual Gradle plugins from the Plugin Portal,
 			// we would need to detect and use pkg:gradle for those instead.
-			purl := fmt.Sprintf("pkg:maven/%s/%s@%s", group, artifact, version)
-
-			// Add checksum qualifier if provenance data is available
-			if provenanceEntry != nil && provenanceEntry.Checksum != "" {
-				purl += fmt.Sprintf("?checksum=sha1:%s", provenanceEntry.Checksum)
-			}
-
-			pkgInfo.PackageURL = purl
+			purl := packageurl.NewPackageURL(packageurl.TypeMaven, group, artifact, version, qualifiers, "")
+			pkgInfo.PackageURL = purl.ToString()
 		}
 	}
 

--- a/pkg/ecosystems/gradle/depgraph_test.go
+++ b/pkg/ecosystems/gradle/depgraph_test.go
@@ -777,7 +777,7 @@ func TestCreatePkgInfo(t *testing.T) {
 
 		assert.Equal(t, "org.example:artifact", pkgInfo.Name)
 		assert.Equal(t, "1.0.0", pkgInfo.Version)
-		assert.Equal(t, "pkg:maven/org.example/artifact@1.0.0?checksum=sha1:abcd1234567890", pkgInfo.PackageURL)
+		assert.Equal(t, "pkg:maven/org.example/artifact@1.0.0?checksum=sha1%3Aabcd1234567890", pkgInfo.PackageURL)
 	})
 
 	t.Run("creates PkgInfo with SHA1 checksum in PURL", func(t *testing.T) {
@@ -789,7 +789,7 @@ func TestCreatePkgInfo(t *testing.T) {
 
 		pkgInfo := createPkgInfo("org.example:artifact", "1.0.0", provenanceEntry, true)
 
-		assert.Equal(t, "pkg:maven/org.example/artifact@1.0.0?checksum=sha1:abcd1234567890", pkgInfo.PackageURL)
+		assert.Equal(t, "pkg:maven/org.example/artifact@1.0.0?checksum=sha1%3Aabcd1234567890", pkgInfo.PackageURL)
 	})
 
 	t.Run("creates PURL without checksum when checksum is empty", func(t *testing.T) {

--- a/pkg/ecosystems/testdata/fixtures/gradle/multi-module/expected_plugin_with_provenance.json
+++ b/pkg/ecosystems/testdata/fixtures/gradle/multi-module/expected_plugin_with_provenance.json
@@ -60,7 +60,7 @@
           "info": {
             "name": "org.apache.commons:commons-lang3",
             "version": "3.14.0",
-            "purl": "pkg:maven/org.apache.commons/commons-lang3@3.14.0?checksum=sha1:1ed471194b02f2c6cb734a0cd6f6f107c673afae"
+            "purl": "pkg:maven/org.apache.commons/commons-lang3@3.14.0?checksum=sha1%3A1ed471194b02f2c6cb734a0cd6f6f107c673afae"
           }
         },
         {
@@ -68,7 +68,7 @@
           "info": {
             "name": "com.google.guava:guava",
             "version": "30.1.1-jre",
-            "purl": "pkg:maven/com.google.guava/guava@30.1.1-jre?checksum=sha1:87e0fd1df874ea3cbe577702fe6f17068b790fd8"
+            "purl": "pkg:maven/com.google.guava/guava@30.1.1-jre?checksum=sha1%3A87e0fd1df874ea3cbe577702fe6f17068b790fd8"
           }
         },
         {
@@ -76,7 +76,7 @@
           "info": {
             "name": "com.google.guava:failureaccess",
             "version": "1.0.1",
-            "purl": "pkg:maven/com.google.guava/failureaccess@1.0.1?checksum=sha1:1dcf1de382a0bf95a3d8b0849546c88bac1292c9"
+            "purl": "pkg:maven/com.google.guava/failureaccess@1.0.1?checksum=sha1%3A1dcf1de382a0bf95a3d8b0849546c88bac1292c9"
           }
         },
         {
@@ -84,7 +84,7 @@
           "info": {
             "name": "com.google.guava:listenablefuture",
             "version": "9999.0-empty-to-avoid-conflict-with-guava",
-            "purl": "pkg:maven/com.google.guava/listenablefuture@9999.0-empty-to-avoid-conflict-with-guava?checksum=sha1:b421526c5f297295adef1c886e5246c39d4ac629"
+            "purl": "pkg:maven/com.google.guava/listenablefuture@9999.0-empty-to-avoid-conflict-with-guava?checksum=sha1%3Ab421526c5f297295adef1c886e5246c39d4ac629"
           }
         },
         {
@@ -92,7 +92,7 @@
           "info": {
             "name": "com.google.code.findbugs:jsr305",
             "version": "3.0.2",
-            "purl": "pkg:maven/com.google.code.findbugs/jsr305@3.0.2?checksum=sha1:25ea2e8b0c338a877313bd4672d3fe056ea78f0d"
+            "purl": "pkg:maven/com.google.code.findbugs/jsr305@3.0.2?checksum=sha1%3A25ea2e8b0c338a877313bd4672d3fe056ea78f0d"
           }
         },
         {
@@ -100,7 +100,7 @@
           "info": {
             "name": "org.checkerframework:checker-qual",
             "version": "3.8.0",
-            "purl": "pkg:maven/org.checkerframework/checker-qual@3.8.0?checksum=sha1:6b83e4a33220272c3a08991498ba9dc09519f190"
+            "purl": "pkg:maven/org.checkerframework/checker-qual@3.8.0?checksum=sha1%3A6b83e4a33220272c3a08991498ba9dc09519f190"
           }
         },
         {
@@ -108,7 +108,7 @@
           "info": {
             "name": "com.google.errorprone:error_prone_annotations",
             "version": "2.5.1",
-            "purl": "pkg:maven/com.google.errorprone/error_prone_annotations@2.5.1?checksum=sha1:562d366678b89ce5d6b6b82c1a073880341e3fba"
+            "purl": "pkg:maven/com.google.errorprone/error_prone_annotations@2.5.1?checksum=sha1%3A562d366678b89ce5d6b6b82c1a073880341e3fba"
           }
         },
         {
@@ -116,7 +116,7 @@
           "info": {
             "name": "com.google.j2objc:j2objc-annotations",
             "version": "1.3",
-            "purl": "pkg:maven/com.google.j2objc/j2objc-annotations@1.3?checksum=sha1:ba035118bc8bac37d7eff77700720999acd9986d"
+            "purl": "pkg:maven/com.google.j2objc/j2objc-annotations@1.3?checksum=sha1%3Aba035118bc8bac37d7eff77700720999acd9986d"
           }
         }
       ],
@@ -233,7 +233,7 @@
           "info": {
             "name": "com.google.guava:guava",
             "version": "30.1.1-jre",
-            "purl": "pkg:maven/com.google.guava/guava@30.1.1-jre?checksum=sha1:87e0fd1df874ea3cbe577702fe6f17068b790fd8"
+            "purl": "pkg:maven/com.google.guava/guava@30.1.1-jre?checksum=sha1%3A87e0fd1df874ea3cbe577702fe6f17068b790fd8"
           }
         },
         {
@@ -241,7 +241,7 @@
           "info": {
             "name": "com.google.guava:failureaccess",
             "version": "1.0.1",
-            "purl": "pkg:maven/com.google.guava/failureaccess@1.0.1?checksum=sha1:1dcf1de382a0bf95a3d8b0849546c88bac1292c9"
+            "purl": "pkg:maven/com.google.guava/failureaccess@1.0.1?checksum=sha1%3A1dcf1de382a0bf95a3d8b0849546c88bac1292c9"
           }
         },
         {
@@ -249,7 +249,7 @@
           "info": {
             "name": "com.google.guava:listenablefuture",
             "version": "9999.0-empty-to-avoid-conflict-with-guava",
-            "purl": "pkg:maven/com.google.guava/listenablefuture@9999.0-empty-to-avoid-conflict-with-guava?checksum=sha1:b421526c5f297295adef1c886e5246c39d4ac629"
+            "purl": "pkg:maven/com.google.guava/listenablefuture@9999.0-empty-to-avoid-conflict-with-guava?checksum=sha1%3Ab421526c5f297295adef1c886e5246c39d4ac629"
           }
         },
         {
@@ -257,7 +257,7 @@
           "info": {
             "name": "com.google.code.findbugs:jsr305",
             "version": "3.0.2",
-            "purl": "pkg:maven/com.google.code.findbugs/jsr305@3.0.2?checksum=sha1:25ea2e8b0c338a877313bd4672d3fe056ea78f0d"
+            "purl": "pkg:maven/com.google.code.findbugs/jsr305@3.0.2?checksum=sha1%3A25ea2e8b0c338a877313bd4672d3fe056ea78f0d"
           }
         },
         {
@@ -265,7 +265,7 @@
           "info": {
             "name": "org.checkerframework:checker-qual",
             "version": "3.8.0",
-            "purl": "pkg:maven/org.checkerframework/checker-qual@3.8.0?checksum=sha1:6b83e4a33220272c3a08991498ba9dc09519f190"
+            "purl": "pkg:maven/org.checkerframework/checker-qual@3.8.0?checksum=sha1%3A6b83e4a33220272c3a08991498ba9dc09519f190"
           }
         },
         {
@@ -273,7 +273,7 @@
           "info": {
             "name": "com.google.errorprone:error_prone_annotations",
             "version": "2.5.1",
-            "purl": "pkg:maven/com.google.errorprone/error_prone_annotations@2.5.1?checksum=sha1:562d366678b89ce5d6b6b82c1a073880341e3fba"
+            "purl": "pkg:maven/com.google.errorprone/error_prone_annotations@2.5.1?checksum=sha1%3A562d366678b89ce5d6b6b82c1a073880341e3fba"
           }
         },
         {
@@ -281,7 +281,7 @@
           "info": {
             "name": "com.google.j2objc:j2objc-annotations",
             "version": "1.3",
-            "purl": "pkg:maven/com.google.j2objc/j2objc-annotations@1.3?checksum=sha1:ba035118bc8bac37d7eff77700720999acd9986d"
+            "purl": "pkg:maven/com.google.j2objc/j2objc-annotations@1.3?checksum=sha1%3Aba035118bc8bac37d7eff77700720999acd9986d"
           }
         }
       ],

--- a/pkg/ecosystems/testdata/fixtures/gradle/platform-bom/expected_plugin_with_provenance.json
+++ b/pkg/ecosystems/testdata/fixtures/gradle/platform-bom/expected_plugin_with_provenance.json
@@ -26,7 +26,7 @@
           "info": {
             "name": "com.google.code.gson:gson",
             "version": "2.8.2",
-            "purl": "pkg:maven/com.google.code.gson/gson@2.8.2?checksum=sha1:3edcfe49d2c6053a70a2a47e4e1c2f94998a49cf"
+            "purl": "pkg:maven/com.google.code.gson/gson@2.8.2?checksum=sha1%3A3edcfe49d2c6053a70a2a47e4e1c2f94998a49cf"
           }
         },
         {
@@ -34,7 +34,7 @@
           "info": {
             "name": "dom4j:dom4j",
             "version": "1.6.1",
-            "purl": "pkg:maven/dom4j/dom4j@1.6.1?checksum=sha1:5d3ccc056b6f056dbf0dddfdf43894b9065a8f94"
+            "purl": "pkg:maven/dom4j/dom4j@1.6.1?checksum=sha1%3A5d3ccc056b6f056dbf0dddfdf43894b9065a8f94"
           }
         },
         {
@@ -42,7 +42,7 @@
           "info": {
             "name": "xml-apis:xml-apis",
             "version": "1.4.01",
-            "purl": "pkg:maven/xml-apis/xml-apis@1.4.01?checksum=sha1:3789d9fada2d3d458c4ba2de349d48780f381ee3"
+            "purl": "pkg:maven/xml-apis/xml-apis@1.4.01?checksum=sha1%3A3789d9fada2d3d458c4ba2de349d48780f381ee3"
           }
         }
       ],

--- a/pkg/ecosystems/testdata/fixtures/gradle/simple/expected_plugin_with_provenance.json
+++ b/pkg/ecosystems/testdata/fixtures/gradle/simple/expected_plugin_with_provenance.json
@@ -18,7 +18,7 @@
           "info": {
             "name": "com.google.guava:guava",
             "version": "30.1.1-jre",
-            "purl": "pkg:maven/com.google.guava/guava@30.1.1-jre?checksum=sha1:87e0fd1df874ea3cbe577702fe6f17068b790fd8"
+            "purl": "pkg:maven/com.google.guava/guava@30.1.1-jre?checksum=sha1%3A87e0fd1df874ea3cbe577702fe6f17068b790fd8"
           }
         },
         {
@@ -26,7 +26,7 @@
           "info": {
             "name": "com.google.guava:failureaccess",
             "version": "1.0.1",
-            "purl": "pkg:maven/com.google.guava/failureaccess@1.0.1?checksum=sha1:1dcf1de382a0bf95a3d8b0849546c88bac1292c9"
+            "purl": "pkg:maven/com.google.guava/failureaccess@1.0.1?checksum=sha1%3A1dcf1de382a0bf95a3d8b0849546c88bac1292c9"
           }
         },
         {
@@ -34,7 +34,7 @@
           "info": {
             "name": "com.google.guava:listenablefuture",
             "version": "9999.0-empty-to-avoid-conflict-with-guava",
-            "purl": "pkg:maven/com.google.guava/listenablefuture@9999.0-empty-to-avoid-conflict-with-guava?checksum=sha1:b421526c5f297295adef1c886e5246c39d4ac629"
+            "purl": "pkg:maven/com.google.guava/listenablefuture@9999.0-empty-to-avoid-conflict-with-guava?checksum=sha1%3Ab421526c5f297295adef1c886e5246c39d4ac629"
           }
         },
         {
@@ -42,7 +42,7 @@
           "info": {
             "name": "com.google.code.findbugs:jsr305",
             "version": "3.0.2",
-            "purl": "pkg:maven/com.google.code.findbugs/jsr305@3.0.2?checksum=sha1:25ea2e8b0c338a877313bd4672d3fe056ea78f0d"
+            "purl": "pkg:maven/com.google.code.findbugs/jsr305@3.0.2?checksum=sha1%3A25ea2e8b0c338a877313bd4672d3fe056ea78f0d"
           }
         },
         {
@@ -50,7 +50,7 @@
           "info": {
             "name": "org.checkerframework:checker-qual",
             "version": "3.8.0",
-            "purl": "pkg:maven/org.checkerframework/checker-qual@3.8.0?checksum=sha1:6b83e4a33220272c3a08991498ba9dc09519f190"
+            "purl": "pkg:maven/org.checkerframework/checker-qual@3.8.0?checksum=sha1%3A6b83e4a33220272c3a08991498ba9dc09519f190"
           }
         },
         {
@@ -58,7 +58,7 @@
           "info": {
             "name": "com.google.errorprone:error_prone_annotations",
             "version": "2.5.1",
-            "purl": "pkg:maven/com.google.errorprone/error_prone_annotations@2.5.1?checksum=sha1:562d366678b89ce5d6b6b82c1a073880341e3fba"
+            "purl": "pkg:maven/com.google.errorprone/error_prone_annotations@2.5.1?checksum=sha1%3A562d366678b89ce5d6b6b82c1a073880341e3fba"
           }
         },
         {
@@ -66,7 +66,7 @@
           "info": {
             "name": "com.google.j2objc:j2objc-annotations",
             "version": "1.3",
-            "purl": "pkg:maven/com.google.j2objc/j2objc-annotations@1.3?checksum=sha1:ba035118bc8bac37d7eff77700720999acd9986d"
+            "purl": "pkg:maven/com.google.j2objc/j2objc-annotations@1.3?checksum=sha1%3Aba035118bc8bac37d7eff77700720999acd9986d"
           }
         },
         {
@@ -74,7 +74,7 @@
           "info": {
             "name": "org.apache.commons:commons-lang3",
             "version": "3.14.0",
-            "purl": "pkg:maven/org.apache.commons/commons-lang3@3.14.0?checksum=sha1:1ed471194b02f2c6cb734a0cd6f6f107c673afae"
+            "purl": "pkg:maven/org.apache.commons/commons-lang3@3.14.0?checksum=sha1%3A1ed471194b02f2c6cb734a0cd6f6f107c673afae"
           }
         }
       ],


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [ ] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

This adjusts our PURL creation in the gradle resolver for the `--include-provenance` flag to instead use the `packageurl-go` package instead of manually creating PURLs.
