### PR TITLE
feat: [CMPA-542] Add NormalizeDepsPostHook to Gradle resolver

### DIFF
--- a/pkg/ecosystems/gradle/normalize_deps.go
+++ b/pkg/ecosystems/gradle/normalize_deps.go
@@ -1,0 +1,32 @@
+package gradle
+
+import (
+	"context"
+
+	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
+	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/logger"
+)
+
+// NormalizeDepsPostHook is the post-hook signature accepted by the Gradle
+// plugin. It rewrites SCA results in place using canonical Maven coordinates
+// resolved by SHA1 via the Snyk Packages API.
+type NormalizeDepsPostHook = func(
+	ctx context.Context,
+	log logger.Logger,
+	results []ecosystems.SCAResult,
+	options *ecosystems.SCAPluginOptions,
+) []ecosystems.SCAResult
+
+// NewNormalizeDepsPostHook returns a no-op post-hook that passes results
+// through unchanged. The full implementation, which resolves canonical Maven
+// coordinates via the Snyk Packages API, is wired in separately.
+func NewNormalizeDepsPostHook() NormalizeDepsPostHook {
+	return func(
+		_ context.Context,
+		_ logger.Logger,
+		results []ecosystems.SCAResult,
+		_ *ecosystems.SCAPluginOptions,
+	) []ecosystems.SCAResult {
+		return results
+	}
+}

--- a/pkg/ecosystems/gradle/plugin.go
+++ b/pkg/ecosystems/gradle/plugin.go
@@ -27,13 +27,23 @@ const (
 
 // Plugin is the Gradle SCA plugin.  It has no exported fields; all
 // configuration is passed through ecosystems.SCAPluginOptions at call time.
-type Plugin struct{}
+type Plugin struct {
+	normalizeDepsPostHook NormalizeDepsPostHook
+}
 
 // Compile-time assertion that Plugin satisfies the SCAPlugin interface.
 var _ ecosystems.SCAPlugin = (*Plugin)(nil)
 
 func (p Plugin) GetName() string {
 	return PluginName
+}
+
+func NewGradlePlugin() *Plugin {
+	return &Plugin{normalizeDepsPostHook: nil}
+}
+
+func NewGradlePluginWithNormalizeDepsHook(normalizeDepsPostHook NormalizeDepsPostHook) *Plugin {
+	return &Plugin{normalizeDepsPostHook: normalizeDepsPostHook}
 }
 
 // BuildDepGraphsFromDir discovers and builds Gradle dependency graphs for the
@@ -75,6 +85,10 @@ func (p Plugin) BuildDepGraphsFromDir(
 	allResults, allProcessedFiles, err := p.processGradleFiles(ctx, log, files, dir, options)
 	if err != nil {
 		return nil, err
+	}
+
+	if options.Gradle.NormalizeDeps && p.normalizeDepsPostHook != nil {
+		allResults = p.normalizeDepsPostHook(ctx, log, allResults, options)
 	}
 
 	return &ecosystems.PluginResult{
@@ -447,7 +461,7 @@ func buildExtraArgs(projectDir string, options *ecosystems.SCAPluginOptions) []s
 	}
 
 	// Pass --include-provenance flag to the init script as a Gradle property
-	if options.Global.IncludeProvenance {
+	if options.Global.IncludeProvenance || options.Gradle.NormalizeDeps {
 		args = append(args, "-PsnykIncludeProvenance=true")
 	}
 

--- a/pkg/ecosystems/gradle/plugin_integration_test.go
+++ b/pkg/ecosystems/gradle/plugin_integration_test.go
@@ -249,7 +249,7 @@ func TestGradleWrapper_BinaryResolution(t *testing.T) {
 	absFixture, err := filepath.Abs(wrapperFixture)
 	require.NoError(t, err, "failed to resolve wrapper fixture path")
 
-	plugin := Plugin{}
+	plugin := NewGradlePlugin()
 	ctx := context.Background()
 
 	testCases := []struct {
@@ -333,7 +333,7 @@ func TestPlugin_BuildDepGraphsFromDir(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 			defer cancel()
 
-			plugin := Plugin{}
+			plugin := NewGradlePlugin()
 			result, err := plugin.BuildDepGraphsFromDir(ctx, logger.Nop(), absFixture, testCase.Options)
 			require.NoError(t, err, "BuildDepGraphsFromDir should not return error")
 			require.NotNil(t, result, "plugin result should not be nil")
@@ -350,6 +350,73 @@ func TestPlugin_BuildDepGraphsFromDir(t *testing.T) {
 			assertResultsMatchExpected(t, result.Results, expected, testCase.Fixture)
 		})
 	}
+}
+
+// TestPlugin_NormalizeDepsPostHook_WiringIntegration verifies that the
+// normalizeDepsPostHook is invoked when --gradle-normalize-deps is set, and
+// is skipped when the flag is absent. It uses a spy hook so no real API
+// calls are made — this exercises only the wiring inside BuildDepGraphsFromDir.
+func TestPlugin_NormalizeDepsPostHook_WiringIntegration(t *testing.T) {
+	gradleVersion, err := gradleRuntime()
+	require.NoErrorf(t, err, "could not detect gradle runtime version")
+	jdkVersion, err := jdkRuntime()
+	require.NoErrorf(t, err, "could not detect jdk runtime version")
+	t.Logf("gradle %s / jdk %s", gradleVersion, jdkVersion)
+
+	fixtureDir := filepath.Join(fixturesRoot, "simple")
+	absFixture, err := filepath.Abs(fixtureDir)
+	require.NoError(t, err, "failed to resolve simple fixture path")
+
+	t.Run("hook_invoked_when_flag_set", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		defer cancel()
+
+		var hookInvoked bool
+		var hookReceivedResults []ecosystems.SCAResult
+		spyHook := func(
+			_ context.Context,
+			_ logger.Logger,
+			results []ecosystems.SCAResult,
+			_ *ecosystems.SCAPluginOptions,
+		) []ecosystems.SCAResult {
+			hookInvoked = true
+			hookReceivedResults = results
+			return results
+		}
+
+		plugin := NewGradlePluginWithNormalizeDepsHook(spyHook)
+		result, err := plugin.BuildDepGraphsFromDir(ctx, logger.Nop(), absFixture,
+			ecosystems.NewPluginOptions().WithGradleNormalizeDeps(true))
+		require.NoError(t, err)
+		require.NotNil(t, result)
+
+		assert.True(t, hookInvoked, "post-hook should be invoked when --gradle-normalize-deps is set")
+		assert.Equal(t, result.Results, hookReceivedResults,
+			"hook should have received the full result set")
+	})
+
+	t.Run("hook_not_invoked_when_flag_unset", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		defer cancel()
+
+		var hookInvoked bool
+		spyHook := func(
+			_ context.Context,
+			_ logger.Logger,
+			results []ecosystems.SCAResult,
+			_ *ecosystems.SCAPluginOptions,
+		) []ecosystems.SCAResult {
+			hookInvoked = true
+			return results
+		}
+
+		plugin := NewGradlePluginWithNormalizeDepsHook(spyHook)
+		_, err := plugin.BuildDepGraphsFromDir(ctx, logger.Nop(), absFixture,
+			ecosystems.NewPluginOptions())
+		require.NoError(t, err)
+
+		assert.False(t, hookInvoked, "post-hook should not be invoked when --gradle-normalize-deps is unset")
+	})
 }
 
 // defaultExpectedFileName returns the snapshot filename used when writing

--- a/pkg/ecosystems/gradle/validation_test.go
+++ b/pkg/ecosystems/gradle/validation_test.go
@@ -230,7 +230,7 @@ func TestValidateOptions_Integration_BuildDepGraphsFromDir(t *testing.T) {
 
 		ctx := context.Background()
 		log := logger.Nop()
-		plugin := Plugin{}
+		plugin := NewGradlePlugin()
 
 		// This should fail fast during validation, before any file discovery or Gradle execution
 		result, err := plugin.BuildDepGraphsFromDir(ctx, log, dir, options)
@@ -251,7 +251,7 @@ func TestValidateOptions_Integration_BuildDepGraphsFromDir(t *testing.T) {
 
 		ctx := context.Background()
 		log := logger.Nop()
-		plugin := Plugin{}
+		plugin := NewGradlePlugin()
 
 		// This should fail fast during validation, before any file discovery
 		result, err := plugin.BuildDepGraphsFromDir(ctx, log, dir, options)
@@ -271,7 +271,7 @@ func TestValidateOptions_Integration_BuildDepGraphsFromDir(t *testing.T) {
 
 		ctx := context.Background()
 		log := logger.Nop()
-		plugin := Plugin{}
+		plugin := NewGradlePlugin()
 
 		// This should fail fast during validation, before any file discovery or Gradle execution
 		result, err := plugin.BuildDepGraphsFromDir(ctx, log, dir, options)

--- a/pkg/ecosystems/options.go
+++ b/pkg/ecosystems/options.go
@@ -62,10 +62,9 @@ type GradleOptions struct {
 	InitScript string `arg:"--init-script"`
 	// SkipWrapper bypasses gradlew discovery and forces use of the gradle command.
 	SkipWrapper bool `arg:"--gradle-skip-wrapper"`
-	// Note: --gradle-normalize-deps is intentionally not yet supported here.
-	// It requires full JAR downloading for fingerprinting, which is incompatible
-	// with the metadata-only resolution approach used by this plugin.
-	// The flag is still forwarded to the legacy CLI as a fallback.
+	// NormalizeDeps uses the SHAs of the dependencies provided by the IncludeProvenance flag
+	// to lookup the canonical GAV coordinates of the dependency and rewrite the produced DepGraphs.
+	NormalizeDeps bool `arg:"--gradle-normalize-deps"`
 }
 
 // BazelOptions contains Bazel-specific options for dependency graph generation.
@@ -200,6 +199,11 @@ func (o *SCAPluginOptions) WithGradleInitScript(initScript string) *SCAPluginOpt
 
 func (o *SCAPluginOptions) WithGradleSkipWrapper(skipWrapper bool) *SCAPluginOptions {
 	o.Gradle.SkipWrapper = skipWrapper
+	return o
+}
+
+func (o *SCAPluginOptions) WithGradleNormalizeDeps(normalizeDeps bool) *SCAPluginOptions {
+	o.Gradle.NormalizeDeps = normalizeDeps
 	return o
 }
 

--- a/pkg/ecosystems/orchestrator/registry.go
+++ b/pkg/ecosystems/orchestrator/registry.go
@@ -43,7 +43,9 @@ func NewDefaultPluginRegistry(ictx workflow.InvocationContext) (*PluginRegistry,
 		return nil, fmt.Errorf("failed to register bun plugin: %w", err)
 	}
 	// gradle (opt-in via feature flag)
-	if err := r.register(gradle.Plugin{}, withFeatureFlagCheck(FlagNewGradleResolver), withPluginDependencies("bazel")); err != nil {
+	normalizeDepsPostHook := gradle.NewNormalizeDepsPostHook()
+	gradlePlugin := gradle.NewGradlePluginWithNormalizeDepsHook(normalizeDepsPostHook)
+	if err := r.register(gradlePlugin, withFeatureFlagCheck(FlagNewGradleResolver), withPluginDependencies("bazel")); err != nil {
 		return nil, fmt.Errorf("failed to register gradle plugin: %w", err)
 	}
 


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [ ] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

This adds the basic `NormalizeDepsPostHook` pattern for the Gradle resolver and adds a simple No-op hook.
