### PR TITLE
feat: [CMPA-542] Adds Gradle dependency normalization

### DIFF
--- a/internal/snykclient/packages.go
+++ b/internal/snykclient/packages.go
@@ -1,0 +1,110 @@
+package snykclient
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+)
+
+const packagesAPIVersion = "2024-10-15"
+
+// MavenPackageQuery describes the input to the Snyk Packages endpoint when
+// looking up the canonical Maven coordinates for an artifact identified by SHA1.
+type MavenPackageQuery struct {
+	Sha1     string
+	GroupID  string
+	Artifact string
+	Version  string
+}
+
+// packagesResponse mirrors the relevant subset of the /rest/packages response.
+type packagesResponse struct {
+	Data []struct {
+		ID string `json:"id"`
+	} `json:"data"`
+}
+
+// LookupMavenPackage resolves a Maven artifact's canonical coordinates by SHA1.
+//
+// It returns the package URL (purl string) of the canonical artifact as
+// reported by the Packages service, or an empty string if the service has no
+// record of the SHA1. Callers should treat the empty return as "no
+// normalisation possible — keep the original coordinates".
+//
+// HTTP/JSON errors are returned so callers can decide whether to log and
+// continue (the typical fallback) or surface the failure.
+func (t *SnykClient) LookupMavenPackage(ctx context.Context, q MavenPackageQuery) (string, error) {
+	u, err := buildPackagesAPIURL(t.apiBaseURL, q)
+	if err != nil {
+		return "", fmt.Errorf("failed to build packages API URL: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), http.NoBody)
+	if err != nil {
+		return "", fmt.Errorf("failed to create packages request: %w", err)
+	}
+	req.Header.Set("Accept", "application/vnd.api+json")
+
+	resp, err := t.client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("packages request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// 404 means the SHA1 is genuinely unknown to the Packages service; return
+	// empty with no error so the caller falls back to the original coordinates
+	// silently. This is the normal "no canonical mapping" path.
+	if resp.StatusCode == http.StatusNotFound {
+		return "", nil
+	}
+	// Treat anything outside 2xx as an error, including 3xx. Redirects are
+	// included because SnykClient wraps the underlying HTTP client with a
+	// non-redirecting policy (http.ErrUseLastResponse), so a 3xx response
+	// here means the redirect was intentionally not followed and is unexpected.
+	// All non-404 failures are surfaced as errors so callers can log them;
+	// normalize-deps remains best-effort so the caller still falls back to the
+	// original coordinates rather than failing the scan.
+	if resp.StatusCode >= 300 {
+		return "", errorWithRequestID("packages request failed", resp)
+	}
+
+	var body packagesResponse
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return "", fmt.Errorf("failed to decode packages response: %w", err)
+	}
+	if len(body.Data) == 0 {
+		return "", nil
+	}
+	return body.Data[0].ID, nil
+}
+
+// buildPackagesAPIURL constructs the /rest/packages query URL. The endpoint is
+// org-agnostic at the path level; org context is provided via the API token.
+func buildPackagesAPIURL(apiBaseURL string, q MavenPackageQuery) (*url.URL, error) {
+	u, err := url.Parse(apiBaseURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse API base URL: %w", err)
+	}
+	u = u.JoinPath("rest", "packages")
+
+	query := url.Values{
+		"version":      []string{packagesAPIVersion},
+		"package_type": []string{"maven"},
+	}
+	if q.Sha1 != "" {
+		query.Set("package_sha1", q.Sha1)
+	}
+	if q.GroupID != "" {
+		query.Set("package_namespace", q.GroupID)
+	}
+	if q.Artifact != "" {
+		query.Set("package_name", q.Artifact)
+	}
+	if q.Version != "" {
+		query.Set("package_version", q.Version)
+	}
+	u.RawQuery = query.Encode()
+	return u, nil
+}

--- a/internal/snykclient/packages.go
+++ b/internal/snykclient/packages.go
@@ -13,7 +13,7 @@ const packagesAPIVersion = "2024-10-15"
 // MavenPackageQuery describes the input to the Snyk Packages endpoint when
 // looking up the canonical Maven coordinates for an artifact identified by SHA1.
 type MavenPackageQuery struct {
-	Sha1     string
+	SHA1     string
 	GroupID  string
 	Artifact string
 	Version  string
@@ -93,8 +93,8 @@ func buildPackagesAPIURL(apiBaseURL string, q MavenPackageQuery) (*url.URL, erro
 		"version":      []string{packagesAPIVersion},
 		"package_type": []string{"maven"},
 	}
-	if q.Sha1 != "" {
-		query.Set("package_sha1", q.Sha1)
+	if q.SHA1 != "" {
+		query.Set("package_sha1", q.SHA1)
 	}
 	if q.GroupID != "" {
 		query.Set("package_namespace", q.GroupID)

--- a/internal/snykclient/packages_test.go
+++ b/internal/snykclient/packages_test.go
@@ -32,7 +32,7 @@ func Test_LookupMavenPackage_Success(t *testing.T) {
 
 	client := snykclient.NewSnykClient(server.Client(), server.URL, "org1")
 	purl, err := client.LookupMavenPackage(context.Background(), snykclient.MavenPackageQuery{
-		Sha1:     "ABCDEF",
+		SHA1:     "ABCDEF",
 		GroupID:  "com.example",
 		Artifact: "foo",
 		Version:  "1.2.3",
@@ -48,7 +48,7 @@ func Test_LookupMavenPackage_404ReturnsEmpty(t *testing.T) {
 	server := mocks.NewMockSBOMService(response)
 
 	client := snykclient.NewSnykClient(server.Client(), server.URL, "org1")
-	purl, err := client.LookupMavenPackage(context.Background(), snykclient.MavenPackageQuery{Sha1: "X"})
+	purl, err := client.LookupMavenPackage(context.Background(), snykclient.MavenPackageQuery{SHA1: "X"})
 	require.NoError(t, err)
 	assert.Empty(t, purl)
 }
@@ -62,7 +62,7 @@ func Test_LookupMavenPackage_EmptyData(t *testing.T) {
 	server := mocks.NewMockSBOMService(response)
 
 	client := snykclient.NewSnykClient(server.Client(), server.URL, "org1")
-	purl, err := client.LookupMavenPackage(context.Background(), snykclient.MavenPackageQuery{Sha1: "X"})
+	purl, err := client.LookupMavenPackage(context.Background(), snykclient.MavenPackageQuery{SHA1: "X"})
 	require.NoError(t, err)
 	assert.Empty(t, purl)
 }
@@ -82,7 +82,7 @@ func Test_LookupMavenPackage_Non404ErrorStatusReturnsError(t *testing.T) {
 			server := mocks.NewMockSBOMService(response)
 
 			client := snykclient.NewSnykClient(server.Client(), server.URL, "org1")
-			_, err := client.LookupMavenPackage(context.Background(), snykclient.MavenPackageQuery{Sha1: "X"})
+			_, err := client.LookupMavenPackage(context.Background(), snykclient.MavenPackageQuery{SHA1: "X"})
 			assert.Errorf(t, err, "expected error for HTTP %d", status)
 		})
 	}

--- a/internal/snykclient/packages_test.go
+++ b/internal/snykclient/packages_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/snyk/cli-extension-dep-graph/internal/mocks"
-	"github.com/snyk/cli-extension-dep-graph/internal/snykclient"
+	"github.com/snyk/cli-extension-dep-graph/v2/internal/mocks"
+	"github.com/snyk/cli-extension-dep-graph/v2/internal/snykclient"
 )
 
 func Test_LookupMavenPackage_Success(t *testing.T) {

--- a/internal/snykclient/packages_test.go
+++ b/internal/snykclient/packages_test.go
@@ -1,0 +1,89 @@
+package snykclient_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/snyk/cli-extension-dep-graph/internal/mocks"
+	"github.com/snyk/cli-extension-dep-graph/internal/snykclient"
+)
+
+func Test_LookupMavenPackage_Success(t *testing.T) {
+	response := mocks.NewMockResponse(
+		"application/vnd.api+json",
+		[]byte(`{"data":[{"id":"pkg:maven/com.example/foo@1.2.3"}]}`),
+		http.StatusOK,
+	)
+	server := mocks.NewMockSBOMService(response, func(r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/rest/packages", r.URL.Path)
+		q := r.URL.Query()
+		assert.NotEmpty(t, q.Get("version"), "request must carry a version qualifier")
+		assert.Equal(t, "maven", q.Get("package_type"))
+		assert.Equal(t, "ABCDEF", q.Get("package_sha1"))
+		assert.Equal(t, "com.example", q.Get("package_namespace"))
+		assert.Equal(t, "foo", q.Get("package_name"))
+		assert.Equal(t, "1.2.3", q.Get("package_version"))
+	})
+
+	client := snykclient.NewSnykClient(server.Client(), server.URL, "org1")
+	purl, err := client.LookupMavenPackage(context.Background(), snykclient.MavenPackageQuery{
+		Sha1:     "ABCDEF",
+		GroupID:  "com.example",
+		Artifact: "foo",
+		Version:  "1.2.3",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "pkg:maven/com.example/foo@1.2.3", purl)
+}
+
+func Test_LookupMavenPackage_404ReturnsEmpty(t *testing.T) {
+	// 404 is the canonical "no mapping" response — not an error from the
+	// caller's perspective; the natural fallback is to keep original coordinates.
+	response := mocks.NewMockResponse("application/vnd.api+json", []byte(`{}`), http.StatusNotFound)
+	server := mocks.NewMockSBOMService(response)
+
+	client := snykclient.NewSnykClient(server.Client(), server.URL, "org1")
+	purl, err := client.LookupMavenPackage(context.Background(), snykclient.MavenPackageQuery{Sha1: "X"})
+	require.NoError(t, err)
+	assert.Empty(t, purl)
+}
+
+func Test_LookupMavenPackage_EmptyData(t *testing.T) {
+	response := mocks.NewMockResponse(
+		"application/vnd.api+json",
+		[]byte(`{"data":[]}`),
+		http.StatusOK,
+	)
+	server := mocks.NewMockSBOMService(response)
+
+	client := snykclient.NewSnykClient(server.Client(), server.URL, "org1")
+	purl, err := client.LookupMavenPackage(context.Background(), snykclient.MavenPackageQuery{Sha1: "X"})
+	require.NoError(t, err)
+	assert.Empty(t, purl)
+}
+
+func Test_LookupMavenPackage_Non404ErrorStatusReturnsError(t *testing.T) {
+	// Non-404 failure responses (auth failures, rate limits, server errors, etc.)
+	// are returned as errors so callers can log them for debugging.
+	errorStatuses := []int{
+		http.StatusUnauthorized,
+		http.StatusForbidden,
+		http.StatusTooManyRequests,
+		http.StatusInternalServerError,
+	}
+	for _, status := range errorStatuses {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			response := mocks.NewMockResponse("application/vnd.api+json", []byte(`{}`), status)
+			server := mocks.NewMockSBOMService(response)
+
+			client := snykclient.NewSnykClient(server.Client(), server.URL, "org1")
+			_, err := client.LookupMavenPackage(context.Background(), snykclient.MavenPackageQuery{Sha1: "X"})
+			assert.Errorf(t, err, "expected error for HTTP %d", status)
+		})
+	}
+}

--- a/pkg/ecosystems/gradle/depgraph.go
+++ b/pkg/ecosystems/gradle/depgraph.go
@@ -243,14 +243,18 @@ func filterConfigurationsByPattern(configurations []gradleConfig, pattern string
 }
 
 // buildProvenanceMap creates a map from dependency ID to provenance information
-// for quick lookups during graph building. When --include-provenance is enabled,
-// this allows us to attach checksum and type information to dependencies.
+// for quick lookups during graph building. This is built when either
+// --include-provenance or --gradle-normalize-deps is enabled, as both features
+// require checksum and type information to be available for dependencies.
 //
 // Note: If multiple configurations resolve the same dependency ID to different
 // artifacts (different checksums), this takes the first one encountered.
 // This could potentially be improved to handle per-configuration artifacts.
 func buildProvenanceMap(configurations []gradleConfig, options *ecosystems.SCAPluginOptions) map[string]*allDepEntry {
-	if options == nil || !options.Global.IncludeProvenance {
+	if options == nil {
+		return nil
+	}
+	if !options.Global.IncludeProvenance && !options.Gradle.NormalizeDeps {
 		return nil
 	}
 

--- a/pkg/ecosystems/gradle/fake_lookuper.go
+++ b/pkg/ecosystems/gradle/fake_lookuper.go
@@ -1,0 +1,54 @@
+//go:build !release
+
+package gradle
+
+// This file contains test utilities and is excluded from release builds.
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+
+	"github.com/snyk/cli-extension-dep-graph/internal/snykclient"
+)
+
+// fakeLookuper is a programmable packageLookuper used to drive the normalize-deps
+// post-hook without making real HTTP calls. It records the sequence of SHA1s queried so
+// tests can verify dedup behavior.
+//
+//nolint:unused // only used in tests
+type fakeLookuper struct {
+	mu         sync.Mutex
+	calls      map[string]int
+	responses  map[string]string // sha1 -> canonical purl ("" = no mapping)
+	errors     map[string]error  // sha1 -> error to return
+	totalCalls atomic.Int64
+}
+
+//nolint:unused // only used in tests
+func newFakeLookuper() *fakeLookuper {
+	return &fakeLookuper{
+		calls:     make(map[string]int),
+		responses: make(map[string]string),
+		errors:    make(map[string]error),
+	}
+}
+
+//nolint:unused // only used in tests
+func (f *fakeLookuper) LookupMavenPackage(_ context.Context, q snykclient.MavenPackageQuery) (string, error) {
+	f.totalCalls.Add(1)
+	f.mu.Lock()
+	f.calls[q.Sha1]++
+	f.mu.Unlock()
+	if err, ok := f.errors[q.Sha1]; ok {
+		return "", err
+	}
+	return f.responses[q.Sha1], nil
+}
+
+//nolint:unused // only used in tests
+func (f *fakeLookuper) callCount(sha1 string) int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls[sha1]
+}

--- a/pkg/ecosystems/gradle/fake_lookuper.go
+++ b/pkg/ecosystems/gradle/fake_lookuper.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/snyk/cli-extension-dep-graph/internal/snykclient"
+	"github.com/snyk/cli-extension-dep-graph/v2/internal/snykclient"
 )
 
 // fakeLookuper is a programmable packageLookuper used to drive the normalize-deps

--- a/pkg/ecosystems/gradle/fake_lookuper.go
+++ b/pkg/ecosystems/gradle/fake_lookuper.go
@@ -38,12 +38,12 @@ func newFakeLookuper() *fakeLookuper {
 func (f *fakeLookuper) LookupMavenPackage(_ context.Context, q snykclient.MavenPackageQuery) (string, error) {
 	f.totalCalls.Add(1)
 	f.mu.Lock()
-	f.calls[q.Sha1]++
-	f.mu.Unlock()
-	if err, ok := f.errors[q.Sha1]; ok {
+	defer f.mu.Unlock()
+	f.calls[q.SHA1]++
+	if err, ok := f.errors[q.SHA1]; ok {
 		return "", err
 	}
-	return f.responses[q.Sha1], nil
+	return f.responses[q.SHA1], nil
 }
 
 //nolint:unused // only used in tests

--- a/pkg/ecosystems/gradle/normalize_deps.go
+++ b/pkg/ecosystems/gradle/normalize_deps.go
@@ -12,7 +12,7 @@ import (
 	"github.com/snyk/dep-graph/go/pkg/depgraph"
 	"golang.org/x/sync/errgroup"
 
-	"github.com/snyk/cli-extension-dep-graph/internal/snykclient"
+	"github.com/snyk/cli-extension-dep-graph/v2/internal/snykclient"
 	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems"
 	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/logger"
 )

--- a/pkg/ecosystems/gradle/normalize_deps.go
+++ b/pkg/ecosystems/gradle/normalize_deps.go
@@ -89,12 +89,7 @@ func newNormalizeDepsPostHookWithClient(client packageLookuper, orgID string) No
 		var canonicalBySha1 map[string]mavenCoords
 		if len(lookups) > 0 {
 			var failures int
-			var err error
-			canonicalBySha1, failures, err = resolveCanonicalCoords(ctx, log, client, lookups)
-			if err != nil {
-				log.Debug(ctx, "gradle: normalisation canceled", logger.Err(err))
-				return results
-			}
+			canonicalBySha1, failures = resolveCanonicalCoords(ctx, log, client, lookups)
 			if failures > 0 {
 				// Info, not Error: per-SHA1 failures are non-fatal — nodes
 				// without a canonical mapping are kept as-is, matching the
@@ -110,7 +105,13 @@ func newNormalizeDepsPostHookWithClient(client packageLookuper, orgID string) No
 			if results[i].DepGraph == nil {
 				continue
 			}
-			results[i].DepGraph = rewriteDepGraph(results[i].DepGraph, canonicalBySha1, includeProvenance)
+			rewritten, err := rewriteDepGraph(results[i].DepGraph, canonicalBySha1, includeProvenance)
+			if err != nil {
+				log.Info(ctx, "gradle: dep-graph rewrite produced an invalid graph; leaving result unchanged",
+					logger.Err(err))
+				continue
+			}
+			results[i].DepGraph = rewritten
 		}
 
 		return results
@@ -174,19 +175,19 @@ func parseMavenPurl(purlString string) (sha1 string, coords mavenCoords, ok bool
 // resolveCanonicalCoords issues one lookup per unique SHA1, returning a map
 // from SHA1 to the canonical Maven coordinates reported by the Packages API.
 //
-// Per-SHA1 failures are tolerated: unmapped entries are simply absent from the
-// returned map, which causes the rewrite pass to leave the corresponding nodes
-// untouched. The failure count is returned alongside the map so callers can
-// surface a summary warning.
-//
-// Context cancellation is treated as a fatal error and propagated to the caller.
+// All per-SHA1 failures are treated as soft failures — including context
+// cancellation, which causes in-flight lookups to return errors that are
+// counted the same as any other API failure. Unmapped entries are simply absent
+// from the returned map, which causes the rewrite pass to leave the
+// corresponding nodes untouched. The failure count is returned alongside the
+// map so callers can surface a summary warning.
 func resolveCanonicalCoords(
 	ctx context.Context,
 	log logger.Logger,
 	client packageLookuper,
 	lookups map[string]mavenCoords,
-) (canonical map[string]mavenCoords, failureCount int, err error) {
-	canonical = make(map[string]mavenCoords, len(lookups))
+) (map[string]mavenCoords, int) {
+	canonical := make(map[string]mavenCoords, len(lookups))
 	var (
 		mu       sync.Mutex
 		failures atomic.Int64
@@ -208,11 +209,9 @@ func resolveCanonicalCoords(
 			return nil
 		})
 	}
-	if err = group.Wait(); err != nil {
-		return nil, 0, fmt.Errorf("dependency normalisation canceled: %w", err)
-	}
+	_ = group.Wait()
 
-	return canonical, int(failures.Load()), nil
+	return canonical, int(failures.Load())
 }
 
 // resolveOne performs a single SHA1 lookup and parses the returned purl.
@@ -273,13 +272,17 @@ func resolveOne(
 //  3. When --include-provenance was not requested, every purl is stripped from
 //     the final output. This matches the behavior of a non-provenance build
 //     and avoids leaking the purls we synthesized solely to power this hook.
+//
+// BuildGraph is called on the result, which validates that every node PkgID
+// still references a known pkg. An error from BuildGraph indicates a bug in
+// the rewrite logic; callers should fall back to the original graph.
 func rewriteDepGraph(
 	dg *depgraph.DepGraph,
 	canonicalBySha1 map[string]mavenCoords,
 	includeProvenance bool,
-) *depgraph.DepGraph {
+) (*depgraph.DepGraph, error) {
 	if dg == nil {
-		return nil
+		return nil, nil
 	}
 
 	oldToNewPkgID := make(map[string]string, len(dg.Pkgs))
@@ -327,7 +330,7 @@ func rewriteDepGraph(
 		}
 	}
 
-	return &depgraph.DepGraph{
+	out := &depgraph.DepGraph{
 		SchemaVersion: dg.SchemaVersion,
 		PkgManager:    dg.PkgManager,
 		Pkgs:          newPkgs,
@@ -336,6 +339,10 @@ func rewriteDepGraph(
 			Nodes:      newNodes,
 		},
 	}
+	if err := out.BuildGraph(); err != nil {
+		return nil, fmt.Errorf("rewritten dep-graph failed validation: %w", err)
+	}
+	return out, nil
 }
 
 // rewritePkg returns a copy of pkg with canonical Maven coordinates applied

--- a/pkg/ecosystems/gradle/normalize_deps.go
+++ b/pkg/ecosystems/gradle/normalize_deps.go
@@ -317,7 +317,9 @@ func rewriteDepGraph(
 		var bestReplacement string
 
 		for oldPkgID, newPkgID := range oldToNewPkgID {
-			if strings.HasPrefix(node.PkgID, oldPkgID) && len(oldPkgID) > len(bestMatch) {
+			// Match must be exact or followed by ':' to avoid partial version matches
+			// e.g., lib@1.2 should match lib@1.2 and lib@1.2:constraint, but not lib@1.2.3
+			if (node.PkgID == oldPkgID || strings.HasPrefix(node.PkgID, oldPkgID+":")) && len(oldPkgID) > len(bestMatch) {
 				bestMatch = oldPkgID
 				bestReplacement = newPkgID
 			}

--- a/pkg/ecosystems/gradle/normalize_deps.go
+++ b/pkg/ecosystems/gradle/normalize_deps.go
@@ -2,9 +2,27 @@ package gradle
 
 import (
 	"context"
+	"fmt"
+	"net/http"
+	"sync"
+	"sync/atomic"
 
+	"github.com/package-url/packageurl-go"
+	"github.com/snyk/dep-graph/go/pkg/depgraph"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/snyk/cli-extension-dep-graph/internal/snykclient"
 	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems"
 	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/logger"
+)
+
+const (
+	// normaliseConcurrency caps in-flight package lookups to avoid overwhelming
+	// the Packages API.
+	normaliseConcurrency = 100
+
+	// Logging attribute keys used consistently across the normalize deps implementation.
+	logAttrSha1 = "sha1"
 )
 
 // NormalizeDepsPostHook is the post-hook signature accepted by the Gradle
@@ -17,16 +35,328 @@ type NormalizeDepsPostHook = func(
 	options *ecosystems.SCAPluginOptions,
 ) []ecosystems.SCAResult
 
-// NewNormalizeDepsPostHook returns a no-op post-hook that passes results
-// through unchanged. The full implementation, which resolves canonical Maven
-// coordinates via the Snyk Packages API, is wired in separately.
-func NewNormalizeDepsPostHook() NormalizeDepsPostHook {
+// packageLookuper is the minimal interface the post-hook needs from the Snyk
+// API client. It is satisfied by *snykclient.SnykClient and is extracted so
+// tests can substitute a fake.
+type packageLookuper interface {
+	LookupMavenPackage(ctx context.Context, q snykclient.MavenPackageQuery) (string, error)
+}
+
+// mavenCoords captures the Maven GAV triple used both for the API lookup
+// fallback and for rewriting the dep-graph after a canonical purl is returned.
+type mavenCoords struct {
+	groupID  string
+	artifact string
+	version  string
+}
+
+// NewNormalizeDepsPostHook returns a post-hook that rewrites Gradle SCA
+// results using canonical Maven coordinates fetched from the Snyk Packages
+// API.
+//
+// httpClient and apiBaseURL must originate from the GAF networking layer so
+// that authentication, retries, and user-agent headers are applied to outbound
+// requests. orgID is required: the Packages API is gated by an authenticated
+// org context, and we no-op (returning the input unchanged) when it is empty.
+func NewNormalizeDepsPostHook(httpClient *http.Client, apiBaseURL, orgID string) NormalizeDepsPostHook {
+	client := snykclient.NewSnykClient(httpClient, apiBaseURL, orgID)
+	return newNormalizeDepsPostHookWithClient(client, orgID)
+}
+
+// newNormalizeDepsPostHookWithClient is the test-friendly seam: it accepts an
+// already-constructed lookuper and the org ID used for the empty-org guard.
+func newNormalizeDepsPostHookWithClient(client packageLookuper, orgID string) NormalizeDepsPostHook {
 	return func(
-		_ context.Context,
-		_ logger.Logger,
+		ctx context.Context,
+		log logger.Logger,
 		results []ecosystems.SCAResult,
-		_ *ecosystems.SCAPluginOptions,
+		options *ecosystems.SCAPluginOptions,
 	) []ecosystems.SCAResult {
+		if log == nil {
+			log = logger.Nop()
+		}
+
+		if orgID == "" {
+			log.Debug(ctx, "gradle: normalize-deps requested but no org id available; skipping normalisation")
+			return results
+		}
+
+		lookups := collectShaLookups(results)
+		log.Debug(ctx, "gradle: collected unique SHA1 lookups for normalisation",
+			logger.Attr("count", len(lookups)))
+
+		var canonicalBySha1 map[string]mavenCoords
+		if len(lookups) > 0 {
+			var failures int
+			var err error
+			canonicalBySha1, failures, err = resolveCanonicalCoords(ctx, log, client, lookups)
+			if err != nil {
+				log.Debug(ctx, "gradle: normalisation canceled", logger.Err(err))
+				return results
+			}
+			if failures > 0 {
+				// Info, not Error: per-SHA1 failures are non-fatal — nodes
+				// without a canonical mapping are kept as-is, matching the
+				// requested partial-rewrite semantics.
+				log.Info(ctx, "gradle: some dependency normalisation lookups failed; affected nodes left unchanged",
+					logger.Attr("failures", failures),
+					logger.Attr("total", len(lookups)))
+			}
+		}
+
+		includeProvenance := options != nil && options.Global.IncludeProvenance
+		for i := range results {
+			if results[i].DepGraph == nil {
+				continue
+			}
+			results[i].DepGraph = rewriteDepGraph(results[i].DepGraph, canonicalBySha1, includeProvenance)
+		}
+
 		return results
 	}
+}
+
+// collectShaLookups walks every dep-graph and returns a map keyed by SHA1
+// containing the original Maven coordinates parsed from each unique purl.
+//
+// Original coordinates are preserved because the Packages API accepts them as
+// a fallback alongside the SHA1. Pkgs without a parseable purl, without a SHA1
+// qualifier, or that are not pkg:maven are skipped — there is nothing to
+// normalise.
+func collectShaLookups(results []ecosystems.SCAResult) map[string]mavenCoords {
+	lookups := make(map[string]mavenCoords)
+	for _, result := range results {
+		if result.DepGraph == nil {
+			continue
+		}
+		for _, pkg := range result.DepGraph.Pkgs {
+			sha1, coords, ok := parseMavenPurl(pkg.Info.PackageURL)
+			if !ok {
+				continue
+			}
+			if _, exists := lookups[sha1]; exists {
+				continue
+			}
+			lookups[sha1] = coords
+		}
+	}
+	return lookups
+}
+
+// parseMavenPurl extracts the SHA1 qualifier and group/artifact/version triple
+// from a pkg:maven purl. It returns ok=false for any non-maven purl, any purl
+// without a sha1 checksum qualifier, or any malformed input.
+func parseMavenPurl(purlString string) (sha1 string, coords mavenCoords, ok bool) {
+	if purlString == "" {
+		return "", mavenCoords{}, false
+	}
+	purl, err := packageurl.FromString(purlString)
+	if err != nil {
+		return "", mavenCoords{}, false
+	}
+	if purl.Type != packageurl.TypeMaven {
+		return "", mavenCoords{}, false
+	}
+	qualifiers := purl.Qualifiers.Map()
+	checksum := qualifiers["checksum"]
+	const sha1Prefix = "sha1:"
+	if len(checksum) <= len(sha1Prefix) || checksum[:len(sha1Prefix)] != sha1Prefix {
+		return "", mavenCoords{}, false
+	}
+	return checksum[len(sha1Prefix):], mavenCoords{
+		groupID:  purl.Namespace,
+		artifact: purl.Name,
+		version:  purl.Version,
+	}, true
+}
+
+// resolveCanonicalCoords issues one lookup per unique SHA1, returning a map
+// from SHA1 to the canonical Maven coordinates reported by the Packages API.
+//
+// Per-SHA1 failures are tolerated: unmapped entries are simply absent from the
+// returned map, which causes the rewrite pass to leave the corresponding nodes
+// untouched. The failure count is returned alongside the map so callers can
+// surface a summary warning.
+//
+// Context cancellation is treated as a fatal error and propagated to the caller.
+func resolveCanonicalCoords(
+	ctx context.Context,
+	log logger.Logger,
+	client packageLookuper,
+	lookups map[string]mavenCoords,
+) (canonical map[string]mavenCoords, failureCount int, err error) {
+	canonical = make(map[string]mavenCoords, len(lookups))
+	var (
+		mu       sync.Mutex
+		failures atomic.Int64
+	)
+
+	group, groupCtx := errgroup.WithContext(ctx)
+	group.SetLimit(normaliseConcurrency)
+
+	for sha1, coords := range lookups {
+		group.Go(func() error {
+			canonicalCoords, ok := resolveOne(groupCtx, log, client, sha1, coords)
+			if !ok {
+				failures.Add(1)
+				return nil
+			}
+			mu.Lock()
+			canonical[sha1] = canonicalCoords
+			mu.Unlock()
+			return nil
+		})
+	}
+	if err = group.Wait(); err != nil {
+		return nil, 0, fmt.Errorf("dependency normalisation canceled: %w", err)
+	}
+
+	return canonical, int(failures.Load()), nil
+}
+
+// resolveOne performs a single SHA1 lookup and parses the returned purl.
+// ok=false signals "no rewrite for this SHA1" — either the API had no record,
+// the request failed, or the response purl was unparseable. All such cases are
+// recoverable by leaving the original coordinates in place.
+func resolveOne(
+	ctx context.Context,
+	log logger.Logger,
+	client packageLookuper,
+	sha1 string,
+	original mavenCoords,
+) (mavenCoords, bool) {
+	purlString, err := client.LookupMavenPackage(ctx, snykclient.MavenPackageQuery{
+		Sha1:     sha1,
+		GroupID:  original.groupID,
+		Artifact: original.artifact,
+		Version:  original.version,
+	})
+	if err != nil {
+		log.Debug(ctx, "gradle: package lookup failed",
+			logger.Attr(logAttrSha1, sha1),
+			logger.Err(err))
+		return mavenCoords{}, false
+	}
+	if purlString == "" {
+		log.Debug(ctx, "gradle: no canonical mapping available for SHA1",
+			logger.Attr(logAttrSha1, sha1))
+		return mavenCoords{}, false
+	}
+	purl, err := packageurl.FromString(purlString)
+	if err != nil {
+		log.Debug(ctx, "gradle: failed to parse canonical purl from API",
+			logger.Attr(logAttrSha1, sha1),
+			logger.Attr("purl", purlString),
+			logger.Err(err))
+		return mavenCoords{}, false
+	}
+	return mavenCoords{
+		groupID:  purl.Namespace,
+		artifact: purl.Name,
+		version:  purl.Version,
+	}, true
+}
+
+// rewriteDepGraph applies canonical Maven coordinates to a dep-graph in a
+// dedupe-aware manner.
+//
+// The dep-graph is rewritten in three steps:
+//  1. For every pkg whose purl carries a SHA1 that resolved to canonical
+//     coordinates, produce a new pkg ID and updated PkgInfo. Two distinct
+//     originals (e.g. different version strings of the same artifact) may
+//     resolve to the same canonical pkg ID — duplicates are merged.
+//  2. Every node referencing a rewritten pkg gets its PkgID updated. Node IDs
+//     themselves are left untouched: they are opaque handles already used in
+//     dep edges, and the suffixed forms used for pruned/constraint nodes must
+//     remain unique.
+//  3. When --include-provenance was not requested, every purl is stripped from
+//     the final output. This matches the behavior of a non-provenance build
+//     and avoids leaking the purls we synthesized solely to power this hook.
+func rewriteDepGraph(
+	dg *depgraph.DepGraph,
+	canonicalBySha1 map[string]mavenCoords,
+	includeProvenance bool,
+) *depgraph.DepGraph {
+	if dg == nil {
+		return nil
+	}
+
+	oldToNewPkgID := make(map[string]string, len(dg.Pkgs))
+	newPkgs := make([]depgraph.Pkg, 0, len(dg.Pkgs))
+	seenNewPkgID := make(map[string]int, len(dg.Pkgs))
+
+	for _, pkg := range dg.Pkgs {
+		newPkg, changed := rewritePkg(&pkg, canonicalBySha1)
+		if changed {
+			oldToNewPkgID[pkg.ID] = newPkg.ID
+		}
+		if !includeProvenance {
+			newPkg.Info.PackageURL = ""
+		}
+		if existingIdx, ok := seenNewPkgID[newPkg.ID]; ok {
+			// Merge: another original pkg has already produced this canonical
+			// ID. Discard the duplicate but keep the redirection so nodes
+			// pointing at this original are rewritten to the survivor below.
+			oldToNewPkgID[pkg.ID] = newPkgs[existingIdx].ID
+			continue
+		}
+		seenNewPkgID[newPkg.ID] = len(newPkgs)
+		newPkgs = append(newPkgs, newPkg)
+	}
+
+	newNodes := make([]depgraph.Node, len(dg.Graph.Nodes))
+	for i, node := range dg.Graph.Nodes {
+		newNodes[i] = node
+		if redirected, ok := oldToNewPkgID[node.PkgID]; ok {
+			newNodes[i].PkgID = redirected
+		}
+	}
+
+	return &depgraph.DepGraph{
+		SchemaVersion: dg.SchemaVersion,
+		PkgManager:    dg.PkgManager,
+		Pkgs:          newPkgs,
+		Graph: depgraph.Graph{
+			RootNodeID: dg.Graph.RootNodeID,
+			Nodes:      newNodes,
+		},
+	}
+}
+
+// rewritePkg returns a copy of pkg with canonical Maven coordinates applied
+// when a SHA1 mapping is available. changed indicates whether the pkg ID
+// changed (used to decide whether to record a redirection for node rewriting).
+//
+// When the original purl had a SHA1 qualifier but no canonical mapping was
+// found, the pkg is returned unchanged: this is the "leave the node as it
+// was" behavior requested for unresolved SHA1s.
+//
+// The checksum qualifier is preserved on rewritten purls (as elsewhere in
+// this plugin, the SHA1 is the source-of-truth artifact identity).
+func rewritePkg(pkg *depgraph.Pkg, canonicalBySha1 map[string]mavenCoords) (depgraph.Pkg, bool) {
+	sha1, _, ok := parseMavenPurl(pkg.Info.PackageURL)
+	if !ok {
+		return *pkg, false
+	}
+	canonical, found := canonicalBySha1[sha1]
+	if !found {
+		return *pkg, false
+	}
+	newName := fmt.Sprintf("%s:%s", canonical.groupID, canonical.artifact)
+	newVersion := canonical.version
+
+	// Create the canonical PURL using the packageurl library
+	qualifiers := packageurl.Qualifiers{
+		{Key: "checksum", Value: "sha1:" + sha1},
+	}
+	purl := packageurl.NewPackageURL(packageurl.TypeMaven, canonical.groupID, canonical.artifact, newVersion, qualifiers, "")
+	newPurl := purl.ToString()
+	return depgraph.Pkg{
+		ID: fmt.Sprintf("%s@%s", newName, newVersion),
+		Info: depgraph.PkgInfo{
+			Name:       newName,
+			Version:    newVersion,
+			PackageURL: newPurl,
+		},
+	}, true
 }

--- a/pkg/ecosystems/gradle/normalize_deps.go
+++ b/pkg/ecosystems/gradle/normalize_deps.go
@@ -324,9 +324,9 @@ func rewriteDepGraph(
 		}
 
 		if bestMatch != "" {
-			// Replace the matching prefix with the canonical ID, preserving any suffix
-			suffix := node.PkgID[len(bestMatch):]
-			newNodes[i].PkgID = bestReplacement + suffix
+			// Replace with the canonical package ID (no suffix)
+			// The NodeID keeps its original identity, but PkgID must reference a real package
+			newNodes[i].PkgID = bestReplacement
 		}
 	}
 
@@ -339,6 +339,7 @@ func rewriteDepGraph(
 			Nodes:      newNodes,
 		},
 	}
+	// Use standard BuildGraph validation - if this fails, our rewrite is wrong
 	if err := out.BuildGraph(); err != nil {
 		return nil, fmt.Errorf("rewritten dep-graph failed validation: %w", err)
 	}

--- a/pkg/ecosystems/gradle/normalize_deps.go
+++ b/pkg/ecosystems/gradle/normalize_deps.go
@@ -309,18 +309,27 @@ func rewriteDepGraph(
 		newPkgs = append(newPkgs, newPkg)
 	}
 
+	// Rewrite node PkgIDs to reference canonical packages
+	// Performance optimization: use fast O(1) lookup for exact matches,
+	// fall back to O(M) prefix search only for suffixed nodes
 	newNodes := make([]depgraph.Node, len(dg.Graph.Nodes))
 	for i, node := range dg.Graph.Nodes {
 		newNodes[i] = node
 
-		// Find the longest matching base package ID that this node starts with
+		// Fast path: check for exact match first (O(1))
+		if newPkgID, exists := oldToNewPkgID[node.PkgID]; exists {
+			newNodes[i].PkgID = newPkgID
+			continue
+		}
+
+		// Slow path: check for suffixed nodes (only when needed)
+		// Find the longest matching base package ID for suffixed nodes
 		var bestMatch string
 		var bestReplacement string
 
 		for oldPkgID, newPkgID := range oldToNewPkgID {
-			// Match must be exact or followed by ':' to avoid partial version matches
-			// e.g., lib@1.2 should match lib@1.2 and lib@1.2:constraint, but not lib@1.2.3
-			if (node.PkgID == oldPkgID || strings.HasPrefix(node.PkgID, oldPkgID+":")) && len(oldPkgID) > len(bestMatch) {
+			// Check if this is a suffixed node (node.PkgID starts with oldPkgID followed by ':')
+			if strings.HasPrefix(node.PkgID, oldPkgID+":") && len(oldPkgID) > len(bestMatch) {
 				bestMatch = oldPkgID
 				bestReplacement = newPkgID
 			}
@@ -328,7 +337,6 @@ func rewriteDepGraph(
 
 		if bestMatch != "" {
 			// Replace with the canonical package ID (no suffix)
-			// The NodeID keeps its original identity, but PkgID must reference a real package
 			newNodes[i].PkgID = bestReplacement
 		}
 	}

--- a/pkg/ecosystems/gradle/normalize_deps.go
+++ b/pkg/ecosystems/gradle/normalize_deps.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 	"sync"
 	"sync/atomic"
 
@@ -307,8 +308,22 @@ func rewriteDepGraph(
 	newNodes := make([]depgraph.Node, len(dg.Graph.Nodes))
 	for i, node := range dg.Graph.Nodes {
 		newNodes[i] = node
-		if redirected, ok := oldToNewPkgID[node.PkgID]; ok {
-			newNodes[i].PkgID = redirected
+
+		// Find the longest matching base package ID that this node starts with
+		var bestMatch string
+		var bestReplacement string
+
+		for oldPkgID, newPkgID := range oldToNewPkgID {
+			if strings.HasPrefix(node.PkgID, oldPkgID) && len(oldPkgID) > len(bestMatch) {
+				bestMatch = oldPkgID
+				bestReplacement = newPkgID
+			}
+		}
+
+		if bestMatch != "" {
+			// Replace the matching prefix with the canonical ID, preserving any suffix
+			suffix := node.PkgID[len(bestMatch):]
+			newNodes[i].PkgID = bestReplacement + suffix
 		}
 	}
 

--- a/pkg/ecosystems/gradle/normalize_deps.go
+++ b/pkg/ecosystems/gradle/normalize_deps.go
@@ -186,8 +186,8 @@ func resolveCanonicalCoords(
 	log logger.Logger,
 	client packageLookuper,
 	lookups map[string]mavenCoords,
-) (map[string]mavenCoords, int) {
-	canonical := make(map[string]mavenCoords, len(lookups))
+) (canonical map[string]mavenCoords, failureCount int) {
+	canonical = make(map[string]mavenCoords, len(lookups))
 	var (
 		mu       sync.Mutex
 		failures atomic.Int64
@@ -204,12 +204,13 @@ func resolveCanonicalCoords(
 				return nil
 			}
 			mu.Lock()
+			defer mu.Unlock()
 			canonical[sha1] = canonicalCoords
-			mu.Unlock()
 			return nil
 		})
 	}
-	_ = group.Wait()
+	//nolint:errcheck // goroutines always return nil; Wait is called for synchronization only
+	group.Wait()
 
 	return canonical, int(failures.Load())
 }
@@ -282,7 +283,7 @@ func rewriteDepGraph(
 	includeProvenance bool,
 ) (*depgraph.DepGraph, error) {
 	if dg == nil {
-		return nil, nil
+		return nil, nil //nolint:nilnil // nil graph in, nil graph out — no error to report
 	}
 
 	oldToNewPkgID := make(map[string]string, len(dg.Pkgs))

--- a/pkg/ecosystems/gradle/normalize_deps.go
+++ b/pkg/ecosystems/gradle/normalize_deps.go
@@ -227,7 +227,7 @@ func resolveOne(
 	original mavenCoords,
 ) (mavenCoords, bool) {
 	purlString, err := client.LookupMavenPackage(ctx, snykclient.MavenPackageQuery{
-		Sha1:     sha1,
+		SHA1:     sha1,
 		GroupID:  original.groupID,
 		Artifact: original.artifact,
 		Version:  original.version,

--- a/pkg/ecosystems/gradle/normalize_deps_test.go
+++ b/pkg/ecosystems/gradle/normalize_deps_test.go
@@ -610,6 +610,56 @@ func TestPostHook_HandlesLongestPrefixMatching(t *testing.T) {
 	assert.Equal(t, "canon-extended:lib@2", pkgIDsByNode["short@1-extended:suffix"], "should match 'short@1-extended' and reference canonical package")
 }
 
+func TestPostHook_DoesNotMatchPartialVersions(t *testing.T) {
+	// Test that version prefixes don't incorrectly match longer versions.
+	// E.g., if lib@1.2 is normalized but lib@1.2.3 exists, lib@1.2.3 should NOT be rewritten.
+	graph := makeDepGraph(t, []depgraph.Pkg{
+		{ID: "root@1", Info: depgraph.PkgInfo{Name: "root", Version: "1"}},
+		{ID: "lib@1.2", Info: depgraph.PkgInfo{
+			Name:       "lib",
+			Version:    "1.2",
+			PackageURL: "pkg:maven/com/lib@1.2?checksum=sha1:H1",
+		}},
+		{ID: "lib@1.2.3", Info: depgraph.PkgInfo{
+			Name:       "lib",
+			Version:    "1.2.3",
+			PackageURL: "pkg:maven/com/lib@1.2.3?checksum=sha1:H2",
+		}},
+	}, [][2]string{{"root@1", "lib@1.2"}, {"root@1", "lib@1.2.3"}})
+
+	fake := newFakeLookuper()
+	// Only lib@1.2 has a canonical mapping, lib@1.2.3 should be left unchanged
+	fake.responses["H1"] = "pkg:maven/canonical/lib@2.0"
+	// H2 (lib@1.2.3) intentionally has no mapping
+
+	hook := newNormalizeDepsPostHookWithClient(fake, "org-1")
+	results := hook(context.Background(), logger.Nop(),
+		[]ecosystems.SCAResult{{DepGraph: graph}},
+		&ecosystems.SCAPluginOptions{Global: ecosystems.GlobalOptions{IncludeProvenance: true}},
+	)
+
+	out := results[0].DepGraph
+	require.NotNil(t, out)
+
+	// lib@1.2 should be rewritten to canonical
+	canonicalPkg := pkgByID(t, out, "canonical:lib@2.0")
+	assert.Equal(t, "canonical:lib", canonicalPkg.Info.Name)
+	assert.Equal(t, "2.0", canonicalPkg.Info.Version)
+
+	// lib@1.2.3 should remain unchanged (not rewritten due to prefix match)
+	originalPkg := pkgByID(t, out, "lib@1.2.3")
+	assert.Equal(t, "lib", originalPkg.Info.Name)
+	assert.Equal(t, "1.2.3", originalPkg.Info.Version)
+
+	// Verify node mappings are correct
+	pkgIDsByNode := make(map[string]string)
+	for _, node := range out.Graph.Nodes {
+		pkgIDsByNode[node.NodeID] = node.PkgID
+	}
+	assert.Equal(t, "canonical:lib@2.0", pkgIDsByNode["lib@1.2"], "lib@1.2 node should reference canonical package")
+	assert.Equal(t, "lib@1.2.3", pkgIDsByNode["lib@1.2.3"], "lib@1.2.3 node should reference original package (not affected by prefix match)")
+}
+
 func TestPostHook_HandlesSuffixedNodesWithMerging(t *testing.T) {
 	// Test that suffix-aware node rewriting works correctly when multiple
 	// original packages get merged into a single canonical package, and some

--- a/pkg/ecosystems/gradle/normalize_deps_test.go
+++ b/pkg/ecosystems/gradle/normalize_deps_test.go
@@ -464,10 +464,10 @@ func TestPostHook_HandlesSuffixedNodeIDs(t *testing.T) {
 					{NodeID: "orig:lib@OLD:pruned"},
 				}},
 				{NodeID: "orig:lib@OLD", PkgID: "orig:lib@OLD", Deps: []depgraph.Dependency{}},
-				// Constraint node with suffixed PkgID
-				{NodeID: "orig:lib@OLD:constraint", PkgID: "orig:lib@OLD:constraint", Deps: []depgraph.Dependency{}},
-				// Pruned node with suffixed PkgID
-				{NodeID: "orig:lib@OLD:pruned", PkgID: "orig:lib@OLD:pruned", Deps: []depgraph.Dependency{}},
+				// Constraint node - NodeID has suffix, PkgID references actual package
+				{NodeID: "orig:lib@OLD:constraint", PkgID: "orig:lib@OLD", Deps: []depgraph.Dependency{}},
+				// Pruned node - NodeID has suffix, PkgID references actual package  
+				{NodeID: "orig:lib@OLD:pruned", PkgID: "orig:lib@OLD", Deps: []depgraph.Dependency{}},
 			},
 		},
 	}
@@ -495,11 +495,11 @@ func TestPostHook_HandlesSuffixedNodeIDs(t *testing.T) {
 		pkgIDsByNode[node.NodeID] = node.PkgID
 	}
 
-	// Verify that all nodes now reference the canonical package ID,
-	// with suffixes preserved
+	// Verify that all nodes now reference the canonical package ID
+	// NodeIDs keep their original identity, PkgIDs reference the canonical package
 	assert.Equal(t, "canon:lib@NEW", pkgIDsByNode["orig:lib@OLD"], "base node should reference canonical package")
-	assert.Equal(t, "canon:lib@NEW:constraint", pkgIDsByNode["orig:lib@OLD:constraint"], "constraint node should reference canonical package with :constraint suffix")
-	assert.Equal(t, "canon:lib@NEW:pruned", pkgIDsByNode["orig:lib@OLD:pruned"], "pruned node should reference canonical package with :pruned suffix")
+	assert.Equal(t, "canon:lib@NEW", pkgIDsByNode["orig:lib@OLD:constraint"], "constraint node should reference canonical package")
+	assert.Equal(t, "canon:lib@NEW", pkgIDsByNode["orig:lib@OLD:pruned"], "pruned node should reference canonical package")
 }
 
 func TestPostHook_HandlesCustomSuffixes(t *testing.T) {
@@ -523,9 +523,9 @@ func TestPostHook_HandlesCustomSuffixes(t *testing.T) {
 					{NodeID: "orig:lib@OLD:custom-suffix"},
 					{NodeID: "orig:lib@OLD:another:complex:suffix"},
 				}},
-				// Custom suffix patterns
-				{NodeID: "orig:lib@OLD:custom-suffix", PkgID: "orig:lib@OLD:custom-suffix", Deps: []depgraph.Dependency{}},
-				{NodeID: "orig:lib@OLD:another:complex:suffix", PkgID: "orig:lib@OLD:another:complex:suffix", Deps: []depgraph.Dependency{}},
+				// Custom suffix patterns - NodeID has suffix, PkgID references actual package
+				{NodeID: "orig:lib@OLD:custom-suffix", PkgID: "orig:lib@OLD", Deps: []depgraph.Dependency{}},
+				{NodeID: "orig:lib@OLD:another:complex:suffix", PkgID: "orig:lib@OLD", Deps: []depgraph.Dependency{}},
 			},
 		},
 	}
@@ -548,9 +548,9 @@ func TestPostHook_HandlesCustomSuffixes(t *testing.T) {
 		pkgIDsByNode[node.NodeID] = node.PkgID
 	}
 
-	// Verify that custom suffixes are preserved
-	assert.Equal(t, "canon:lib@NEW:custom-suffix", pkgIDsByNode["orig:lib@OLD:custom-suffix"], "custom suffix should be preserved")
-	assert.Equal(t, "canon:lib@NEW:another:complex:suffix", pkgIDsByNode["orig:lib@OLD:another:complex:suffix"], "complex suffix should be preserved")
+	// Verify that nodes reference the canonical package
+	assert.Equal(t, "canon:lib@NEW", pkgIDsByNode["orig:lib@OLD:custom-suffix"], "custom suffixed node should reference canonical package")
+	assert.Equal(t, "canon:lib@NEW", pkgIDsByNode["orig:lib@OLD:another:complex:suffix"], "complex suffixed node should reference canonical package")
 }
 
 func TestPostHook_HandlesLongestPrefixMatching(t *testing.T) {
@@ -579,9 +579,9 @@ func TestPostHook_HandlesLongestPrefixMatching(t *testing.T) {
 					{NodeID: "short@1:suffix"},
 					{NodeID: "short@1-extended:suffix"},
 				}},
-				// Node with suffix that could match multiple prefixes
-				{NodeID: "short@1:suffix", PkgID: "short@1:suffix", Deps: []depgraph.Dependency{}},
-				{NodeID: "short@1-extended:suffix", PkgID: "short@1-extended:suffix", Deps: []depgraph.Dependency{}},
+				// Node with suffix that could match multiple prefixes - PkgID references actual packages
+				{NodeID: "short@1:suffix", PkgID: "short@1", Deps: []depgraph.Dependency{}},
+				{NodeID: "short@1-extended:suffix", PkgID: "short@1-extended", Deps: []depgraph.Dependency{}},
 			},
 		},
 	}
@@ -606,8 +606,8 @@ func TestPostHook_HandlesLongestPrefixMatching(t *testing.T) {
 	}
 
 	// Verify that longest prefix matching worked correctly
-	assert.Equal(t, "canon-short:lib@2:suffix", pkgIDsByNode["short@1:suffix"], "should match 'short@1' not a substring")
-	assert.Equal(t, "canon-extended:lib@2:suffix", pkgIDsByNode["short@1-extended:suffix"], "should match full 'short@1-extended' prefix")
+	assert.Equal(t, "canon-short:lib@2", pkgIDsByNode["short@1:suffix"], "should match 'short@1' and reference canonical package")
+	assert.Equal(t, "canon-extended:lib@2", pkgIDsByNode["short@1-extended:suffix"], "should match 'short@1-extended' and reference canonical package")
 }
 
 func TestPostHook_HandlesSuffixedNodesWithMerging(t *testing.T) {
@@ -643,9 +643,9 @@ func TestPostHook_HandlesSuffixedNodesWithMerging(t *testing.T) {
 				// Regular nodes
 				{NodeID: "a:lib@OLD1", PkgID: "a:lib@OLD1", Deps: []depgraph.Dependency{}},
 				{NodeID: "b:lib@OLD2", PkgID: "b:lib@OLD2", Deps: []depgraph.Dependency{}},
-				// Suffixed nodes from different originals
-				{NodeID: "a:lib@OLD1:constraint", PkgID: "a:lib@OLD1:constraint", Deps: []depgraph.Dependency{}},
-				{NodeID: "b:lib@OLD2:pruned", PkgID: "b:lib@OLD2:pruned", Deps: []depgraph.Dependency{}},
+				// Suffixed nodes from different originals - PkgID references actual packages
+				{NodeID: "a:lib@OLD1:constraint", PkgID: "a:lib@OLD1", Deps: []depgraph.Dependency{}},
+				{NodeID: "b:lib@OLD2:pruned", PkgID: "b:lib@OLD2", Deps: []depgraph.Dependency{}},
 			},
 		},
 	}
@@ -680,10 +680,9 @@ func TestPostHook_HandlesSuffixedNodesWithMerging(t *testing.T) {
 		pkgIDsByNode[node.NodeID] = node.PkgID
 	}
 
-	// All nodes should now reference the canonical package,
-	// with suffixes properly preserved
+	// All nodes should now reference the canonical package
 	assert.Equal(t, "canon:lib@NEW", pkgIDsByNode["a:lib@OLD1"], "regular node from package A should reference canonical")
 	assert.Equal(t, "canon:lib@NEW", pkgIDsByNode["b:lib@OLD2"], "regular node from package B should reference canonical")
-	assert.Equal(t, "canon:lib@NEW:constraint", pkgIDsByNode["a:lib@OLD1:constraint"], "constraint node from package A should reference canonical with suffix")
-	assert.Equal(t, "canon:lib@NEW:pruned", pkgIDsByNode["b:lib@OLD2:pruned"], "pruned node from package B should reference canonical with suffix")
+	assert.Equal(t, "canon:lib@NEW", pkgIDsByNode["a:lib@OLD1:constraint"], "constraint node from package A should reference canonical")
+	assert.Equal(t, "canon:lib@NEW", pkgIDsByNode["b:lib@OLD2:pruned"], "pruned node from package B should reference canonical")
 }

--- a/pkg/ecosystems/gradle/normalize_deps_test.go
+++ b/pkg/ecosystems/gradle/normalize_deps_test.go
@@ -439,3 +439,251 @@ func TestPostHook_PreservesNilDepGraphResults(t *testing.T) {
 	assert.Nil(t, results[1].DepGraph)
 	assert.Equal(t, int64(0), fake.totalCalls.Load())
 }
+
+func TestPostHook_HandlesSuffixedNodeIDs(t *testing.T) {
+	// Test that nodes with suffixed PkgIDs (like constraint and pruned nodes)
+	// are correctly rewritten to reference the canonical packages while
+	// preserving their suffixes.
+	graph := &depgraph.DepGraph{
+		SchemaVersion: "1.3.0",
+		PkgManager:    depgraph.PkgManager{Name: pkgManagerName},
+		Pkgs: []depgraph.Pkg{
+			{ID: "root@1", Info: depgraph.PkgInfo{Name: "root", Version: "1"}},
+			{ID: "orig:lib@OLD", Info: depgraph.PkgInfo{
+				Name:       "orig:lib",
+				Version:    "OLD",
+				PackageURL: "pkg:maven/orig/lib@OLD?checksum=sha1:H1",
+			}},
+		},
+		Graph: depgraph.Graph{
+			RootNodeID: "root@1",
+			Nodes: []depgraph.Node{
+				{NodeID: "root@1", PkgID: "root@1", Deps: []depgraph.Dependency{
+					{NodeID: "orig:lib@OLD"},
+					{NodeID: "orig:lib@OLD:constraint"},
+					{NodeID: "orig:lib@OLD:pruned"},
+				}},
+				{NodeID: "orig:lib@OLD", PkgID: "orig:lib@OLD", Deps: []depgraph.Dependency{}},
+				// Constraint node with suffixed PkgID
+				{NodeID: "orig:lib@OLD:constraint", PkgID: "orig:lib@OLD:constraint", Deps: []depgraph.Dependency{}},
+				// Pruned node with suffixed PkgID
+				{NodeID: "orig:lib@OLD:pruned", PkgID: "orig:lib@OLD:pruned", Deps: []depgraph.Dependency{}},
+			},
+		},
+	}
+
+	fake := newFakeLookuper()
+	fake.responses["H1"] = "pkg:maven/canon/lib@NEW"
+
+	hook := newNormalizeDepsPostHookWithClient(fake, "org-1")
+	results := hook(context.Background(), logger.Nop(),
+		[]ecosystems.SCAResult{{DepGraph: graph}},
+		&ecosystems.SCAPluginOptions{Global: ecosystems.GlobalOptions{IncludeProvenance: true}},
+	)
+
+	out := results[0].DepGraph
+	require.NotNil(t, out)
+
+	// The canonical package should exist
+	canonicalPkg := pkgByID(t, out, "canon:lib@NEW")
+	assert.Equal(t, "canon:lib", canonicalPkg.Info.Name)
+	assert.Equal(t, "NEW", canonicalPkg.Info.Version)
+
+	// Build a map of NodeID -> PkgID for easy verification
+	pkgIDsByNode := make(map[string]string)
+	for _, node := range out.Graph.Nodes {
+		pkgIDsByNode[node.NodeID] = node.PkgID
+	}
+
+	// Verify that all nodes now reference the canonical package ID,
+	// with suffixes preserved
+	assert.Equal(t, "canon:lib@NEW", pkgIDsByNode["orig:lib@OLD"], "base node should reference canonical package")
+	assert.Equal(t, "canon:lib@NEW:constraint", pkgIDsByNode["orig:lib@OLD:constraint"], "constraint node should reference canonical package with :constraint suffix")
+	assert.Equal(t, "canon:lib@NEW:pruned", pkgIDsByNode["orig:lib@OLD:pruned"], "pruned node should reference canonical package with :pruned suffix")
+}
+
+func TestPostHook_HandlesCustomSuffixes(t *testing.T) {
+	// Test that the suffix-aware logic works for any suffix pattern, not just
+	// the hardcoded :constraint and :pruned ones.
+	graph := &depgraph.DepGraph{
+		SchemaVersion: "1.3.0",
+		PkgManager:    depgraph.PkgManager{Name: pkgManagerName},
+		Pkgs: []depgraph.Pkg{
+			{ID: "root@1", Info: depgraph.PkgInfo{Name: "root", Version: "1"}},
+			{ID: "orig:lib@OLD", Info: depgraph.PkgInfo{
+				Name:       "orig:lib",
+				Version:    "OLD",
+				PackageURL: "pkg:maven/orig/lib@OLD?checksum=sha1:H1",
+			}},
+		},
+		Graph: depgraph.Graph{
+			RootNodeID: "root@1",
+			Nodes: []depgraph.Node{
+				{NodeID: "root@1", PkgID: "root@1", Deps: []depgraph.Dependency{
+					{NodeID: "orig:lib@OLD:custom-suffix"},
+					{NodeID: "orig:lib@OLD:another:complex:suffix"},
+				}},
+				// Custom suffix patterns
+				{NodeID: "orig:lib@OLD:custom-suffix", PkgID: "orig:lib@OLD:custom-suffix", Deps: []depgraph.Dependency{}},
+				{NodeID: "orig:lib@OLD:another:complex:suffix", PkgID: "orig:lib@OLD:another:complex:suffix", Deps: []depgraph.Dependency{}},
+			},
+		},
+	}
+
+	fake := newFakeLookuper()
+	fake.responses["H1"] = "pkg:maven/canon/lib@NEW"
+
+	hook := newNormalizeDepsPostHookWithClient(fake, "org-1")
+	results := hook(context.Background(), logger.Nop(),
+		[]ecosystems.SCAResult{{DepGraph: graph}},
+		&ecosystems.SCAPluginOptions{Global: ecosystems.GlobalOptions{IncludeProvenance: true}},
+	)
+
+	out := results[0].DepGraph
+	require.NotNil(t, out)
+
+	// Build a map of NodeID -> PkgID for easy verification
+	pkgIDsByNode := make(map[string]string)
+	for _, node := range out.Graph.Nodes {
+		pkgIDsByNode[node.NodeID] = node.PkgID
+	}
+
+	// Verify that custom suffixes are preserved
+	assert.Equal(t, "canon:lib@NEW:custom-suffix", pkgIDsByNode["orig:lib@OLD:custom-suffix"], "custom suffix should be preserved")
+	assert.Equal(t, "canon:lib@NEW:another:complex:suffix", pkgIDsByNode["orig:lib@OLD:another:complex:suffix"], "complex suffix should be preserved")
+}
+
+func TestPostHook_HandlesLongestPrefixMatching(t *testing.T) {
+	// Test that the longest-prefix matching works correctly when one package ID
+	// is a prefix of another (edge case prevention).
+	graph := &depgraph.DepGraph{
+		SchemaVersion: "1.3.0",
+		PkgManager:    depgraph.PkgManager{Name: pkgManagerName},
+		Pkgs: []depgraph.Pkg{
+			{ID: "root@1", Info: depgraph.PkgInfo{Name: "root", Version: "1"}},
+			{ID: "short@1", Info: depgraph.PkgInfo{
+				Name:       "short",
+				Version:    "1",
+				PackageURL: "pkg:maven/short/lib@1?checksum=sha1:H1",
+			}},
+			{ID: "short@1-extended", Info: depgraph.PkgInfo{
+				Name:       "short-extended",
+				Version:    "1",
+				PackageURL: "pkg:maven/short/extended@1?checksum=sha1:H2",
+			}},
+		},
+		Graph: depgraph.Graph{
+			RootNodeID: "root@1",
+			Nodes: []depgraph.Node{
+				{NodeID: "root@1", PkgID: "root@1", Deps: []depgraph.Dependency{
+					{NodeID: "short@1:suffix"},
+					{NodeID: "short@1-extended:suffix"},
+				}},
+				// Node with suffix that could match multiple prefixes
+				{NodeID: "short@1:suffix", PkgID: "short@1:suffix", Deps: []depgraph.Dependency{}},
+				{NodeID: "short@1-extended:suffix", PkgID: "short@1-extended:suffix", Deps: []depgraph.Dependency{}},
+			},
+		},
+	}
+
+	fake := newFakeLookuper()
+	fake.responses["H1"] = "pkg:maven/canon-short/lib@2"
+	fake.responses["H2"] = "pkg:maven/canon-extended/lib@2"
+
+	hook := newNormalizeDepsPostHookWithClient(fake, "org-1")
+	results := hook(context.Background(), logger.Nop(),
+		[]ecosystems.SCAResult{{DepGraph: graph}},
+		&ecosystems.SCAPluginOptions{Global: ecosystems.GlobalOptions{IncludeProvenance: true}},
+	)
+
+	out := results[0].DepGraph
+	require.NotNil(t, out)
+
+	// Build a map of NodeID -> PkgID for easy verification
+	pkgIDsByNode := make(map[string]string)
+	for _, node := range out.Graph.Nodes {
+		pkgIDsByNode[node.NodeID] = node.PkgID
+	}
+
+	// Verify that longest prefix matching worked correctly
+	assert.Equal(t, "canon-short:lib@2:suffix", pkgIDsByNode["short@1:suffix"], "should match 'short@1' not a substring")
+	assert.Equal(t, "canon-extended:lib@2:suffix", pkgIDsByNode["short@1-extended:suffix"], "should match full 'short@1-extended' prefix")
+}
+
+func TestPostHook_HandlesSuffixedNodesWithMerging(t *testing.T) {
+	// Test that suffix-aware node rewriting works correctly when multiple
+	// original packages get merged into a single canonical package, and some
+	// of those have suffixed nodes (constraint/pruned).
+	graph := &depgraph.DepGraph{
+		SchemaVersion: "1.3.0",
+		PkgManager:    depgraph.PkgManager{Name: pkgManagerName},
+		Pkgs: []depgraph.Pkg{
+			{ID: "root@1", Info: depgraph.PkgInfo{Name: "root", Version: "1"}},
+			// Two different original packages that will map to the same canonical
+			{ID: "a:lib@OLD1", Info: depgraph.PkgInfo{
+				Name:       "a:lib",
+				Version:    "OLD1",
+				PackageURL: "pkg:maven/a/lib@OLD1?checksum=sha1:H1",
+			}},
+			{ID: "b:lib@OLD2", Info: depgraph.PkgInfo{
+				Name:       "b:lib",
+				Version:    "OLD2",
+				PackageURL: "pkg:maven/b/lib@OLD2?checksum=sha1:H2",
+			}},
+		},
+		Graph: depgraph.Graph{
+			RootNodeID: "root@1",
+			Nodes: []depgraph.Node{
+				{NodeID: "root@1", PkgID: "root@1", Deps: []depgraph.Dependency{
+					{NodeID: "a:lib@OLD1"},
+					{NodeID: "a:lib@OLD1:constraint"},
+					{NodeID: "b:lib@OLD2"},
+					{NodeID: "b:lib@OLD2:pruned"},
+				}},
+				// Regular nodes
+				{NodeID: "a:lib@OLD1", PkgID: "a:lib@OLD1", Deps: []depgraph.Dependency{}},
+				{NodeID: "b:lib@OLD2", PkgID: "b:lib@OLD2", Deps: []depgraph.Dependency{}},
+				// Suffixed nodes from different originals
+				{NodeID: "a:lib@OLD1:constraint", PkgID: "a:lib@OLD1:constraint", Deps: []depgraph.Dependency{}},
+				{NodeID: "b:lib@OLD2:pruned", PkgID: "b:lib@OLD2:pruned", Deps: []depgraph.Dependency{}},
+			},
+		},
+	}
+
+	fake := newFakeLookuper()
+	// Both different originals map to the same canonical package
+	fake.responses["H1"] = "pkg:maven/canon/lib@NEW"
+	fake.responses["H2"] = "pkg:maven/canon/lib@NEW"
+
+	hook := newNormalizeDepsPostHookWithClient(fake, "org-1")
+	results := hook(context.Background(), logger.Nop(),
+		[]ecosystems.SCAResult{{DepGraph: graph}},
+		&ecosystems.SCAPluginOptions{Global: ecosystems.GlobalOptions{IncludeProvenance: true}},
+	)
+
+	out := results[0].DepGraph
+	require.NotNil(t, out)
+
+	// Verify merging: only one canonical package should exist
+	canonicalCount := 0
+	for _, pkg := range out.Pkgs {
+		if pkg.ID == "canon:lib@NEW" {
+			canonicalCount++
+		}
+	}
+	assert.Equal(t, 1, canonicalCount, "expected merged packages to result in single canonical pkg")
+	assert.Len(t, out.Pkgs, 2, "expected exactly root + 1 canonical pkg")
+
+	// Build a map of NodeID -> PkgID for verification
+	pkgIDsByNode := make(map[string]string)
+	for _, node := range out.Graph.Nodes {
+		pkgIDsByNode[node.NodeID] = node.PkgID
+	}
+
+	// All nodes should now reference the canonical package,
+	// with suffixes properly preserved
+	assert.Equal(t, "canon:lib@NEW", pkgIDsByNode["a:lib@OLD1"], "regular node from package A should reference canonical")
+	assert.Equal(t, "canon:lib@NEW", pkgIDsByNode["b:lib@OLD2"], "regular node from package B should reference canonical")
+	assert.Equal(t, "canon:lib@NEW:constraint", pkgIDsByNode["a:lib@OLD1:constraint"], "constraint node from package A should reference canonical with suffix")
+	assert.Equal(t, "canon:lib@NEW:pruned", pkgIDsByNode["b:lib@OLD2:pruned"], "pruned node from package B should reference canonical with suffix")
+}

--- a/pkg/ecosystems/gradle/normalize_deps_test.go
+++ b/pkg/ecosystems/gradle/normalize_deps_test.go
@@ -5,58 +5,15 @@ package gradle
 import (
 	"context"
 	"errors"
-	"sync"
-	"sync/atomic"
 	"testing"
 
 	"github.com/snyk/dep-graph/go/pkg/depgraph"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/snyk/cli-extension-dep-graph/internal/snykclient"
 	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
 	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/logger"
 )
-
-// fakeLookuper is a programmable packageLookuper used to drive the post-hook
-// without making real HTTP calls. It records the sequence of SHA1s queried so
-// tests can verify dedup behaviour.
-type fakeLookuper struct {
-	mu          sync.Mutex
-	calls       map[string]int
-	responses   map[string]string // sha1 -> canonical purl ("" = no mapping)
-	errors      map[string]error  // sha1 -> error to return
-	totalCalls  atomic.Int64
-	beforeReply func(sha1 string) // optional hook for synchronisation
-}
-
-func newFakeLookuper() *fakeLookuper {
-	return &fakeLookuper{
-		calls:     make(map[string]int),
-		responses: make(map[string]string),
-		errors:    make(map[string]error),
-	}
-}
-
-func (f *fakeLookuper) LookupMavenPackage(_ context.Context, q snykclient.MavenPackageQuery) (string, error) {
-	f.totalCalls.Add(1)
-	f.mu.Lock()
-	f.calls[q.Sha1]++
-	f.mu.Unlock()
-	if f.beforeReply != nil {
-		f.beforeReply(q.Sha1)
-	}
-	if err, ok := f.errors[q.Sha1]; ok {
-		return "", err
-	}
-	return f.responses[q.Sha1], nil
-}
-
-func (f *fakeLookuper) callCount(sha1 string) int {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	return f.calls[sha1]
-}
 
 // makeDepGraph builds a minimal DepGraph from a slice of pkgs and a
 // parent-child edge list. Node IDs match pkg IDs for ease of reading.

--- a/pkg/ecosystems/gradle/normalize_deps_test.go
+++ b/pkg/ecosystems/gradle/normalize_deps_test.go
@@ -466,7 +466,7 @@ func TestPostHook_HandlesSuffixedNodeIDs(t *testing.T) {
 				{NodeID: "orig:lib@OLD", PkgID: "orig:lib@OLD", Deps: []depgraph.Dependency{}},
 				// Constraint node - NodeID has suffix, PkgID references actual package
 				{NodeID: "orig:lib@OLD:constraint", PkgID: "orig:lib@OLD", Deps: []depgraph.Dependency{}},
-				// Pruned node - NodeID has suffix, PkgID references actual package  
+				// Pruned node - NodeID has suffix, PkgID references actual package
 				{NodeID: "orig:lib@OLD:pruned", PkgID: "orig:lib@OLD", Deps: []depgraph.Dependency{}},
 			},
 		},

--- a/pkg/ecosystems/gradle/normalize_deps_test.go
+++ b/pkg/ecosystems/gradle/normalize_deps_test.go
@@ -1,0 +1,484 @@
+//go:build !integration
+
+package gradle
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/snyk/dep-graph/go/pkg/depgraph"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/snyk/cli-extension-dep-graph/internal/snykclient"
+	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
+	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/logger"
+)
+
+// fakeLookuper is a programmable packageLookuper used to drive the post-hook
+// without making real HTTP calls. It records the sequence of SHA1s queried so
+// tests can verify dedup behaviour.
+type fakeLookuper struct {
+	mu          sync.Mutex
+	calls       map[string]int
+	responses   map[string]string // sha1 -> canonical purl ("" = no mapping)
+	errors      map[string]error  // sha1 -> error to return
+	totalCalls  atomic.Int64
+	beforeReply func(sha1 string) // optional hook for synchronisation
+}
+
+func newFakeLookuper() *fakeLookuper {
+	return &fakeLookuper{
+		calls:     make(map[string]int),
+		responses: make(map[string]string),
+		errors:    make(map[string]error),
+	}
+}
+
+func (f *fakeLookuper) LookupMavenPackage(_ context.Context, q snykclient.MavenPackageQuery) (string, error) {
+	f.totalCalls.Add(1)
+	f.mu.Lock()
+	f.calls[q.Sha1]++
+	f.mu.Unlock()
+	if f.beforeReply != nil {
+		f.beforeReply(q.Sha1)
+	}
+	if err, ok := f.errors[q.Sha1]; ok {
+		return "", err
+	}
+	return f.responses[q.Sha1], nil
+}
+
+func (f *fakeLookuper) callCount(sha1 string) int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls[sha1]
+}
+
+// makeDepGraph builds a minimal DepGraph from a slice of pkgs and a
+// parent-child edge list. Node IDs match pkg IDs for ease of reading.
+// The first pkg becomes the root.
+func makeDepGraph(t *testing.T, pkgs []depgraph.Pkg, edges [][2]string) *depgraph.DepGraph {
+	t.Helper()
+	nodes := make([]depgraph.Node, len(pkgs))
+	for i, pkg := range pkgs {
+		nodes[i] = depgraph.Node{
+			NodeID: pkg.ID,
+			PkgID:  pkg.ID,
+			Deps:   []depgraph.Dependency{},
+		}
+	}
+	nodeByID := make(map[string]*depgraph.Node, len(nodes))
+	for i := range nodes {
+		nodeByID[nodes[i].NodeID] = &nodes[i]
+	}
+	for _, edge := range edges {
+		parent, ok := nodeByID[edge[0]]
+		require.True(t, ok, "edge references unknown parent %q", edge[0])
+		_, ok = nodeByID[edge[1]]
+		require.True(t, ok, "edge references unknown child %q", edge[1])
+		parent.Deps = append(parent.Deps, depgraph.Dependency{NodeID: edge[1]})
+	}
+	return &depgraph.DepGraph{
+		SchemaVersion: "1.3.0",
+		PkgManager:    depgraph.PkgManager{Name: pkgManagerName},
+		Pkgs:          pkgs,
+		Graph: depgraph.Graph{
+			RootNodeID: pkgs[0].ID,
+			Nodes:      nodes,
+		},
+	}
+}
+
+// pkgByID returns the (single) pkg with the given ID, or fails the test.
+func pkgByID(t *testing.T, dg *depgraph.DepGraph, id string) depgraph.Pkg {
+	t.Helper()
+	for _, pkg := range dg.Pkgs {
+		if pkg.ID == id {
+			return pkg
+		}
+	}
+	t.Fatalf("pkg %q not found", id)
+	return depgraph.Pkg{}
+}
+
+func TestParseMavenPurl(t *testing.T) {
+	tests := []struct {
+		name      string
+		purl      string
+		wantOK    bool
+		wantSha1  string
+		wantGroup string
+		wantArt   string
+		wantVer   string
+	}{
+		{
+			name:      "valid maven purl with sha1",
+			purl:      "pkg:maven/com.example/foo@1.2.3?checksum=sha1:abc123",
+			wantOK:    true,
+			wantSha1:  "abc123",
+			wantGroup: "com.example",
+			wantArt:   "foo",
+			wantVer:   "1.2.3",
+		},
+		{
+			name:   "missing checksum qualifier",
+			purl:   "pkg:maven/com.example/foo@1.2.3",
+			wantOK: false,
+		},
+		{
+			name:   "non-maven type",
+			purl:   "pkg:npm/foo@1.0.0?checksum=sha1:abc",
+			wantOK: false,
+		},
+		{
+			name:   "non-sha1 checksum",
+			purl:   "pkg:maven/com.example/foo@1.2.3?checksum=md5:abc",
+			wantOK: false,
+		},
+		{
+			name:   "empty string",
+			purl:   "",
+			wantOK: false,
+		},
+		{
+			name:   "malformed purl",
+			purl:   "not-a-purl",
+			wantOK: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			sha1, coords, ok := parseMavenPurl(tc.purl)
+			assert.Equal(t, tc.wantOK, ok)
+			if tc.wantOK {
+				assert.Equal(t, tc.wantSha1, sha1)
+				assert.Equal(t, tc.wantGroup, coords.groupID)
+				assert.Equal(t, tc.wantArt, coords.artifact)
+				assert.Equal(t, tc.wantVer, coords.version)
+			}
+		})
+	}
+}
+
+func TestCollectShaLookups_DedupesAcrossGraphs(t *testing.T) {
+	// Two distinct graphs both reference the same SHA1 — the lookup map
+	// should contain it exactly once. A second SHA1 appears only in graph B
+	// and must still be picked up.
+	graphA := makeDepGraph(t, []depgraph.Pkg{
+		{ID: "root@1", Info: depgraph.PkgInfo{Name: "root", Version: "1"}},
+		{ID: "shared@1", Info: depgraph.PkgInfo{
+			Name:       "shared",
+			Version:    "1",
+			PackageURL: "pkg:maven/g/shared@1?checksum=sha1:SHARED",
+		}},
+	}, [][2]string{{"root@1", "shared@1"}})
+	graphB := makeDepGraph(t, []depgraph.Pkg{
+		{ID: "root@2", Info: depgraph.PkgInfo{Name: "root", Version: "2"}},
+		{ID: "shared@1", Info: depgraph.PkgInfo{
+			Name:       "shared",
+			Version:    "1",
+			PackageURL: "pkg:maven/g/shared@1?checksum=sha1:SHARED",
+		}},
+		{ID: "other@1", Info: depgraph.PkgInfo{
+			Name:       "other",
+			Version:    "1",
+			PackageURL: "pkg:maven/g/other@1?checksum=sha1:OTHER",
+		}},
+	}, [][2]string{{"root@2", "shared@1"}, {"root@2", "other@1"}})
+
+	results := []ecosystems.SCAResult{{DepGraph: graphA}, {DepGraph: graphB}}
+	lookups := collectShaLookups(results)
+
+	require.Len(t, lookups, 2)
+	assert.Equal(t, mavenCoords{"g", "shared", "1"}, lookups["SHARED"])
+	assert.Equal(t, mavenCoords{"g", "other", "1"}, lookups["OTHER"])
+}
+
+func TestCollectShaLookups_SkipsPkgsWithoutSha1(t *testing.T) {
+	graph := makeDepGraph(t, []depgraph.Pkg{
+		{ID: "root@1", Info: depgraph.PkgInfo{Name: "root", Version: "1"}},
+		{ID: "no-purl@1", Info: depgraph.PkgInfo{Name: "no-purl", Version: "1"}},
+		{ID: "no-sha1@1", Info: depgraph.PkgInfo{
+			Name:       "no-sha1",
+			Version:    "1",
+			PackageURL: "pkg:maven/g/no-sha1@1",
+		}},
+		{ID: "with-sha1@1", Info: depgraph.PkgInfo{
+			Name:       "with-sha1",
+			Version:    "1",
+			PackageURL: "pkg:maven/g/with-sha1@1?checksum=sha1:HASH",
+		}},
+	}, nil)
+
+	lookups := collectShaLookups([]ecosystems.SCAResult{{DepGraph: graph}})
+
+	require.Len(t, lookups, 1)
+	assert.Contains(t, lookups, "HASH")
+}
+
+func TestPostHook_RewritesGraphFromCanonicalCoords(t *testing.T) {
+	graph := makeDepGraph(t, []depgraph.Pkg{
+		{ID: "root@1", Info: depgraph.PkgInfo{Name: "root", Version: "1"}},
+		{ID: "orig:lib@OLD", Info: depgraph.PkgInfo{
+			Name:       "orig:lib",
+			Version:    "OLD",
+			PackageURL: "pkg:maven/orig/lib@OLD?checksum=sha1:H1",
+		}},
+	}, [][2]string{{"root@1", "orig:lib@OLD"}})
+
+	fake := newFakeLookuper()
+	fake.responses["H1"] = "pkg:maven/canon/lib@NEW"
+
+	hook := newNormalizeDepsPostHookWithClient(fake, "org-1")
+	results := hook(context.Background(), logger.Nop(),
+		[]ecosystems.SCAResult{{DepGraph: graph}},
+		&ecosystems.SCAPluginOptions{Global: ecosystems.GlobalOptions{IncludeProvenance: true}},
+	)
+
+	require.Len(t, results, 1)
+	out := results[0].DepGraph
+	require.NotNil(t, out)
+
+	// The rewritten pkg uses canonical name and version, and the checksum
+	// qualifier is preserved (IncludeProvenance=true).
+	pkg := pkgByID(t, out, "canon:lib@NEW")
+	assert.Equal(t, "canon:lib", pkg.Info.Name)
+	assert.Equal(t, "NEW", pkg.Info.Version)
+	assert.Equal(t, "pkg:maven/canon/lib@NEW?checksum=sha1%3AH1", pkg.Info.PackageURL)
+
+	// The node IDs are stable; only PkgID rewrites. The "orig:lib@OLD" node
+	// must now reference the canonical pkg.
+	var foundNode *depgraph.Node
+	for i := range out.Graph.Nodes {
+		if out.Graph.Nodes[i].NodeID == "orig:lib@OLD" {
+			foundNode = &out.Graph.Nodes[i]
+			break
+		}
+	}
+	require.NotNil(t, foundNode, "expected node 'orig:lib@OLD' to be preserved")
+	assert.Equal(t, "canon:lib@NEW", foundNode.PkgID)
+}
+
+func TestPostHook_LeavesUnresolvedSha1Untouched(t *testing.T) {
+	graph := makeDepGraph(t, []depgraph.Pkg{
+		{ID: "root@1", Info: depgraph.PkgInfo{Name: "root", Version: "1"}},
+		{ID: "orig:lib@OLD", Info: depgraph.PkgInfo{
+			Name:       "orig:lib",
+			Version:    "OLD",
+			PackageURL: "pkg:maven/orig/lib@OLD?checksum=sha1:H_UNKNOWN",
+		}},
+	}, [][2]string{{"root@1", "orig:lib@OLD"}})
+
+	fake := newFakeLookuper()
+	// No response configured: API returns "no mapping" for this SHA1.
+
+	hook := newNormalizeDepsPostHookWithClient(fake, "org-1")
+	results := hook(context.Background(), logger.Nop(),
+		[]ecosystems.SCAResult{{DepGraph: graph}},
+		&ecosystems.SCAPluginOptions{Global: ecosystems.GlobalOptions{IncludeProvenance: true}},
+	)
+
+	out := results[0].DepGraph
+	pkg := pkgByID(t, out, "orig:lib@OLD")
+	assert.Equal(t, "orig:lib", pkg.Info.Name)
+	assert.Equal(t, "OLD", pkg.Info.Version)
+	// purl preserved untouched.
+	assert.Equal(t, "pkg:maven/orig/lib@OLD?checksum=sha1:H_UNKNOWN", pkg.Info.PackageURL)
+}
+
+func TestPostHook_StripsPurlsWhenProvenanceDisabled(t *testing.T) {
+	graph := makeDepGraph(t, []depgraph.Pkg{
+		{ID: "root@1", Info: depgraph.PkgInfo{Name: "root", Version: "1"}},
+		// One pkg with a canonical mapping…
+		{ID: "orig:lib@OLD", Info: depgraph.PkgInfo{
+			Name:       "orig:lib",
+			Version:    "OLD",
+			PackageURL: "pkg:maven/orig/lib@OLD?checksum=sha1:H1",
+		}},
+		// …and one without (API will not return a mapping).
+		{ID: "unmapped:lib@1", Info: depgraph.PkgInfo{
+			Name:       "unmapped:lib",
+			Version:    "1",
+			PackageURL: "pkg:maven/unmapped/lib@1?checksum=sha1:H_NONE",
+		}},
+	}, [][2]string{{"root@1", "orig:lib@OLD"}, {"root@1", "unmapped:lib@1"}})
+
+	fake := newFakeLookuper()
+	fake.responses["H1"] = "pkg:maven/canon/lib@NEW"
+
+	hook := newNormalizeDepsPostHookWithClient(fake, "org-1")
+	results := hook(context.Background(), logger.Nop(),
+		[]ecosystems.SCAResult{{DepGraph: graph}},
+		// IncludeProvenance not set → user did not ask for purls in the
+		// output; we should strip them after normalisation.
+		&ecosystems.SCAPluginOptions{},
+	)
+
+	out := results[0].DepGraph
+	// Every pkg in the output (including the un-rewritten one) should have an
+	// empty PackageURL.
+	for _, pkg := range out.Pkgs {
+		assert.Empty(t, pkg.Info.PackageURL,
+			"expected purl stripped for %s when --include-provenance is off", pkg.ID)
+	}
+	// The canonical rewrite still applied (we just dropped the purl).
+	pkgByID(t, out, "canon:lib@NEW")
+}
+
+func TestPostHook_MergesCollidingPkgsAfterRewrite(t *testing.T) {
+	// Two distinct originals (different SHA1s, e.g. different jar files)
+	// resolve to the same canonical GAV. The result should be a single pkg in
+	// the merged graph, with both original nodes pointing at it.
+	graph := makeDepGraph(t, []depgraph.Pkg{
+		{ID: "root@1", Info: depgraph.PkgInfo{Name: "root", Version: "1"}},
+		{ID: "a:lib@OLD1", Info: depgraph.PkgInfo{
+			Name:       "a:lib",
+			Version:    "OLD1",
+			PackageURL: "pkg:maven/a/lib@OLD1?checksum=sha1:H1",
+		}},
+		{ID: "b:lib@OLD2", Info: depgraph.PkgInfo{
+			Name:       "b:lib",
+			Version:    "OLD2",
+			PackageURL: "pkg:maven/b/lib@OLD2?checksum=sha1:H2",
+		}},
+	}, [][2]string{{"root@1", "a:lib@OLD1"}, {"root@1", "b:lib@OLD2"}})
+
+	fake := newFakeLookuper()
+	fake.responses["H1"] = "pkg:maven/canon/lib@NEW"
+	fake.responses["H2"] = "pkg:maven/canon/lib@NEW"
+
+	hook := newNormalizeDepsPostHookWithClient(fake, "org-1")
+	results := hook(context.Background(), logger.Nop(),
+		[]ecosystems.SCAResult{{DepGraph: graph}},
+		&ecosystems.SCAPluginOptions{Global: ecosystems.GlobalOptions{IncludeProvenance: true}},
+	)
+
+	out := results[0].DepGraph
+
+	// Exactly one canonical pkg, plus root.
+	canonicalCount := 0
+	for _, pkg := range out.Pkgs {
+		if pkg.ID == "canon:lib@NEW" {
+			canonicalCount++
+		}
+	}
+	assert.Equal(t, 1, canonicalCount, "expected duplicate canonical pkgs to be merged")
+	assert.Len(t, out.Pkgs, 2, "expected exactly root + 1 canonical pkg")
+
+	// Both original nodes should now reference the canonical pkg.
+	pkgIDsByNode := make(map[string]string)
+	for _, node := range out.Graph.Nodes {
+		pkgIDsByNode[node.NodeID] = node.PkgID
+	}
+	assert.Equal(t, "canon:lib@NEW", pkgIDsByNode["a:lib@OLD1"])
+	assert.Equal(t, "canon:lib@NEW", pkgIDsByNode["b:lib@OLD2"])
+}
+
+func TestPostHook_NoOpsWhenOrgIDEmpty(t *testing.T) {
+	graph := makeDepGraph(t, []depgraph.Pkg{
+		{ID: "root@1", Info: depgraph.PkgInfo{Name: "root", Version: "1"}},
+		{ID: "orig:lib@OLD", Info: depgraph.PkgInfo{
+			Name:       "orig:lib",
+			Version:    "OLD",
+			PackageURL: "pkg:maven/orig/lib@OLD?checksum=sha1:H1",
+		}},
+	}, [][2]string{{"root@1", "orig:lib@OLD"}})
+
+	fake := newFakeLookuper()
+	fake.responses["H1"] = "pkg:maven/canon/lib@NEW"
+
+	hook := newNormalizeDepsPostHookWithClient(fake, "")
+	results := hook(context.Background(), logger.Nop(),
+		[]ecosystems.SCAResult{{DepGraph: graph}},
+		&ecosystems.SCAPluginOptions{Global: ecosystems.GlobalOptions{IncludeProvenance: true}},
+	)
+
+	// Graph returned unchanged; no lookups performed.
+	assert.Equal(t, int64(0), fake.totalCalls.Load())
+	out := results[0].DepGraph
+	pkgByID(t, out, "orig:lib@OLD")
+}
+
+func TestPostHook_TreatsAPIErrorsAsUnmapped(t *testing.T) {
+	graph := makeDepGraph(t, []depgraph.Pkg{
+		{ID: "root@1", Info: depgraph.PkgInfo{Name: "root", Version: "1"}},
+		{ID: "ok:lib@OLD", Info: depgraph.PkgInfo{
+			Name:       "ok:lib",
+			Version:    "OLD",
+			PackageURL: "pkg:maven/ok/lib@OLD?checksum=sha1:H_OK",
+		}},
+		{ID: "bad:lib@OLD", Info: depgraph.PkgInfo{
+			Name:       "bad:lib",
+			Version:    "OLD",
+			PackageURL: "pkg:maven/bad/lib@OLD?checksum=sha1:H_ERR",
+		}},
+	}, [][2]string{{"root@1", "ok:lib@OLD"}, {"root@1", "bad:lib@OLD"}})
+
+	fake := newFakeLookuper()
+	fake.responses["H_OK"] = "pkg:maven/canon/lib@NEW"
+	fake.errors["H_ERR"] = errors.New("simulated network failure")
+
+	hook := newNormalizeDepsPostHookWithClient(fake, "org-1")
+	results := hook(context.Background(), logger.Nop(),
+		[]ecosystems.SCAResult{{DepGraph: graph}},
+		&ecosystems.SCAPluginOptions{Global: ecosystems.GlobalOptions{IncludeProvenance: true}},
+	)
+
+	out := results[0].DepGraph
+
+	// Successful lookup rewrote its pkg.
+	pkgByID(t, out, "canon:lib@NEW")
+	// Failed lookup left its pkg as-is.
+	pkg := pkgByID(t, out, "bad:lib@OLD")
+	assert.Equal(t, "pkg:maven/bad/lib@OLD?checksum=sha1:H_ERR", pkg.Info.PackageURL)
+}
+
+func TestPostHook_IssuesOneLookupPerUniqueSha1(t *testing.T) {
+	// The same SHA1 referenced from three graphs and several pkgs must
+	// result in exactly one API call.
+	makeGraph := func(rootID, pkgID, purl string) *depgraph.DepGraph {
+		return makeDepGraph(t, []depgraph.Pkg{
+			{ID: rootID, Info: depgraph.PkgInfo{Name: rootID, Version: "1"}},
+			{ID: pkgID, Info: depgraph.PkgInfo{
+				Name:       "lib",
+				Version:    "1",
+				PackageURL: purl,
+			}},
+		}, [][2]string{{rootID, pkgID}})
+	}
+	purl := "pkg:maven/g/lib@1?checksum=sha1:H1"
+	results := []ecosystems.SCAResult{
+		{DepGraph: makeGraph("rA@1", "lib@1", purl)},
+		{DepGraph: makeGraph("rB@1", "lib@1", purl)},
+		{DepGraph: makeGraph("rC@1", "lib@1", purl)},
+	}
+
+	fake := newFakeLookuper()
+	fake.responses["H1"] = "pkg:maven/canon/lib@2"
+
+	hook := newNormalizeDepsPostHookWithClient(fake, "org-1")
+	_ = hook(context.Background(), logger.Nop(), results,
+		&ecosystems.SCAPluginOptions{Global: ecosystems.GlobalOptions{IncludeProvenance: true}},
+	)
+
+	assert.Equal(t, 1, fake.callCount("H1"), "expected SHA1 lookup to be deduped across graphs")
+	assert.Equal(t, int64(1), fake.totalCalls.Load())
+}
+
+func TestPostHook_PreservesNilDepGraphResults(t *testing.T) {
+	// Error results (DepGraph == nil) must pass through cleanly.
+	fake := newFakeLookuper()
+	hook := newNormalizeDepsPostHookWithClient(fake, "org-1")
+	results := hook(context.Background(), logger.Nop(),
+		[]ecosystems.SCAResult{{DepGraph: nil}, {DepGraph: nil}},
+		&ecosystems.SCAPluginOptions{},
+	)
+	require.Len(t, results, 2)
+	assert.Nil(t, results[0].DepGraph)
+	assert.Nil(t, results[1].DepGraph)
+	assert.Equal(t, int64(0), fake.totalCalls.Load())
+}

--- a/pkg/ecosystems/gradle/normalize_deps_test.go
+++ b/pkg/ecosystems/gradle/normalize_deps_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/logger"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/logger"
 )
 
 // makeDepGraph builds a minimal DepGraph from a slice of pkgs and a

--- a/pkg/ecosystems/gradle/plugin_integration_test.go
+++ b/pkg/ecosystems/gradle/plugin_integration_test.go
@@ -484,12 +484,12 @@ func TestPlugin_NormalizeDepsIntegration(t *testing.T) {
 			normalizeDepsHook := newNormalizeDepsPostHookWithClient(fake, "test-org-id")
 
 			plugin := NewGradlePluginWithNormalizeDepsHook(normalizeDepsHook)
-			result, err := plugin.BuildDepGraphsFromDir(ctx, logger.Nop(), absFixture, testCase.Options)
+			result, err := scatest.Run(ctx, plugin, logger.Nop(), absFixture, testCase.Options)
 			require.NoError(t, err, "BuildDepGraphsFromDir should not return error")
 			require.NotNil(t, result, "plugin result should not be nil")
 
 			if updateFixtures {
-				writeExpectedSnapshot(t, filepath.Join(fixturePath, testCase.ExpectedFile), result.Results)
+				writeExpectedSnapshot(t, filepath.Join(fixturePath, testCase.ExpectedFile), result)
 				return
 			}
 
@@ -497,7 +497,7 @@ func TestPlugin_NormalizeDepsIntegration(t *testing.T) {
 			require.NoErrorf(t, err, "no expected snapshot for fixture %q; run with %s=1 to generate", testCase.Fixture, updateFixturesEnvVar)
 
 			expected := loadExpectedResults(t, expectedPath)
-			assertResultsMatchExpected(t, result.Results, expected, testCase.Fixture)
+			assertResultsMatchExpected(t, result, expected, testCase.Fixture)
 		})
 	}
 }

--- a/pkg/ecosystems/gradle/plugin_integration_test.go
+++ b/pkg/ecosystems/gradle/plugin_integration_test.go
@@ -240,13 +240,23 @@ func normalizeDepsTestCases() map[string]PluginTestCase {
 	return map[string]PluginTestCase{
 		"simple_with_normalize_deps": {
 			Fixture:      "simple",
-			Options:      ecosystems.NewPluginOptions().WithGradleNormalizeDeps(true).WithIncludeProvenance(true),
+			Options:      ecosystems.NewPluginOptions().WithGradleNormalizeDeps(true),
 			ExpectedFile: "expected_plugin_with_normalize_deps.json",
+		},
+		"simple_with_normalize_deps_and_provenance": {
+			Fixture:      "simple",
+			Options:      ecosystems.NewPluginOptions().WithGradleNormalizeDeps(true).WithIncludeProvenance(true),
+			ExpectedFile: "expected_plugin_with_normalize_deps_and_provenance.json",
 		},
 		"platform_bom_with_normalize_deps": {
 			Fixture:      "platform-bom",
-			Options:      ecosystems.NewPluginOptions().WithGradleNormalizeDeps(true).WithIncludeProvenance(true),
+			Options:      ecosystems.NewPluginOptions().WithGradleNormalizeDeps(true),
 			ExpectedFile: "expected_plugin_bom_with_normalize_deps.json",
+		},
+		"platform_bom_with_normalize_deps_and_provenance": {
+			Fixture:      "platform-bom",
+			Options:      ecosystems.NewPluginOptions().WithGradleNormalizeDeps(true).WithIncludeProvenance(true),
+			ExpectedFile: "expected_plugin_bom_with_normalize_deps_and_provenance.json",
 		},
 	}
 }

--- a/pkg/ecosystems/gradle/plugin_integration_test.go
+++ b/pkg/ecosystems/gradle/plugin_integration_test.go
@@ -233,6 +233,24 @@ func pluginTestCases() map[string]PluginTestCase {
 	}
 }
 
+// normalizeDepsTestCases defines integration test cases specifically for the
+// normalize-deps functionality. These require special handling with mocked
+// Snyk client responses and are not part of the main pluginTestCases.
+func normalizeDepsTestCases() map[string]PluginTestCase {
+	return map[string]PluginTestCase{
+		"simple_with_normalize_deps": {
+			Fixture:      "simple",
+			Options:      ecosystems.NewPluginOptions().WithGradleNormalizeDeps(true).WithIncludeProvenance(true),
+			ExpectedFile: "expected_plugin_with_normalize_deps.json",
+		},
+		"platform_bom_with_normalize_deps": {
+			Fixture:      "platform-bom",
+			Options:      ecosystems.NewPluginOptions().WithGradleNormalizeDeps(true).WithIncludeProvenance(true),
+			ExpectedFile: "expected_plugin_bom_with_normalize_deps.json",
+		},
+	}
+}
+
 // TestGradleWrapper_BinaryResolution validates that the plugin correctly chooses
 // between wrapper and system gradle binaries based on options and fixture setup.
 // These tests focus on execution path and metadata, not graph content (which is
@@ -418,6 +436,90 @@ func TestPlugin_NormalizeDepsPostHook_WiringIntegration(t *testing.T) {
 
 		assert.False(t, hookInvoked, "post-hook should not be invoked when --gradle-normalize-deps is unset")
 	})
+}
+
+// TestPlugin_NormalizeDepsIntegration exercises the full normalize-deps functionality
+// by running the Gradle plugin against real fixtures with mocked Snyk client responses.
+// This test verifies that dependency coordinates are properly transformed and the
+// dependency graph structure is preserved.
+func TestPlugin_NormalizeDepsIntegration(t *testing.T) {
+	updateFixtures := os.Getenv(updateFixturesEnvVar) != ""
+
+	gradleVersion, err := gradleRuntime()
+	require.NoErrorf(t, err, "could not detect gradle runtime version")
+	jdkVersion, err := jdkRuntime()
+	require.NoErrorf(t, err, "could not detect jdk runtime version")
+	t.Logf("gradle %s / jdk %s", gradleVersion, jdkVersion)
+
+	for name, testCase := range normalizeDepsTestCases() {
+		t.Run(name, func(t *testing.T) {
+			fixturePath := filepath.Join(fixturesRoot, testCase.Fixture)
+			absFixture, err := filepath.Abs(fixturePath)
+			require.NoError(t, err, "failed to resolve fixture path")
+
+			meta, err := loadFixtureMetadata(absFixture)
+			require.NoErrorf(t, err, "failed to load metadata for fixture %q", testCase.Fixture)
+
+			if reason, err := meta.skipReason(gradleVersion, jdkVersion); err != nil {
+				t.Fatalf("invalid metadata for fixture %q: %v", testCase.Fixture, err)
+			} else if reason != "" {
+				t.Skipf("fixture %q not applicable: %s", testCase.Fixture, reason)
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+			defer cancel()
+
+			// Create a fake lookuper with predefined transformations
+			fake := createNormalizeDepsFakeLookuper()
+			normalizeDepsHook := newNormalizeDepsPostHookWithClient(fake, "test-org-id")
+
+			plugin := NewGradlePluginWithNormalizeDepsHook(normalizeDepsHook)
+			result, err := plugin.BuildDepGraphsFromDir(ctx, logger.Nop(), absFixture, testCase.Options)
+			require.NoError(t, err, "BuildDepGraphsFromDir should not return error")
+			require.NotNil(t, result, "plugin result should not be nil")
+
+			if updateFixtures {
+				writeExpectedSnapshot(t, filepath.Join(fixturePath, testCase.ExpectedFile), result.Results)
+				return
+			}
+
+			expectedPath, err := resolveExpectedSnapshotPath(fixturePath, testCase, gradleVersion)
+			require.NoErrorf(t, err, "no expected snapshot for fixture %q; run with %s=1 to generate", testCase.Fixture, updateFixturesEnvVar)
+
+			expected := loadExpectedResults(t, expectedPath)
+			assertResultsMatchExpected(t, result.Results, expected, testCase.Fixture)
+		})
+	}
+}
+
+// createNormalizeDepsFakeLookuper creates a fake lookuper with predefined
+// coordinate transformations for testing normalize-deps functionality.
+func createNormalizeDepsFakeLookuper() *fakeLookuper {
+	fake := newFakeLookuper()
+
+	// Define transformations: SHA1 -> canonical purl
+	// These SHA1s correspond to packages in the simple and platform-bom fixtures
+
+	// Simple fixture packages
+	fake.responses["87e0fd1df874ea3cbe577702fe6f17068b790fd8"] = "pkg:maven/io.snyk.guava/snyk-guava@30.1.1-jre"
+	fake.responses["25ea2e8b0c338a877313bd4672d3fe056ea78f0d"] = "pkg:maven/io.snyk.findbugs/snyk-jsr305@3.0.2"
+	fake.responses["1dcf1de382a0bf95a3d8b0849546c88bac1292c9"] = "pkg:maven/io.snyk.guava/snyk-failureaccess@1.0.1"
+	fake.responses["6b83e4a33220272c3a08991498ba9dc09519f190"] = "pkg:maven/io.snyk.checker/snyk-checker-qual@3.8.0"
+	fake.responses["562d366678b89ce5d6b6b82c1a073880341e3fba"] = "pkg:maven/io.snyk.errorprone/snyk-error-prone-annotations@2.5.1"
+	fake.responses["ba035118bc8bac37d7eff77700720999acd9986d"] = "pkg:maven/io.snyk.j2objc/snyk-j2objc-annotations@1.3"
+	fake.responses["1ed471194b02f2c6cb734a0cd6f6f107c673afae"] = "pkg:maven/io.snyk.commons/snyk-commons-lang3@3.14.0"
+
+	// Platform-bom fixture packages
+	fake.responses["3edcfe49d2c6053a70a2a47e4e1c2f94998a49cf"] = "pkg:maven/io.snyk.gson/snyk-gson@2.8.2"
+	fake.responses["5d3ccc056b6f056dbf0dddfdf43894b9065a8f94"] = "pkg:maven/io.snyk.dom4j/snyk-dom4j@1.6.1"
+	fake.responses["3789d9fada2d3d458c4ba2de349d48780f381ee3"] = "pkg:maven/io.snyk.xmlapis/snyk-xml-apis@1.4.01"
+
+	// Leave some packages unmapped to test fallback behavior
+	// The listenablefuture package will remain unmapped to verify
+	// that unmapped packages are left unchanged
+	// fake.responses["b421526c5f297295adef1c886e5246c39d4ac629"] = "" // intentionally unmapped
+
+	return fake
 }
 
 // defaultExpectedFileName returns the snapshot filename used when writing

--- a/pkg/ecosystems/orchestrator/registry.go
+++ b/pkg/ecosystems/orchestrator/registry.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/rs/zerolog"
+	"github.com/snyk/go-application-framework/pkg/configuration"
 	"github.com/snyk/go-application-framework/pkg/workflow"
 
 	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems"
@@ -43,7 +44,12 @@ func NewDefaultPluginRegistry(ictx workflow.InvocationContext) (*PluginRegistry,
 		return nil, fmt.Errorf("failed to register bun plugin: %w", err)
 	}
 	// gradle (opt-in via feature flag)
-	normalizeDepsPostHook := gradle.NewNormalizeDepsPostHook()
+	cfg := ictx.GetConfiguration()
+	normalizeDepsPostHook := gradle.NewNormalizeDepsPostHook(
+		ictx.GetNetworkAccess().GetHttpClient(),
+		cfg.GetString(configuration.API_URL),
+		cfg.GetString(configuration.ORGANIZATION),
+	)
 	gradlePlugin := gradle.NewGradlePluginWithNormalizeDepsHook(normalizeDepsPostHook)
 	if err := r.register(gradlePlugin, withFeatureFlagCheck(FlagNewGradleResolver), withPluginDependencies("bazel")); err != nil {
 		return nil, fmt.Errorf("failed to register gradle plugin: %w", err)

--- a/pkg/ecosystems/orchestrator/registry_test.go
+++ b/pkg/ecosystems/orchestrator/registry_test.go
@@ -2,6 +2,7 @@ package orchestrator
 
 import (
 	"context"
+	"net/http"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -395,6 +396,7 @@ func setupMockInvocationContextWithConfig(t *testing.T, configure func(configura
 	ctrl := gomock.NewController(t)
 	ictx := gafmocks.NewMockInvocationContext(ctrl)
 	engine := gafmocks.NewMockEngine(ctrl)
+	networkAccess := gafmocks.NewMockNetworkAccess(ctrl)
 	cfg := configuration.New()
 	if configure != nil {
 		configure(cfg)
@@ -405,6 +407,9 @@ func setupMockInvocationContextWithConfig(t *testing.T, configure func(configura
 	ictx.EXPECT().GetEngine().Return(engine).AnyTimes()
 	ictx.EXPECT().GetEnhancedLogger().Return(&logger).AnyTimes()
 	ictx.EXPECT().Context().Return(context.Background()).AnyTimes()
+	ictx.EXPECT().GetNetworkAccess().Return(networkAccess).AnyTimes()
+
+	networkAccess.EXPECT().GetHttpClient().Return(&http.Client{}).AnyTimes()
 
 	engine.EXPECT().
 		InvokeWithConfig(gomock.Any(), gomock.Any()).

--- a/pkg/ecosystems/testdata/fixtures/gradle/platform-bom/expected_plugin_bom_with_normalize_deps.json
+++ b/pkg/ecosystems/testdata/fixtures/gradle/platform-bom/expected_plugin_bom_with_normalize_deps.json
@@ -1,0 +1,142 @@
+[
+  {
+    "depGraph": {
+      "schemaVersion": "1.3.0",
+      "pkgManager": {
+        "name": "gradle"
+      },
+      "pkgs": [
+        {
+          "id": "com.snyk.fixtures:platform-bom@1.0.0",
+          "info": {
+            "name": "com.snyk.fixtures:platform-bom",
+            "version": "1.0.0"
+          }
+        },
+        {
+          "id": "org.springframework.boot:spring-boot-dependencies@1.5.8.RELEASE",
+          "info": {
+            "name": "org.springframework.boot:spring-boot-dependencies",
+            "version": "1.5.8.RELEASE",
+            "purl": "pkg:maven/org.springframework.boot/spring-boot-dependencies@1.5.8.RELEASE"
+          }
+        },
+        {
+          "id": "io.snyk.gson:snyk-gson@2.8.2",
+          "info": {
+            "name": "io.snyk.gson:snyk-gson",
+            "version": "2.8.2",
+            "purl": "pkg:maven/io.snyk.gson/snyk-gson@2.8.2?checksum=sha1%3A3edcfe49d2c6053a70a2a47e4e1c2f94998a49cf"
+          }
+        },
+        {
+          "id": "io.snyk.dom4j:snyk-dom4j@1.6.1",
+          "info": {
+            "name": "io.snyk.dom4j:snyk-dom4j",
+            "version": "1.6.1",
+            "purl": "pkg:maven/io.snyk.dom4j/snyk-dom4j@1.6.1?checksum=sha1%3A5d3ccc056b6f056dbf0dddfdf43894b9065a8f94"
+          }
+        },
+        {
+          "id": "io.snyk.xmlapis:snyk-xml-apis@1.4.01",
+          "info": {
+            "name": "io.snyk.xmlapis:snyk-xml-apis",
+            "version": "1.4.01",
+            "purl": "pkg:maven/io.snyk.xmlapis/snyk-xml-apis@1.4.01?checksum=sha1%3A3789d9fada2d3d458c4ba2de349d48780f381ee3"
+          }
+        }
+      ],
+      "graph": {
+        "rootNodeId": "root-node",
+        "nodes": [
+          {
+            "nodeId": "root-node",
+            "pkgId": "com.snyk.fixtures:platform-bom@1.0.0",
+            "deps": [
+              {
+                "nodeId": "org.springframework.boot:spring-boot-dependencies@1.5.8.RELEASE"
+              },
+              {
+                "nodeId": "com.google.code.gson:gson@2.8.2"
+              },
+              {
+                "nodeId": "dom4j:dom4j@1.6.1"
+              }
+            ]
+          },
+          {
+            "nodeId": "org.springframework.boot:spring-boot-dependencies@1.5.8.RELEASE",
+            "pkgId": "org.springframework.boot:spring-boot-dependencies@1.5.8.RELEASE",
+            "deps": [
+              {
+                "nodeId": "com.google.code.gson:gson@2.8.2:constraint"
+              },
+              {
+                "nodeId": "dom4j:dom4j@1.6.1:constraint"
+              },
+              {
+                "nodeId": "xml-apis:xml-apis@1.4.01:constraint"
+              }
+            ]
+          },
+          {
+            "nodeId": "com.google.code.gson:gson@2.8.2:constraint",
+            "pkgId": "io.snyk.gson:snyk-gson@2.8.2",
+            "info": {
+              "labels": {
+                "constraint": "true"
+              }
+            },
+            "deps": []
+          },
+          {
+            "nodeId": "dom4j:dom4j@1.6.1:constraint",
+            "pkgId": "io.snyk.dom4j:snyk-dom4j@1.6.1",
+            "info": {
+              "labels": {
+                "constraint": "true"
+              }
+            },
+            "deps": []
+          },
+          {
+            "nodeId": "xml-apis:xml-apis@1.4.01:constraint",
+            "pkgId": "io.snyk.xmlapis:snyk-xml-apis@1.4.01",
+            "info": {
+              "labels": {
+                "constraint": "true"
+              }
+            },
+            "deps": []
+          },
+          {
+            "nodeId": "com.google.code.gson:gson@2.8.2",
+            "pkgId": "io.snyk.gson:snyk-gson@2.8.2",
+            "deps": []
+          },
+          {
+            "nodeId": "dom4j:dom4j@1.6.1",
+            "pkgId": "io.snyk.dom4j:snyk-dom4j@1.6.1",
+            "deps": [
+              {
+                "nodeId": "xml-apis:xml-apis@1.4.01"
+              }
+            ]
+          },
+          {
+            "nodeId": "xml-apis:xml-apis@1.4.01",
+            "pkgId": "io.snyk.xmlapis:snyk-xml-apis@1.4.01",
+            "deps": []
+          }
+        ]
+      }
+    },
+    "projectDescriptor": {
+      "identity": {
+        "type": "gradle",
+        "targetFile": "build.gradle",
+        "rootComponentName": "com.snyk.fixtures:platform-bom"
+      }
+    }
+  }
+]

--- a/pkg/ecosystems/testdata/fixtures/gradle/platform-bom/expected_plugin_bom_with_normalize_deps_and_provenance.json
+++ b/pkg/ecosystems/testdata/fixtures/gradle/platform-bom/expected_plugin_bom_with_normalize_deps_and_provenance.json
@@ -17,28 +17,32 @@
           "id": "org.springframework.boot:spring-boot-dependencies@1.5.8.RELEASE",
           "info": {
             "name": "org.springframework.boot:spring-boot-dependencies",
-            "version": "1.5.8.RELEASE"
+            "version": "1.5.8.RELEASE",
+            "purl": "pkg:maven/org.springframework.boot/spring-boot-dependencies@1.5.8.RELEASE"
           }
         },
         {
           "id": "io.snyk.gson:snyk-gson@2.8.2",
           "info": {
             "name": "io.snyk.gson:snyk-gson",
-            "version": "2.8.2"
+            "version": "2.8.2",
+            "purl": "pkg:maven/io.snyk.gson/snyk-gson@2.8.2?checksum=sha1%3A3edcfe49d2c6053a70a2a47e4e1c2f94998a49cf"
           }
         },
         {
           "id": "io.snyk.dom4j:snyk-dom4j@1.6.1",
           "info": {
             "name": "io.snyk.dom4j:snyk-dom4j",
-            "version": "1.6.1"
+            "version": "1.6.1",
+            "purl": "pkg:maven/io.snyk.dom4j/snyk-dom4j@1.6.1?checksum=sha1%3A5d3ccc056b6f056dbf0dddfdf43894b9065a8f94"
           }
         },
         {
           "id": "io.snyk.xmlapis:snyk-xml-apis@1.4.01",
           "info": {
             "name": "io.snyk.xmlapis:snyk-xml-apis",
-            "version": "1.4.01"
+            "version": "1.4.01",
+            "purl": "pkg:maven/io.snyk.xmlapis/snyk-xml-apis@1.4.01?checksum=sha1%3A3789d9fada2d3d458c4ba2de349d48780f381ee3"
           }
         }
       ],

--- a/pkg/ecosystems/testdata/fixtures/gradle/simple/expected_plugin_with_normalize_deps.json
+++ b/pkg/ecosystems/testdata/fixtures/gradle/simple/expected_plugin_with_normalize_deps.json
@@ -1,0 +1,166 @@
+[
+  {
+    "depGraph": {
+      "schemaVersion": "1.3.0",
+      "pkgManager": {
+        "name": "gradle"
+      },
+      "pkgs": [
+        {
+          "id": "com.snyk.fixtures:simple-app@1.0.0",
+          "info": {
+            "name": "com.snyk.fixtures:simple-app",
+            "version": "1.0.0"
+          }
+        },
+        {
+          "id": "io.snyk.guava:snyk-guava@30.1.1-jre",
+          "info": {
+            "name": "io.snyk.guava:snyk-guava",
+            "version": "30.1.1-jre",
+            "purl": "pkg:maven/io.snyk.guava/snyk-guava@30.1.1-jre?checksum=sha1%3A87e0fd1df874ea3cbe577702fe6f17068b790fd8"
+          }
+        },
+        {
+          "id": "io.snyk.guava:snyk-failureaccess@1.0.1",
+          "info": {
+            "name": "io.snyk.guava:snyk-failureaccess",
+            "version": "1.0.1",
+            "purl": "pkg:maven/io.snyk.guava/snyk-failureaccess@1.0.1?checksum=sha1%3A1dcf1de382a0bf95a3d8b0849546c88bac1292c9"
+          }
+        },
+        {
+          "id": "com.google.guava:listenablefuture@9999.0-empty-to-avoid-conflict-with-guava",
+          "info": {
+            "name": "com.google.guava:listenablefuture",
+            "version": "9999.0-empty-to-avoid-conflict-with-guava",
+            "purl": "pkg:maven/com.google.guava/listenablefuture@9999.0-empty-to-avoid-conflict-with-guava?checksum=sha1%3Ab421526c5f297295adef1c886e5246c39d4ac629"
+          }
+        },
+        {
+          "id": "io.snyk.findbugs:snyk-jsr305@3.0.2",
+          "info": {
+            "name": "io.snyk.findbugs:snyk-jsr305",
+            "version": "3.0.2",
+            "purl": "pkg:maven/io.snyk.findbugs/snyk-jsr305@3.0.2?checksum=sha1%3A25ea2e8b0c338a877313bd4672d3fe056ea78f0d"
+          }
+        },
+        {
+          "id": "io.snyk.checker:snyk-checker-qual@3.8.0",
+          "info": {
+            "name": "io.snyk.checker:snyk-checker-qual",
+            "version": "3.8.0",
+            "purl": "pkg:maven/io.snyk.checker/snyk-checker-qual@3.8.0?checksum=sha1%3A6b83e4a33220272c3a08991498ba9dc09519f190"
+          }
+        },
+        {
+          "id": "io.snyk.errorprone:snyk-error-prone-annotations@2.5.1",
+          "info": {
+            "name": "io.snyk.errorprone:snyk-error-prone-annotations",
+            "version": "2.5.1",
+            "purl": "pkg:maven/io.snyk.errorprone/snyk-error-prone-annotations@2.5.1?checksum=sha1%3A562d366678b89ce5d6b6b82c1a073880341e3fba"
+          }
+        },
+        {
+          "id": "io.snyk.j2objc:snyk-j2objc-annotations@1.3",
+          "info": {
+            "name": "io.snyk.j2objc:snyk-j2objc-annotations",
+            "version": "1.3",
+            "purl": "pkg:maven/io.snyk.j2objc/snyk-j2objc-annotations@1.3?checksum=sha1%3Aba035118bc8bac37d7eff77700720999acd9986d"
+          }
+        },
+        {
+          "id": "io.snyk.commons:snyk-commons-lang3@3.14.0",
+          "info": {
+            "name": "io.snyk.commons:snyk-commons-lang3",
+            "version": "3.14.0",
+            "purl": "pkg:maven/io.snyk.commons/snyk-commons-lang3@3.14.0?checksum=sha1%3A1ed471194b02f2c6cb734a0cd6f6f107c673afae"
+          }
+        }
+      ],
+      "graph": {
+        "rootNodeId": "root-node",
+        "nodes": [
+          {
+            "nodeId": "root-node",
+            "pkgId": "com.snyk.fixtures:simple-app@1.0.0",
+            "deps": [
+              {
+                "nodeId": "com.google.guava:guava@30.1.1-jre"
+              },
+              {
+                "nodeId": "org.apache.commons:commons-lang3@3.14.0"
+              }
+            ]
+          },
+          {
+            "nodeId": "com.google.guava:guava@30.1.1-jre",
+            "pkgId": "io.snyk.guava:snyk-guava@30.1.1-jre",
+            "deps": [
+              {
+                "nodeId": "com.google.guava:failureaccess@1.0.1"
+              },
+              {
+                "nodeId": "com.google.guava:listenablefuture@9999.0-empty-to-avoid-conflict-with-guava"
+              },
+              {
+                "nodeId": "com.google.code.findbugs:jsr305@3.0.2"
+              },
+              {
+                "nodeId": "org.checkerframework:checker-qual@3.8.0"
+              },
+              {
+                "nodeId": "com.google.errorprone:error_prone_annotations@2.5.1"
+              },
+              {
+                "nodeId": "com.google.j2objc:j2objc-annotations@1.3"
+              }
+            ]
+          },
+          {
+            "nodeId": "com.google.guava:failureaccess@1.0.1",
+            "pkgId": "io.snyk.guava:snyk-failureaccess@1.0.1",
+            "deps": []
+          },
+          {
+            "nodeId": "com.google.guava:listenablefuture@9999.0-empty-to-avoid-conflict-with-guava",
+            "pkgId": "com.google.guava:listenablefuture@9999.0-empty-to-avoid-conflict-with-guava",
+            "deps": []
+          },
+          {
+            "nodeId": "com.google.code.findbugs:jsr305@3.0.2",
+            "pkgId": "io.snyk.findbugs:snyk-jsr305@3.0.2",
+            "deps": []
+          },
+          {
+            "nodeId": "org.checkerframework:checker-qual@3.8.0",
+            "pkgId": "io.snyk.checker:snyk-checker-qual@3.8.0",
+            "deps": []
+          },
+          {
+            "nodeId": "com.google.errorprone:error_prone_annotations@2.5.1",
+            "pkgId": "io.snyk.errorprone:snyk-error-prone-annotations@2.5.1",
+            "deps": []
+          },
+          {
+            "nodeId": "com.google.j2objc:j2objc-annotations@1.3",
+            "pkgId": "io.snyk.j2objc:snyk-j2objc-annotations@1.3",
+            "deps": []
+          },
+          {
+            "nodeId": "org.apache.commons:commons-lang3@3.14.0",
+            "pkgId": "io.snyk.commons:snyk-commons-lang3@3.14.0",
+            "deps": []
+          }
+        ]
+      }
+    },
+    "projectDescriptor": {
+      "identity": {
+        "type": "gradle",
+        "targetFile": "build.gradle",
+        "rootComponentName": "com.snyk.fixtures:simple-app"
+      }
+    }
+  }
+]

--- a/pkg/ecosystems/testdata/fixtures/gradle/simple/expected_plugin_with_normalize_deps_and_provenance.json
+++ b/pkg/ecosystems/testdata/fixtures/gradle/simple/expected_plugin_with_normalize_deps_and_provenance.json
@@ -17,56 +17,64 @@
           "id": "io.snyk.guava:snyk-guava@30.1.1-jre",
           "info": {
             "name": "io.snyk.guava:snyk-guava",
-            "version": "30.1.1-jre"
+            "version": "30.1.1-jre",
+            "purl": "pkg:maven/io.snyk.guava/snyk-guava@30.1.1-jre?checksum=sha1%3A87e0fd1df874ea3cbe577702fe6f17068b790fd8"
           }
         },
         {
           "id": "io.snyk.guava:snyk-failureaccess@1.0.1",
           "info": {
             "name": "io.snyk.guava:snyk-failureaccess",
-            "version": "1.0.1"
+            "version": "1.0.1",
+            "purl": "pkg:maven/io.snyk.guava/snyk-failureaccess@1.0.1?checksum=sha1%3A1dcf1de382a0bf95a3d8b0849546c88bac1292c9"
           }
         },
         {
           "id": "com.google.guava:listenablefuture@9999.0-empty-to-avoid-conflict-with-guava",
           "info": {
             "name": "com.google.guava:listenablefuture",
-            "version": "9999.0-empty-to-avoid-conflict-with-guava"
+            "version": "9999.0-empty-to-avoid-conflict-with-guava",
+            "purl": "pkg:maven/com.google.guava/listenablefuture@9999.0-empty-to-avoid-conflict-with-guava?checksum=sha1%3Ab421526c5f297295adef1c886e5246c39d4ac629"
           }
         },
         {
           "id": "io.snyk.findbugs:snyk-jsr305@3.0.2",
           "info": {
             "name": "io.snyk.findbugs:snyk-jsr305",
-            "version": "3.0.2"
+            "version": "3.0.2",
+            "purl": "pkg:maven/io.snyk.findbugs/snyk-jsr305@3.0.2?checksum=sha1%3A25ea2e8b0c338a877313bd4672d3fe056ea78f0d"
           }
         },
         {
           "id": "io.snyk.checker:snyk-checker-qual@3.8.0",
           "info": {
             "name": "io.snyk.checker:snyk-checker-qual",
-            "version": "3.8.0"
+            "version": "3.8.0",
+            "purl": "pkg:maven/io.snyk.checker/snyk-checker-qual@3.8.0?checksum=sha1%3A6b83e4a33220272c3a08991498ba9dc09519f190"
           }
         },
         {
           "id": "io.snyk.errorprone:snyk-error-prone-annotations@2.5.1",
           "info": {
             "name": "io.snyk.errorprone:snyk-error-prone-annotations",
-            "version": "2.5.1"
+            "version": "2.5.1",
+            "purl": "pkg:maven/io.snyk.errorprone/snyk-error-prone-annotations@2.5.1?checksum=sha1%3A562d366678b89ce5d6b6b82c1a073880341e3fba"
           }
         },
         {
           "id": "io.snyk.j2objc:snyk-j2objc-annotations@1.3",
           "info": {
             "name": "io.snyk.j2objc:snyk-j2objc-annotations",
-            "version": "1.3"
+            "version": "1.3",
+            "purl": "pkg:maven/io.snyk.j2objc/snyk-j2objc-annotations@1.3?checksum=sha1%3Aba035118bc8bac37d7eff77700720999acd9986d"
           }
         },
         {
           "id": "io.snyk.commons:snyk-commons-lang3@3.14.0",
           "info": {
             "name": "io.snyk.commons:snyk-commons-lang3",
-            "version": "3.14.0"
+            "version": "3.14.0",
+            "purl": "pkg:maven/io.snyk.commons/snyk-commons-lang3@3.14.0?checksum=sha1%3A1ed471194b02f2c6cb734a0cd6f6f107c673afae"
           }
         }
       ],


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [ ] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Implements --gradle-normalize-deps flag that post-processes dependency graphs to use canonical Maven coordinates. Queries Snyk Packages API by SHA1 to resolve alternative artifact names/versions to their canonical forms, enabling consistent dependency identification across builds.

**Key features**:
- Extracts SHA1 checksums from dependency PURLs (requires --include-provenance)
- Queries Snyk Packages API to resolve canonical Maven GAV coordinates
- Rewrites dependency graphs with normalized names/versions while preserving SHA1 identity
- Deduplicates dependencies that resolve to the same canonical coordinates
- Handles suffixed nodes (constraint/pruned) correctly during rewriting
- Gracefully handles failures by leaving unmappable dependencies unchanged
- Concurrent API lookups with deduplication across multiple dependency graphs

**Usage**: --gradle-normalize-deps (requires authenticated org context)

**Implementation notes**:
- Post-processing hook architecture allows orthogonal feature composition
- Validates rewritten graphs using BuildGraph() to catch potential bugs
- Best-effort approach: individual lookup failures don't abort the entire scan
