### PR TITLE
feat: migrate go module path to /v2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -151,11 +151,11 @@ formatters:
     - goimports
   settings:
     gofumpt:
-      module-path: github.com/snyk/cli-extension-dep-graph
+      module-path: github.com/snyk/cli-extension-dep-graph/v2
       extra-rules: true
     goimports:
       local-prefixes:
-        - github.com/snyk/cli-extension-dep-graph
+        - github.com/snyk/cli-extension-dep-graph/v2
   exclusions:
     generated: lax
     paths:

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -14,38 +14,49 @@ The version bump is determined by the **Pull Request title**, which must follow 
 
 The release system uses **Pull Request titles** following the **Conventional Commits** format to determine version bumps:
 
-- **`fix:`** or **`fix(scope):`** → Bumps **PATCH** version (e.g., 1.0.0 → 1.0.1)
-- **`feat:`** or **`feat(scope):`** → Bumps **MINOR** version (e.g., 1.0.0 → 1.1.0)
-- **`type!:`** (breaking change) → Bumps **MAJOR** version (e.g., 1.0.0 → 2.0.0)
-- **`chore:`**, **`docs:`**, **`style:`**, **`refactor:`**, **`test:`**, **`ci:`** → **No release** created
+- **`feat:`** or **`feat(scope):`** → Bumps **MINOR** version (e.g., 2.0.0 → 2.1.0)
+- **`type!:`** (breaking change marker) → Bumps **MINOR** version (treated the same as `feat:`; see "Major versions" below)
+- **`fix:`**, **`perf:`**, **`revert:`**, **`refactor:`**, **`chore:`** (and their `(scope)` variants) → Bumps **PATCH** version (e.g., 2.0.0 → 2.0.1)
+- **`docs:`**, **`style:`**, **`test:`**, **`ci:`**, **`build:`** → **No release** created
 
 ### 2. PR Title Examples
 
 When creating a Pull Request, use these title formats:
 
 ```
-# Patch version bump (bug fixes)
+# Patch version bump (bug fixes, refactors, chores)
 fix: resolve null pointer exception in parser
 fix(parser): handle edge case in dependency resolution
+refactor(parser): simplify token stream handling
+chore: update dependencies
 
-# Minor version bump (new features)
+# Minor version bump (new features, or "breaking" changes — see below)
 feat: add support for new dependency format
 feat(python): add Python 3.13 support
-
-# Major version bump (breaking changes)
-# Use ! after type or type(scope) to indicate breaking changes
-fix!: change return type of core API
 feat(api)!: redesign authentication flow
-refactor(parser)!: remove support for legacy format
-chore!: drop support for Python 3.7
 
-# No release (maintenance)
-chore: update dependencies
+# No release (docs, formatting, CI, build config)
 docs: improve README documentation
 test: add integration tests for edge cases
+ci: tighten lint config
 ```
 
-### 3. GitHub Action - PR Title Validation
+### 3. Major versions are not supported
+
+This module is committed to staying on its current major version (`v2`). New
+major versions would require a Go module path change (e.g. `/v3`) and a
+coordinated migration of every consumer, which we are not planning to do.
+
+As a result, the `!` breaking-change marker in Conventional Commits (e.g.
+`feat!:`, `refactor(api)!:`) is accepted but **does not** trigger a major
+version bump — it is treated as a minor bump. The `BREAKING CHANGE:` footer
+in commit bodies is likewise not interpreted by our release tooling (only the
+subject line is read).
+
+If you genuinely have a breaking change, prefer to split it so the public API
+stays backwards-compatible, or raise it for discussion before merging.
+
+### 4. GitHub Action - PR Title Validation
 
 When you create or edit a Pull Request:
 
@@ -55,35 +66,19 @@ When you create or edit a Pull Request:
    - ❌ Fail if the title is invalid
 3. The check must pass before the PR can be merged
 
-### 4. CircleCI Workflow
+### 5. CircleCI Workflow
 
 When code is merged to `main` using **"Squash and merge"**, the following happens:
 
 1. **Run Tests**: All tests (lint, unit tests, integration tests, security scans) must pass
 2. **Determine Version**: The `version-bump.sh` script reads the commit subject (PR title) and determines the version bump
-3. **Tag Release**: If a release is needed (not a chore), a git tag is created and pushed (e.g., `v1.2.3`) using CircleCI's built-in environment variables (`CIRCLE_PROJECT_USERNAME` and `CIRCLE_PROJECT_REPONAME`)
+3. **Tag Release**: If a release is needed (i.e. the PR title is not in the "no release" set), a git tag is created and pushed (e.g., `v2.1.0`) using CircleCI's built-in environment variables (`CIRCLE_PROJECT_USERNAME` and `CIRCLE_PROJECT_REPONAME`)
 4. **Build & Release**: GoReleaser creates:
    - GitHub Release with changelog
    - Source archives for Linux, macOS, and Windows
    - Checksums for verification
 
 **Note:** Always use "Squash and merge" when merging PRs to ensure the PR title becomes the commit message.
-
-### 5. Increasing the Major Version
-
-To trigger a **major version bump**, add `!` after the type (or scope) in your PR title:
-
-```
-# Breaking change examples
-PR Title: fix!: change API return type
-PR Title: feat(api)!: redesign authentication flow
-PR Title: refactor(parser)!: remove legacy format support
-PR Title: chore!: drop support for Python 3.7
-```
-
-**Standard:** This follows the [Conventional Commits specification](https://www.conventionalcommits.org/) which uses `!` to indicate breaking changes in the commit subject line.
-
-**Note:** The `BREAKING CHANGE:` footer in commit bodies is part of the Conventional Commits spec, but our PR title validation only checks the subject line. Use `!` in the PR title for automatic major version bumps.
 
 ## Manual Release (Local Testing)
 
@@ -142,7 +137,7 @@ Each release includes:
 **Problem**: Code was merged to `main` but no release was created.
 
 **Solutions**:
-- Check if PR title starts with `chore:`, `docs:`, etc. (these skip releases)
+- Check if PR title starts with `docs:`, `style:`, `test:`, `ci:`, or `build:` (these skip releases)
 - Verify all tests passed in CircleCI
 - Check CircleCI logs for the "Determine Version" job
 - Verify the PR title was correctly formatted
@@ -152,7 +147,8 @@ Each release includes:
 **Problem**: Expected a minor bump but got a patch bump.
 
 **Solutions**:
-- Verify PR title follows convention: `feat:` for minor, `fix:` for patch, `type!:` for major
+- Verify PR title follows convention: `feat:` (or `type!:`) for minor; `fix:`/`perf:`/`revert:`/`refactor:`/`chore:` for patch
+- Note: `!` breaking-change markers produce a **minor** bump, not a major one — see "Major versions are not supported"
 - Check the "Determine Version" job output in CircleCI to see the calculated version bump
 - PR title must match the regex patterns in `version-bump.sh`
 - Ensure the GitHub Action validation check passed on the PR

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/snyk/cli-extension-dep-graph
+module github.com/snyk/cli-extension-dep-graph/v2
 
 go 1.26.3
 

--- a/internal/legacycli/errors.go
+++ b/internal/legacycli/errors.go
@@ -9,7 +9,7 @@ import (
 	"github.com/snyk/error-catalog-golang-public/snyk_errors"
 	"github.com/snyk/go-application-framework/pkg/workflow"
 
-	"github.com/snyk/cli-extension-dep-graph/pkg/depgraph/parsers"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/depgraph/parsers"
 )
 
 var ErrNoDepGraphsFound = errors.New("no depgraphs found")

--- a/internal/legacycli/errors_test.go
+++ b/internal/legacycli/errors_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/snyk/cli-extension-dep-graph/internal/workflow"
+	"github.com/snyk/cli-extension-dep-graph/v2/internal/workflow"
 )
 
 const (

--- a/internal/legacycli/legacy_resolution.go
+++ b/internal/legacycli/legacy_resolution.go
@@ -9,8 +9,8 @@ import (
 	"github.com/snyk/go-application-framework/pkg/configuration"
 	gafworkflow "github.com/snyk/go-application-framework/pkg/workflow"
 
-	"github.com/snyk/cli-extension-dep-graph/internal/workflow"
-	"github.com/snyk/cli-extension-dep-graph/pkg/depgraph/parsers"
+	"github.com/snyk/cli-extension-dep-graph/v2/internal/workflow"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/depgraph/parsers"
 )
 
 const (

--- a/internal/legacycli/legacy_resolution_test.go
+++ b/internal/legacycli/legacy_resolution_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/snyk/cli-extension-dep-graph/internal/workflow"
-	"github.com/snyk/cli-extension-dep-graph/pkg/depgraph/parsers"
+	"github.com/snyk/cli-extension-dep-graph/v2/internal/workflow"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/depgraph/parsers"
 )
 
 //go:embed testdata/legacy_cli_output

--- a/internal/remoteconv/extract_test.go
+++ b/internal/remoteconv/extract_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/snyk/cli-extension-dep-graph/internal/snykclient"
+	"github.com/snyk/cli-extension-dep-graph/v2/internal/snykclient"
 )
 
 func TestExtractDepGraphsFromScans_Success(t *testing.T) {

--- a/internal/remoteconv/remote_converter.go
+++ b/internal/remoteconv/remote_converter.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/snyk/dep-graph/go/pkg/depgraph"
 
-	"github.com/snyk/cli-extension-dep-graph/internal/snykclient"
-	"github.com/snyk/cli-extension-dep-graph/pkg/conversion"
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/logger"
+	"github.com/snyk/cli-extension-dep-graph/v2/internal/snykclient"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/conversion"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/logger"
 )
 
 // RemoteSBOMConverter implements SBOMConverter by calling the remote conversion endpoint.

--- a/internal/remoteconv/remote_converter_test.go
+++ b/internal/remoteconv/remote_converter_test.go
@@ -10,10 +10,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/snyk/cli-extension-dep-graph/internal/mocks"
-	"github.com/snyk/cli-extension-dep-graph/internal/snykclient"
-	"github.com/snyk/cli-extension-dep-graph/pkg/conversion"
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/logger"
+	"github.com/snyk/cli-extension-dep-graph/v2/internal/mocks"
+	"github.com/snyk/cli-extension-dep-graph/v2/internal/snykclient"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/conversion"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/logger"
 )
 
 const singleDepGraphResponse = `{

--- a/internal/snykclient/sbomconvert.go
+++ b/internal/snykclient/sbomconvert.go
@@ -10,7 +10,7 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/logger"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/logger"
 )
 
 const (

--- a/internal/snykclient/sbomconvert_test.go
+++ b/internal/snykclient/sbomconvert_test.go
@@ -10,9 +10,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/snyk/cli-extension-dep-graph/internal/mocks"
-	"github.com/snyk/cli-extension-dep-graph/internal/snykclient"
-	pkglogger "github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/logger"
+	"github.com/snyk/cli-extension-dep-graph/v2/internal/mocks"
+	"github.com/snyk/cli-extension-dep-graph/v2/internal/snykclient"
+	pkglogger "github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/logger"
 )
 
 var logger = pkglogger.Nop()

--- a/internal/snykclient/snykclient_test.go
+++ b/internal/snykclient/snykclient_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/snyk/cli-extension-dep-graph/internal/snykclient"
+	"github.com/snyk/cli-extension-dep-graph/v2/internal/snykclient"
 )
 
 func TestNewSnykClient(t *testing.T) {

--- a/pkg/depgraph/callback.go
+++ b/pkg/depgraph/callback.go
@@ -3,8 +3,8 @@ package depgraph
 import (
 	gafworkflow "github.com/snyk/go-application-framework/pkg/workflow"
 
-	"github.com/snyk/cli-extension-dep-graph/internal/legacycli"
-	"github.com/snyk/cli-extension-dep-graph/internal/workflow"
+	"github.com/snyk/cli-extension-dep-graph/v2/internal/legacycli"
+	"github.com/snyk/cli-extension-dep-graph/v2/internal/workflow"
 )
 
 func callback(ctx gafworkflow.InvocationContext, _ []gafworkflow.Data) ([]gafworkflow.Data, error) {

--- a/pkg/depgraph/flags.go
+++ b/pkg/depgraph/flags.go
@@ -3,7 +3,7 @@ package depgraph
 import (
 	"github.com/spf13/pflag"
 
-	"github.com/snyk/cli-extension-dep-graph/internal/workflow"
+	"github.com/snyk/cli-extension-dep-graph/v2/internal/workflow"
 )
 
 const (

--- a/pkg/depgraph/sbom_resolution.go
+++ b/pkg/depgraph/sbom_resolution.go
@@ -15,14 +15,14 @@ import (
 	"github.com/snyk/go-application-framework/pkg/configuration"
 	gafworkflow "github.com/snyk/go-application-framework/pkg/workflow"
 
-	"github.com/snyk/cli-extension-dep-graph/internal/legacycli"
-	"github.com/snyk/cli-extension-dep-graph/internal/remoteconv"
-	"github.com/snyk/cli-extension-dep-graph/internal/snykclient"
-	"github.com/snyk/cli-extension-dep-graph/internal/workflow"
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/legacy"
-	ecosystemslogger "github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/logger"
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/python/uv"
+	"github.com/snyk/cli-extension-dep-graph/v2/internal/legacycli"
+	"github.com/snyk/cli-extension-dep-graph/v2/internal/remoteconv"
+	"github.com/snyk/cli-extension-dep-graph/v2/internal/snykclient"
+	"github.com/snyk/cli-extension-dep-graph/v2/internal/workflow"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/legacy"
+	ecosystemslogger "github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/logger"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/python/uv"
 )
 
 func handleSBOMResolution(

--- a/pkg/depgraph/sbom_resolution_test.go
+++ b/pkg/depgraph/sbom_resolution_test.go
@@ -24,14 +24,14 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/snyk/cli-extension-dep-graph/internal/legacycli"
-	"github.com/snyk/cli-extension-dep-graph/internal/mocks"
-	"github.com/snyk/cli-extension-dep-graph/internal/workflow"
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/legacy"
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/logger"
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/python/uv"
-	"github.com/snyk/cli-extension-dep-graph/pkg/identity"
+	"github.com/snyk/cli-extension-dep-graph/v2/internal/legacycli"
+	"github.com/snyk/cli-extension-dep-graph/v2/internal/mocks"
+	"github.com/snyk/cli-extension-dep-graph/v2/internal/workflow"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/legacy"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/logger"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/python/uv"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/identity"
 )
 
 //go:embed testdata/uv-sbom-convert-expected-dep-graph.json

--- a/pkg/depgraph/workflow.go
+++ b/pkg/depgraph/workflow.go
@@ -5,7 +5,7 @@ import (
 
 	gafworkflow "github.com/snyk/go-application-framework/pkg/workflow"
 
-	"github.com/snyk/cli-extension-dep-graph/internal/workflow"
+	"github.com/snyk/cli-extension-dep-graph/v2/internal/workflow"
 )
 
 var (

--- a/pkg/ecosystems/README.md
+++ b/pkg/ecosystems/README.md
@@ -176,7 +176,7 @@ type ResolverMetadata struct {
 **Standard keys** are available in the `metadata` package:
 
 ```go
-import "github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/metadata"
+import "github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/metadata"
 
 // Available keys:
 const (
@@ -195,7 +195,7 @@ const (
 **Example usage:**
 
 ```go
-import "github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/metadata"
+import "github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/metadata"
 
 resolverMetadata := ResolverMetadata{
     PluginName: "gradle",
@@ -219,8 +219,8 @@ Plugins return `PluginResult`, where:
 import (
     "context"
     "fmt"
-    "github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
-    "github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/python/pip"
+    "github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems"
+    "github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/python/pip"
 )
 
 func main() {
@@ -290,8 +290,8 @@ To add support for a new ecosystem:
    
    import (
        "context"
-       "github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
-       "github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/logger"
+       "github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems"
+       "github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/logger"
    )
    
    type Plugin struct {

--- a/pkg/ecosystems/bazel/go.go
+++ b/pkg/ecosystems/bazel/go.go
@@ -12,7 +12,7 @@ import (
 	"golang.org/x/mod/modfile"
 	"golang.org/x/mod/module"
 
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems"
 )
 
 const (

--- a/pkg/ecosystems/bazel/go_integration_test.go
+++ b/pkg/ecosystems/bazel/go_integration_test.go
@@ -11,9 +11,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/logger"
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/scatest"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/logger"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/scatest"
 )
 
 func assertGoProcessedFiles(t *testing.T, files []string) {

--- a/pkg/ecosystems/bazel/jvm.go
+++ b/pkg/ecosystems/bazel/jvm.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/snyk/dep-graph/go/pkg/depgraph"
 
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems"
 )
 
 // label is an identifier for a Bazel target.

--- a/pkg/ecosystems/bazel/jvm_integration_test.go
+++ b/pkg/ecosystems/bazel/jvm_integration_test.go
@@ -10,9 +10,9 @@ import (
 	"github.com/gkampitakis/go-snaps/snaps"
 	"github.com/stretchr/testify/require"
 
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/logger"
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/scatest"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/logger"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/scatest"
 )
 
 // Only run when BAZEL_JVM_INTEGRATION_TESTS=1 (needs Bazel on PATH; Android fixture needs ANDROID_HOME / SDK).

--- a/pkg/ecosystems/bazel/plugin.go
+++ b/pkg/ecosystems/bazel/plugin.go
@@ -5,9 +5,9 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/logger"
-	"github.com/snyk/cli-extension-dep-graph/pkg/identity"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/logger"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/identity"
 )
 
 const (

--- a/pkg/ecosystems/bazel/plugin_test.go
+++ b/pkg/ecosystems/bazel/plugin_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems"
 )
 
 func Test_checkTargetLimit(t *testing.T) {

--- a/pkg/ecosystems/bazel/resolver.go
+++ b/pkg/ecosystems/bazel/resolver.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/snyk/dep-graph/go/pkg/depgraph"
 
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems"
 )
 
 type bazelDependencyResolver interface {

--- a/pkg/ecosystems/bazel/resolver_test.go
+++ b/pkg/ecosystems/bazel/resolver_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems"
 )
 
 func Test_newResolverFromOptions(t *testing.T) {

--- a/pkg/ecosystems/bazel/testhelpers_test.go
+++ b/pkg/ecosystems/bazel/testhelpers_test.go
@@ -1,7 +1,7 @@
 package bazel
 
 import (
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems"
 )
 
 // snapshotResults wraps results in the shape JSON snapshot tests

--- a/pkg/ecosystems/gradle/depgraph.go
+++ b/pkg/ecosystems/gradle/depgraph.go
@@ -8,7 +8,7 @@ import (
 	"github.com/package-url/packageurl-go"
 	"github.com/snyk/dep-graph/go/pkg/depgraph"
 
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems"
 )
 
 const pkgManagerName = "gradle"

--- a/pkg/ecosystems/gradle/depgraph_test.go
+++ b/pkg/ecosystems/gradle/depgraph_test.go
@@ -5,7 +5,7 @@ package gradle
 import (
 	"testing"
 
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems"
 	"github.com/snyk/dep-graph/go/pkg/depgraph"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/pkg/ecosystems/gradle/normalize_deps.go
+++ b/pkg/ecosystems/gradle/normalize_deps.go
@@ -3,8 +3,8 @@ package gradle
 import (
 	"context"
 
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/logger"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/logger"
 )
 
 // NormalizeDepsPostHook is the post-hook signature accepted by the Gradle

--- a/pkg/ecosystems/gradle/plugin.go
+++ b/pkg/ecosystems/gradle/plugin.go
@@ -9,11 +9,11 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/discovery"
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/logger"
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/metadata"
-	"github.com/snyk/cli-extension-dep-graph/pkg/identity"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/discovery"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/logger"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/metadata"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/identity"
 )
 
 //go:embed init/snyk-deps-init.gradle

--- a/pkg/ecosystems/gradle/plugin_integration_test.go
+++ b/pkg/ecosystems/gradle/plugin_integration_test.go
@@ -18,10 +18,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/logger"
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/metadata"
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/scatest"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/logger"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/metadata"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/scatest"
 )
 
 // updateFixturesEnvVar, when set to a truthy value, causes the integration tests

--- a/pkg/ecosystems/gradle/plugin_test.go
+++ b/pkg/ecosystems/gradle/plugin_test.go
@@ -11,9 +11,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/logger"
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/metadata"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/logger"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/metadata"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/pkg/ecosystems/gradle/testhelpers_test.go
+++ b/pkg/ecosystems/gradle/testhelpers_test.go
@@ -3,8 +3,8 @@ package gradle
 import (
 	"context"
 
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/logger"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/logger"
 )
 
 // collectConvert drains convertProjects's streaming emit into a slice.

--- a/pkg/ecosystems/gradle/validation.go
+++ b/pkg/ecosystems/gradle/validation.go
@@ -7,7 +7,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems"
 )
 
 // ValidateOptions validates the provided options and returns an error if any are invalid.

--- a/pkg/ecosystems/gradle/validation_test.go
+++ b/pkg/ecosystems/gradle/validation_test.go
@@ -8,9 +8,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/logger"
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/scatest"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/logger"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/scatest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/pkg/ecosystems/javascript/bun/acceptance_test.go
+++ b/pkg/ecosystems/javascript/bun/acceptance_test.go
@@ -28,10 +28,10 @@ import (
 
 	"github.com/snyk/dep-graph/go/pkg/depgraph"
 
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/javascript/bun"
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/logger"
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/scatest"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/javascript/bun"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/logger"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/scatest"
 )
 
 type acceptanceFixture struct {

--- a/pkg/ecosystems/javascript/bun/plugin.go
+++ b/pkg/ecosystems/javascript/bun/plugin.go
@@ -7,10 +7,10 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/discovery"
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/logger"
-	"github.com/snyk/cli-extension-dep-graph/pkg/identity"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/discovery"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/logger"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/identity"
 )
 
 const (

--- a/pkg/ecosystems/javascript/bun/plugin_test.go
+++ b/pkg/ecosystems/javascript/bun/plugin_test.go
@@ -14,9 +14,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/logger"
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/scatest"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/logger"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/scatest"
 )
 
 // testFindResultByRoot finds the SCAResult whose root package name equals rootName.

--- a/pkg/ecosystems/javascript/bun/stability_test.go
+++ b/pkg/ecosystems/javascript/bun/stability_test.go
@@ -22,9 +22,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/javascript/bun"
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/scatest"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/javascript/bun"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/scatest"
 )
 
 // TestBunWhyOutputStability runs the plugin against every fixture directory

--- a/pkg/ecosystems/javascript/bun/why_parser.go
+++ b/pkg/ecosystems/javascript/bun/why_parser.go
@@ -10,7 +10,7 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/logger"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/logger"
 )
 
 var (

--- a/pkg/ecosystems/javascript/bun/why_parser_test.go
+++ b/pkg/ecosystems/javascript/bun/why_parser_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/logger"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/logger"
 )
 
 func openFixture(t *testing.T, path string) *os.File {

--- a/pkg/ecosystems/legacy/plugin.go
+++ b/pkg/ecosystems/legacy/plugin.go
@@ -12,12 +12,12 @@ import (
 	"github.com/snyk/go-application-framework/pkg/configuration"
 	gafworkflow "github.com/snyk/go-application-framework/pkg/workflow"
 
-	"github.com/snyk/cli-extension-dep-graph/internal/legacycli"
-	"github.com/snyk/cli-extension-dep-graph/internal/workflow"
-	"github.com/snyk/cli-extension-dep-graph/pkg/depgraph/parsers"
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/logger"
-	"github.com/snyk/cli-extension-dep-graph/pkg/identity"
+	"github.com/snyk/cli-extension-dep-graph/v2/internal/legacycli"
+	"github.com/snyk/cli-extension-dep-graph/v2/internal/workflow"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/depgraph/parsers"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/logger"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/identity"
 )
 
 const PluginName = "legacycli"

--- a/pkg/ecosystems/legacy/plugin_test.go
+++ b/pkg/ecosystems/legacy/plugin_test.go
@@ -15,12 +15,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/snyk/cli-extension-dep-graph/internal/legacycli"
-	"github.com/snyk/cli-extension-dep-graph/internal/workflow"
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/legacy"
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/logger"
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/scatest"
+	"github.com/snyk/cli-extension-dep-graph/v2/internal/legacycli"
+	"github.com/snyk/cli-extension-dep-graph/v2/internal/workflow"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/legacy"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/logger"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/scatest"
 )
 
 func TestPlugin_GetName(t *testing.T) {

--- a/pkg/ecosystems/options.go
+++ b/pkg/ecosystems/options.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/argparser"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/argparser"
 )
 
 // SCAPluginOptions contains configuration options for SCA plugins,

--- a/pkg/ecosystems/orchestrator/registry.go
+++ b/pkg/ecosystems/orchestrator/registry.go
@@ -7,12 +7,12 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/snyk/go-application-framework/pkg/workflow"
 
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/bazel"
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/gradle"
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/javascript/bun"
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/legacy"
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/logger"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/bazel"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/gradle"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/javascript/bun"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/legacy"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/logger"
 )
 
 type pluginEntry struct {

--- a/pkg/ecosystems/orchestrator/registry_test.go
+++ b/pkg/ecosystems/orchestrator/registry_test.go
@@ -12,9 +12,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/logger"
-	"github.com/snyk/cli-extension-dep-graph/pkg/identity"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/logger"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/identity"
 )
 
 type mockPlugin struct {

--- a/pkg/ecosystems/plugin_interface.go
+++ b/pkg/ecosystems/plugin_interface.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/snyk/dep-graph/go/pkg/depgraph"
 
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/logger"
-	"github.com/snyk/cli-extension-dep-graph/pkg/identity"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/logger"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/identity"
 )
 
 type ResolverMetadata struct {

--- a/pkg/ecosystems/python/pip/depgraph.go
+++ b/pkg/ecosystems/python/pip/depgraph.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/snyk/dep-graph/go/pkg/depgraph"
 
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/logger"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/logger"
 )
 
 // depStringPattern extracts the package name from a dependency string.

--- a/pkg/ecosystems/python/pip/depgraph_test.go
+++ b/pkg/ecosystems/python/pip/depgraph_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/logger"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/logger"
 )
 
 func TestReport_ToDependencyGraph(t *testing.T) {

--- a/pkg/ecosystems/python/pip/plugin.go
+++ b/pkg/ecosystems/python/pip/plugin.go
@@ -14,11 +14,11 @@ import (
 	snyk_ecosystems "github.com/snyk/error-catalog-golang-public/opensource/ecosystems"
 	"github.com/snyk/error-catalog-golang-public/snyk_errors"
 
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/discovery"
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/logger"
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/metadata"
-	"github.com/snyk/cli-extension-dep-graph/pkg/identity"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/discovery"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/logger"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/metadata"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/identity"
 )
 
 const (

--- a/pkg/ecosystems/python/pip/plugin_integration_test.go
+++ b/pkg/ecosystems/python/pip/plugin_integration_test.go
@@ -20,10 +20,10 @@ import (
 
 	snykerrors "github.com/snyk/error-catalog-golang-public/snyk_errors"
 
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/logger"
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/metadata"
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/scatest"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/logger"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/metadata"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/scatest"
 )
 
 // PluginTestCase defines a test case for the plugin

--- a/pkg/ecosystems/python/pip/plugin_test.go
+++ b/pkg/ecosystems/python/pip/plugin_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems"
 )
 
 func ptr(s string) *string { return &s }

--- a/pkg/ecosystems/python/pip/report.go
+++ b/pkg/ecosystems/python/pip/report.go
@@ -14,7 +14,7 @@ import (
 	"github.com/snyk/error-catalog-golang-public/snyk"
 	"github.com/snyk/error-catalog-golang-public/snyk_errors"
 
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/logger"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/logger"
 )
 
 // Report represents the minimal JSON output from pip install --report

--- a/pkg/ecosystems/python/pipenv/plugin.go
+++ b/pkg/ecosystems/python/pipenv/plugin.go
@@ -14,12 +14,12 @@ import (
 	"github.com/snyk/error-catalog-golang-public/prchecks"
 	"github.com/snyk/error-catalog-golang-public/snyk_errors"
 
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/discovery"
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/logger"
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/metadata"
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/python/pip"
-	"github.com/snyk/cli-extension-dep-graph/pkg/identity"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/discovery"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/logger"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/metadata"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/python/pip"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/identity"
 )
 
 const (

--- a/pkg/ecosystems/python/pipenv/plugin_integration_test.go
+++ b/pkg/ecosystems/python/pipenv/plugin_integration_test.go
@@ -20,11 +20,11 @@ import (
 
 	snykerrors "github.com/snyk/error-catalog-golang-public/snyk_errors"
 
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/logger"
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/metadata"
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/python/pip"
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/scatest"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/logger"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/metadata"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/python/pip"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/scatest"
 )
 
 // PluginTestCase defines a test case for the plugin.

--- a/pkg/ecosystems/python/pipenv/plugin_test.go
+++ b/pkg/ecosystems/python/pipenv/plugin_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems"
 )
 
 // TestPlugin_DiscoverPipfiles_HonorsExcludePaths locks in that the pipenv plugin reads

--- a/pkg/ecosystems/python/uv/mock_client.go
+++ b/pkg/ecosystems/python/uv/mock_client.go
@@ -1,7 +1,7 @@
 package uv
 
 import (
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems"
 )
 
 type MockClient struct {

--- a/pkg/ecosystems/python/uv/mock_converter_test.go
+++ b/pkg/ecosystems/python/uv/mock_converter_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/snyk/dep-graph/go/pkg/depgraph"
 
-	"github.com/snyk/cli-extension-dep-graph/pkg/conversion"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/conversion"
 )
 
 // MockSBOMConverter is a test double for conversion.SBOMConverter. It records

--- a/pkg/ecosystems/python/uv/plugin.go
+++ b/pkg/ecosystems/python/uv/plugin.go
@@ -11,11 +11,11 @@ import (
 
 	"github.com/snyk/error-catalog-golang-public/opensource/ecosystems"
 
-	"github.com/snyk/cli-extension-dep-graph/pkg/conversion"
-	scaecosystems "github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/discovery"
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/logger"
-	"github.com/snyk/cli-extension-dep-graph/pkg/identity"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/conversion"
+	scaecosystems "github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/discovery"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/logger"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/identity"
 )
 
 const PluginName = "uv"

--- a/pkg/ecosystems/python/uv/plugin_test.go
+++ b/pkg/ecosystems/python/uv/plugin_test.go
@@ -13,9 +13,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/logger"
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/scatest"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/logger"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/scatest"
 )
 
 var testLogger = logger.Nop()

--- a/pkg/ecosystems/python/uv/testhelpers_test.go
+++ b/pkg/ecosystems/python/uv/testhelpers_test.go
@@ -3,8 +3,8 @@ package uv
 import (
 	"context"
 
-	scaecosystems "github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/logger"
+	scaecosystems "github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/logger"
 )
 
 // collectBuildResults drains plugin.buildResults's streaming emit

--- a/pkg/ecosystems/python/uv/uvclient.go
+++ b/pkg/ecosystems/python/uv/uvclient.go
@@ -10,7 +10,7 @@ import (
 	"github.com/snyk/error-catalog-golang-public/opensource/ecosystems"
 	"github.com/snyk/error-catalog-golang-public/snyk_errors"
 
-	scaecosystems "github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
+	scaecosystems "github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems"
 )
 
 const (

--- a/pkg/ecosystems/python/uv/uvclient_test.go
+++ b/pkg/ecosystems/python/uv/uvclient_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems"
 )
 
 type mockCmdExecutor struct {

--- a/pkg/ecosystems/scatest/scatest.go
+++ b/pkg/ecosystems/scatest/scatest.go
@@ -8,8 +8,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/logger"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/logger"
 )
 
 // Run drives plugin.BuildDepGraphsFromDir and returns every emitted

--- a/script/version-bump.sh
+++ b/script/version-bump.sh
@@ -39,6 +39,59 @@ NEW_TAG="v${NEW_VERSION}"
 
 echo "Bump type: $BUMP_TYPE ($LATEST_TAG → $NEW_TAG)"
 
+# Guardrail: enforce Go Semantic Import Versioning when tagging v2+.
+#
+# Go modules require that any module at major version >= 2 carries the major
+# version as a /vN suffix on the module path (e.g. module .../v2). Without
+# this, `go get` cannot resolve v2+ tags and consumers see resolution errors.
+# See: https://go.dev/ref/mod#major-version-suffixes
+#
+# This guardrail compares the major version in the upcoming tag against the
+# /vN suffix in go.mod and aborts the release if they disagree.
+if [ "$BUMP_TYPE" != "none" ]; then
+    GO_MOD_PATH="$(dirname "$0")/../go.mod"
+    if [ ! -f "$GO_MOD_PATH" ]; then
+        echo "Error: cannot find go.mod at $GO_MOD_PATH" >&2
+        exit 1
+    fi
+
+    MODULE_LINE=$(awk '/^module / {print $2; exit}' "$GO_MOD_PATH")
+    if [ -z "$MODULE_LINE" ]; then
+        echo "Error: could not parse module path from $GO_MOD_PATH" >&2
+        exit 1
+    fi
+
+    # Extract trailing /vN suffix (if any) from the module path.
+    if [[ "$MODULE_LINE" =~ /v([0-9]+)$ ]]; then
+        MODULE_MAJOR="${BASH_REMATCH[1]}"
+    else
+        MODULE_MAJOR=1  # v0 and v1 both use no suffix
+    fi
+
+    # Tag major 0 and 1 both correspond to a module path with no /vN suffix.
+    if [ "$MAJOR" -le 1 ]; then
+        EXPECTED_MODULE_MAJOR=1
+    else
+        EXPECTED_MODULE_MAJOR="$MAJOR"
+    fi
+
+    if [ "$MODULE_MAJOR" != "$EXPECTED_MODULE_MAJOR" ]; then
+        echo "Error: Go Semantic Import Versioning violation." >&2
+        echo "  Upcoming tag:  $NEW_TAG (major=$MAJOR)" >&2
+        echo "  Module path:   $MODULE_LINE" >&2
+        if [ "$MAJOR" -le 1 ]; then
+            echo "  Expected module path to have no /vN suffix." >&2
+        else
+            echo "  Expected module path to end with /v$MAJOR." >&2
+        fi
+        echo "" >&2
+        echo "Before releasing $NEW_TAG, update the module path in go.mod and" >&2
+        echo "rewrite all internal imports to match. See:" >&2
+        echo "  https://go.dev/ref/mod#major-version-suffixes" >&2
+        exit 1
+    fi
+fi
+
 # Export for CircleCI (only if BASH_ENV is set)
 if [ -n "$BASH_ENV" ]; then
     echo "export BUMP_TYPE=$BUMP_TYPE" >> "$BASH_ENV"

--- a/script/version-bump.sh
+++ b/script/version-bump.sh
@@ -12,14 +12,15 @@ IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
 PR_TITLE=$(git log -1 --pretty=%s)
 echo "PR title: $PR_TITLE"
 
-# Determine version bump based on PR title
-if [[ "$PR_TITLE" =~ ^[a-z]+(\(.*\))?!: ]]; then
-    # Breaking change indicator with ! (e.g., fix!:, feat(api)!:)
-    BUMP_TYPE="major"
-    MAJOR=$((MAJOR + 1))
-    MINOR=0
-    PATCH=0
-elif [[ "$PR_TITLE" =~ ^feat(\(.*\))?:|^feature: ]]; then
+# Determine version bump based on PR title.
+#
+# Note: major version bumps are intentionally not supported. This module is
+# committed to staying on its current major version; new majors would require
+# a Go module path change (e.g. /v3) and a coordinated consumer migration,
+# which we are not planning to do. Conventional Commits "!" titles (e.g.
+# `feat!:`, `refactor(api)!:`) are therefore treated as a minor bump.
+if [[ "$PR_TITLE" =~ ^[a-z]+(\(.*\))?!: ]] || \
+   [[ "$PR_TITLE" =~ ^feat(\(.*\))?:|^feature: ]]; then
     BUMP_TYPE="minor"
     MINOR=$((MINOR + 1))
     PATCH=0
@@ -38,59 +39,6 @@ NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}"
 NEW_TAG="v${NEW_VERSION}"
 
 echo "Bump type: $BUMP_TYPE ($LATEST_TAG → $NEW_TAG)"
-
-# Guardrail: enforce Go Semantic Import Versioning when tagging v2+.
-#
-# Go modules require that any module at major version >= 2 carries the major
-# version as a /vN suffix on the module path (e.g. module .../v2). Without
-# this, `go get` cannot resolve v2+ tags and consumers see resolution errors.
-# See: https://go.dev/ref/mod#major-version-suffixes
-#
-# This guardrail compares the major version in the upcoming tag against the
-# /vN suffix in go.mod and aborts the release if they disagree.
-if [ "$BUMP_TYPE" != "none" ]; then
-    GO_MOD_PATH="$(dirname "$0")/../go.mod"
-    if [ ! -f "$GO_MOD_PATH" ]; then
-        echo "Error: cannot find go.mod at $GO_MOD_PATH" >&2
-        exit 1
-    fi
-
-    MODULE_LINE=$(awk '/^module / {print $2; exit}' "$GO_MOD_PATH")
-    if [ -z "$MODULE_LINE" ]; then
-        echo "Error: could not parse module path from $GO_MOD_PATH" >&2
-        exit 1
-    fi
-
-    # Extract trailing /vN suffix (if any) from the module path.
-    if [[ "$MODULE_LINE" =~ /v([0-9]+)$ ]]; then
-        MODULE_MAJOR="${BASH_REMATCH[1]}"
-    else
-        MODULE_MAJOR=1  # v0 and v1 both use no suffix
-    fi
-
-    # Tag major 0 and 1 both correspond to a module path with no /vN suffix.
-    if [ "$MAJOR" -le 1 ]; then
-        EXPECTED_MODULE_MAJOR=1
-    else
-        EXPECTED_MODULE_MAJOR="$MAJOR"
-    fi
-
-    if [ "$MODULE_MAJOR" != "$EXPECTED_MODULE_MAJOR" ]; then
-        echo "Error: Go Semantic Import Versioning violation." >&2
-        echo "  Upcoming tag:  $NEW_TAG (major=$MAJOR)" >&2
-        echo "  Module path:   $MODULE_LINE" >&2
-        if [ "$MAJOR" -le 1 ]; then
-            echo "  Expected module path to have no /vN suffix." >&2
-        else
-            echo "  Expected module path to end with /v$MAJOR." >&2
-        fi
-        echo "" >&2
-        echo "Before releasing $NEW_TAG, update the module path in go.mod and" >&2
-        echo "rewrite all internal imports to match. See:" >&2
-        echo "  https://go.dev/ref/mod#major-version-suffixes" >&2
-        exit 1
-    fi
-fi
 
 # Export for CircleCI (only if BASH_ENV is set)
 if [ -n "$BASH_ENV" ]; then


### PR DESCRIPTION
## Why

The `v2.0.0` and `v2.0.1` tags exist but are unusable by Go consumers (like `snyk/cli-extension-os-flows`). Go's Semantic Import Versioning rule requires modules at major version >= 2 to carry a `/vN` suffix onthe module path; without it, `go get @v2.x.x` errors out and `@latest` silently resolves to `v1.26.0`.

See [go documentation on major version suffixes](https://go.dev/ref/mod#major-version-suffixes) for more details.

## What

- `go.mod`: `module github.com/snyk/cli-extension-dep-graph/v2`
- Rewrote all internal imports to `.../v2/...`
- Updated `.golangci.yml`
- Updated import examples in `pkg/ecosystems/README.md`
- Updated `script/version-bump.sh` to only ever bump minor or patch. Major will never automatically be bumped.