### PR TITLE
feat: get depgraph for single uv workspace member

### DIFF
--- a/pkg/ecosystems/options.go
+++ b/pkg/ecosystems/options.go
@@ -30,6 +30,7 @@ type GlobalOptions struct {
 	ForceIncludeWorkspacePackages bool                 `arg:"--internal-uv-workspace-packages"`
 	ProjectName                   *string              `arg:"--project-name"`
 	IncludeProvenance             bool                 `arg:"--include-provenance"`
+	WorkspacePackage              *string              `arg:"--workspace-package"`
 	RawFlags                      []string
 }
 
@@ -169,6 +170,11 @@ func (o *SCAPluginOptions) WithForceIncludeWorkspacePackages(forceIncludeWorkspa
 
 func (o *SCAPluginOptions) WithProjectName(projectName string) *SCAPluginOptions {
 	o.Global.ProjectName = &projectName
+	return o
+}
+
+func (o *SCAPluginOptions) WithWorkspacePackage(pkg string) *SCAPluginOptions {
+	o.Global.WorkspacePackage = &pkg
 	return o
 }
 

--- a/pkg/ecosystems/python/uv/plugin.go
+++ b/pkg/ecosystems/python/uv/plugin.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/snyk/dep-graph/go/pkg/depgraph"
 
+	clierrors "github.com/snyk/error-catalog-golang-public/cli"
 	"github.com/snyk/error-catalog-golang-public/opensource/ecosystems"
 
 	"github.com/snyk/cli-extension-dep-graph/v2/pkg/conversion"
@@ -95,8 +96,8 @@ func (p Plugin) BuildDepGraphsFromDir(
 			return err
 		}
 
-		if !options.Global.AllProjects && emitted > 0 {
-			// We don't want more than one project
+		if (!options.Global.AllProjects || selectedWorkspacePackage(options) != "") && emitted > 0 {
+			// We don't want more than one project (a selected workspace package is a single project too).
 			break
 		}
 	}
@@ -121,7 +122,10 @@ func (p Plugin) buildResults(
 		return 0, fmt.Errorf("failed to parse and validate sbom for %s: %w", lockFilePath, err)
 	}
 
-	if !options.Global.AllProjects && !options.Global.ForceIncludeWorkspacePackages && !hasProjectRoot(parsedSbom) {
+	workspaceMember := selectedWorkspacePackage(options)
+
+	if !options.Global.AllProjects && !options.Global.ForceIncludeWorkspacePackages &&
+		workspaceMember == "" && !hasProjectRoot(parsedSbom) {
 		log.Info(ctx, "No root project found in SBOM", logger.Attr("lockFile", lockFilePath))
 		noRootErr := ecosystems.NewUvNoProjectRootError(
 			"Found uv workspace with no root project. To scan all workspace members use the --all-projects flag.",
@@ -149,56 +153,70 @@ func (p Plugin) buildResults(
 		return 0, fmt.Errorf("failed to convert sbom to dep-graphs for %s: %w", lockFilePath, err)
 	}
 
+	if workspaceMember != "" {
+		depGraphs = filterDepGraphsByName(depGraphs, workspaceMember)
+		if len(depGraphs) == 0 {
+			log.Info(ctx, "Workspace package not found", logger.Attr("workspacePackage", workspaceMember), logger.Attr("lockFile", lockFilePath))
+			return 1, onGraph(workspacePackageNotFoundResult(workspaceMember, lockFilePath))
+		}
+	}
+
 	emitted := 0
 	for _, depGraph := range depGraphs {
 		workspacePackage := findWorkspacePackage(depGraph, workspacePackages)
-
-		var manifestFile string
-		switch {
-		case workspacePackage != nil:
-			manifestFile = filepath.Join(lockFileDir, workspacePackage.Path, PyprojectTomlFileName)
-		case lockFileDir == ".":
-			manifestFile = PyprojectTomlFileName
-		default:
-			manifestFile = filepath.Join(lockFileDir, PyprojectTomlFileName)
-		}
-
-		packagePath := lockFileDir
-		if workspacePackage != nil {
-			packagePath = filepath.Join(packagePath, workspacePackage.Path)
-		}
-		processedFiles := make([]string, 0, 3)
-		for _, name := range []string{LockFileName, PyprojectTomlFileName, RequirementsTxtFileName} {
-			processedFiles = append(processedFiles, filepath.Join(packagePath, name))
-		}
-
-		var rootName string
-		if rootPkg := depGraph.GetRootPkg(); rootPkg != nil {
-			rootName = rootPkg.Info.Name
-		}
-
-		if emitErr := onGraph(scaecosystems.SCAResult{
-			DepGraph: depGraph,
-			ProjectDescriptor: identity.ProjectDescriptor{
-				Identity: identity.ProjectIdentity{
-					ProjectType:       "uv",
-					TargetFile:        &manifestFile,
-					RootComponentName: rootName,
-				},
-			},
-			ResolverMetadata: &scaecosystems.ResolverMetadata{
-				PluginName:           PluginName,
-				NormalisedTargetFile: manifestFile,
-				VersionBuildInfo:     map[string]string{},
-			},
-			ProcessedFiles: processedFiles,
-		}); emitErr != nil {
+		result := buildSCAResult(depGraph, lockFileDir, workspacePackage)
+		if emitErr := onGraph(result); emitErr != nil {
 			return emitted, emitErr
 		}
 		emitted++
 	}
 
 	return emitted, nil
+}
+
+// buildSCAResult constructs the SCAResult for a single dep-graph, deriving the
+// manifest path and processed files from the (optional) workspace package.
+func buildSCAResult(depGraph *depgraph.DepGraph, lockFileDir string, workspacePackage *WorkspacePackage) scaecosystems.SCAResult {
+	var manifestFile string
+	switch {
+	case workspacePackage != nil:
+		manifestFile = filepath.Join(lockFileDir, workspacePackage.Path, PyprojectTomlFileName)
+	case lockFileDir == ".":
+		manifestFile = PyprojectTomlFileName
+	default:
+		manifestFile = filepath.Join(lockFileDir, PyprojectTomlFileName)
+	}
+
+	packagePath := lockFileDir
+	if workspacePackage != nil {
+		packagePath = filepath.Join(packagePath, workspacePackage.Path)
+	}
+	processedFiles := make([]string, 0, 3)
+	for _, name := range []string{LockFileName, PyprojectTomlFileName, RequirementsTxtFileName} {
+		processedFiles = append(processedFiles, filepath.Join(packagePath, name))
+	}
+
+	var rootName string
+	if rootPkg := depGraph.GetRootPkg(); rootPkg != nil {
+		rootName = rootPkg.Info.Name
+	}
+
+	return scaecosystems.SCAResult{
+		DepGraph: depGraph,
+		ProjectDescriptor: identity.ProjectDescriptor{
+			Identity: identity.ProjectIdentity{
+				ProjectType:       "uv",
+				TargetFile:        &manifestFile,
+				RootComponentName: rootName,
+			},
+		},
+		ResolverMetadata: &scaecosystems.ResolverMetadata{
+			PluginName:           PluginName,
+			NormalisedTargetFile: manifestFile,
+			VersionBuildInfo:     map[string]string{},
+		},
+		ProcessedFiles: processedFiles,
+	}
 }
 
 // sbomMetadata is the minimal metadata needed to construct an empty dep-graph
@@ -261,6 +279,43 @@ func buildEmptyDepGraph(metadata *sbomMetadata) (*depgraph.DepGraph, error) {
 	return builder.Build(), nil
 }
 
+// selectedWorkspacePackage returns the requested workspace member name, or "" if none.
+func selectedWorkspacePackage(options *scaecosystems.SCAPluginOptions) string {
+	if options.Global.WorkspacePackage != nil {
+		return *options.Global.WorkspacePackage
+	}
+	return ""
+}
+
+// filterDepGraphsByName keeps only the dep-graphs whose root package matches name.
+func filterDepGraphsByName(depGraphs []*depgraph.DepGraph, name string) []*depgraph.DepGraph {
+	var filtered []*depgraph.DepGraph
+	for _, dg := range depGraphs {
+		if rootPkg := dg.GetRootPkg(); rootPkg != nil && rootPkg.Info.Name == name {
+			filtered = append(filtered, dg)
+		}
+	}
+	return filtered
+}
+
+// workspacePackageNotFoundResult builds a single errored result for a requested
+// workspace member that is not present in the exported workspace.
+func workspacePackageNotFoundResult(pkg, lockFilePath string) scaecosystems.SCAResult {
+	return scaecosystems.SCAResult{
+		ProjectDescriptor: identity.ProjectDescriptor{
+			Identity: identity.ProjectIdentity{
+				ProjectType: "uv",
+				TargetFile:  &lockFilePath,
+			},
+		},
+		ResolverMetadata: &scaecosystems.ResolverMetadata{
+			PluginName:           PluginName,
+			NormalisedTargetFile: lockFilePath,
+		},
+		Error: clierrors.NewGeneralSCAFailureError(fmt.Sprintf("Workspace package '%s' not found.", pkg)),
+	}
+}
+
 // Returns nil if the package was not found.
 func findWorkspacePackage(depGraph *depgraph.DepGraph, workspacePackages []WorkspacePackage) *WorkspacePackage {
 	root := depGraph.GetRootPkg()
@@ -283,7 +338,7 @@ func (p Plugin) discoverLockFiles(
 	var findOpts []discovery.FindOption
 
 	switch {
-	case options.Global.AllProjects:
+	case options.Global.AllProjects && selectedWorkspacePackage(options) == "":
 		findOpts = []discovery.FindOption{
 			discovery.WithInclude(LockFileName),
 			discovery.WithCommonExcludes(),

--- a/pkg/ecosystems/python/uv/plugin_test.go
+++ b/pkg/ecosystems/python/uv/plugin_test.go
@@ -2,6 +2,7 @@ package uv
 
 import (
 	"context"
+	_ "embed"
 	"errors"
 	"os"
 	"path/filepath"
@@ -19,6 +20,12 @@ import (
 )
 
 var testLogger = logger.Nop()
+
+//go:embed testdata/workspace_sbom.json
+var workspaceSBOMJSON []byte
+
+//go:embed testdata/virtual_workspace_sbom.json
+var virtualWorkspaceSBOMJSON []byte
 
 const validSBOMJSON = `{
 	"bomFormat": "CycloneDX",
@@ -715,47 +722,58 @@ func TestBuildFindings_MultipleDepGraphs(t *testing.T) {
 	assert.Equal(t, "package2", findings[1].DepGraph.GetRootPkg().Info.Name)
 }
 
-func TestBuildFindings_WorkspacePackage(t *testing.T) {
-	sbomJSON := `{
-		"bomFormat": "CycloneDX",
-		"specVersion": "1.5",
-		"version": 1,
-		"metadata": {
-			"tools": [{"vendor": "Astral Software Inc.", "name": "uv", "version": "0.10.9"}],
-			"component": {
-				"type": "library",
-				"bom-ref": "workspace-root-1@1.0.0",
-				"name": "workspace-root",
-				"version": "1.0.0",
-				"properties": [
-					{"name": "uv:package:is_project_root", "value": "true"}
-				]
-			}
-		},
-		"components": [
-			{
-				"type": "library",
-				"bom-ref": "workspace-package-2@3.1.0",
-				"name": "workspace-package",
-				"version": "3.1.0",
-				"properties": [
-					{
-						"name": "uv:workspace:path",
-						"value": "packages/my-package"
-					}
-				]
-			}
-		]
-	}`
-	sbom := Sbom(sbomJSON)
-	plugin := NewPlugin(&MockClient{}, mockConverter(createTestDepGraph("workspace-package", "3.1.0")), "")
+func TestBuildFindings_WorkspacePackage_FiltersToMember(t *testing.T) {
+	sbom := Sbom(workspaceSBOMJSON)
+	plugin := NewPlugin(&MockClient{}, mockConverter(
+		createTestDepGraph("package-a", "0.1.0"),
+		createTestDepGraph("package-b", "0.1.0"),
+		createTestDepGraph("package-c", "0.1.0"),
+	), "")
 
-	results, err := collectBuildResults(context.Background(), plugin, sbom, "uv.lock", ".", ecosystems.NewPluginOptions(), testLogger)
+	opts := ecosystems.NewPluginOptions().WithWorkspacePackage("package-b")
+	results, err := collectBuildResults(context.Background(), plugin, sbom, "uv.lock", ".", opts, testLogger)
 
-	findings := results
 	require.NoError(t, err)
-	require.Len(t, findings, 1)
-	assert.Equal(t, filepath.Join("packages", "my-package", "pyproject.toml"), findings[0].ResolverMetadata.NormalisedTargetFile)
+	require.Len(t, results, 1)
+	res := results[0]
+	require.NoError(t, res.Error)
+	assert.Equal(t, "package-b", res.DepGraph.GetRootPkg().Info.Name)
+
+	expected := filepath.Join("packages", "package_b", "pyproject.toml")
+	assert.Equal(t, expected, res.ResolverMetadata.NormalisedTargetFile)
+	require.NotNil(t, res.ProjectDescriptor.Identity.TargetFile)
+	assert.Equal(t, expected, *res.ProjectDescriptor.Identity.TargetFile)
+}
+
+func TestBuildFindings_WorkspacePackage_NotFound(t *testing.T) {
+	sbom := Sbom(workspaceSBOMJSON)
+	plugin := NewPlugin(&MockClient{}, mockConverter(
+		createTestDepGraph("package-a", "0.1.0"),
+		createTestDepGraph("package-c", "0.1.0"),
+	), "")
+
+	opts := ecosystems.NewPluginOptions().WithWorkspacePackage("nope")
+	results, err := collectBuildResults(context.Background(), plugin, sbom, "uv.lock", ".", opts, testLogger)
+
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	var snykErr snyk_errors.Error
+	require.ErrorAs(t, results[0].Error, &snykErr)
+	assert.Equal(t, "Workspace package 'nope' not found.", snykErr.Detail)
+}
+
+func TestBuildFindings_WorkspacePackage_BypassesNoRootGuard(t *testing.T) {
+	sbom := Sbom(virtualWorkspaceSBOMJSON)
+	plugin := NewPlugin(&MockClient{}, mockConverter(createTestDepGraph("albatross", "0.1.0")), "")
+
+	opts := ecosystems.NewPluginOptions().WithWorkspacePackage("albatross")
+	results, err := collectBuildResults(context.Background(), plugin, sbom, "uv.lock", ".", opts, testLogger)
+
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	require.NoError(t, results[0].Error)
+	assert.Equal(t, "albatross", results[0].DepGraph.GetRootPkg().Info.Name)
 }
 
 func TestBuildFindings_PathConstruction_RootDir(t *testing.T) {

--- a/pkg/ecosystems/python/uv/testdata/virtual_workspace_sbom.json
+++ b/pkg/ecosystems/python/uv/testdata/virtual_workspace_sbom.json
@@ -1,0 +1,314 @@
+{
+	"bomFormat": "CycloneDX",
+	"specVersion": "1.5",
+	"version": 1,
+	"serialNumber": "urn:uuid:b154b949-3612-48f1-8e37-a400123fb925",
+	"metadata": {
+	  "timestamp": "2026-06-03T13:27:49.688958000Z",
+	  "tools": [
+		{
+		  "vendor": "Astral Software Inc.",
+		  "name": "uv",
+		  "version": "0.10.9"
+		}
+	  ],
+	  "component": {
+		"type": "library",
+		"bom-ref": "uv-workspace-21",
+		"name": "uv-workspace",
+		"properties": [
+		  {
+			"name": "uv:package:is_synthetic_root",
+			"value": "true"
+		  }
+		]
+	  }
+	},
+	"components": [
+	  {
+		"type": "library",
+		"bom-ref": "albatross-1@0.1.0",
+		"name": "albatross",
+		"version": "0.1.0",
+		"properties": [
+		  {
+			"name": "uv:workspace:path",
+			"value": "packages/albatross"
+		  }
+		]
+	  },
+	  {
+		"type": "library",
+		"bom-ref": "anyio-2@4.12.1",
+		"name": "anyio",
+		"version": "4.12.1",
+		"purl": "pkg:pypi/anyio@4.12.1"
+	  },
+	  {
+		"type": "library",
+		"bom-ref": "asgiref-3@3.2.10",
+		"name": "asgiref",
+		"version": "3.2.10",
+		"purl": "pkg:pypi/asgiref@3.2.10"
+	  },
+	  {
+		"type": "library",
+		"bom-ref": "bird-feeder-4@1.0.0",
+		"name": "bird-feeder",
+		"version": "1.0.0",
+		"properties": [
+		  {
+			"name": "uv:workspace:path",
+			"value": "packages/bird-feeder"
+		  }
+		]
+	  },
+	  {
+		"type": "library",
+		"bom-ref": "cffi-5@2.0.0",
+		"name": "cffi",
+		"version": "2.0.0",
+		"purl": "pkg:pypi/cffi@2.0.0"
+	  },
+	  {
+		"type": "library",
+		"bom-ref": "cryptography-6@3.3",
+		"name": "cryptography",
+		"version": "3.3",
+		"purl": "pkg:pypi/cryptography@3.3"
+	  },
+	  {
+		"type": "library",
+		"bom-ref": "django-7@3.1",
+		"name": "django",
+		"version": "3.1",
+		"purl": "pkg:pypi/django@3.1"
+	  },
+	  {
+		"type": "library",
+		"bom-ref": "idna-8@3.6",
+		"name": "idna",
+		"version": "3.6",
+		"purl": "pkg:pypi/idna@3.6"
+	  },
+	  {
+		"type": "library",
+		"bom-ref": "iniconfig-9@2.3.0",
+		"name": "iniconfig",
+		"version": "2.3.0",
+		"purl": "pkg:pypi/iniconfig@2.3.0"
+	  },
+	  {
+		"type": "library",
+		"bom-ref": "jinja2-10@2.11.2",
+		"name": "jinja2",
+		"version": "2.11.2",
+		"purl": "pkg:pypi/jinja2@2.11.2"
+	  },
+	  {
+		"type": "library",
+		"bom-ref": "markupsafe-11@3.0.3",
+		"name": "markupsafe",
+		"version": "3.0.3",
+		"purl": "pkg:pypi/markupsafe@3.0.3"
+	  },
+	  {
+		"type": "library",
+		"bom-ref": "pillow-12@8.1.0",
+		"name": "pillow",
+		"version": "8.1.0",
+		"purl": "pkg:pypi/pillow@8.1.0"
+	  },
+	  {
+		"type": "library",
+		"bom-ref": "pycparser-13@3.0",
+		"name": "pycparser",
+		"version": "3.0",
+		"purl": "pkg:pypi/pycparser@3.0",
+		"properties": [
+		  {
+			"name": "uv:package:marker",
+			"value": "implementation_name != 'PyPy'"
+		  }
+		]
+	  },
+	  {
+		"type": "library",
+		"bom-ref": "pytz-14@2025.2",
+		"name": "pytz",
+		"version": "2025.2",
+		"purl": "pkg:pypi/pytz@2025.2"
+	  },
+	  {
+		"type": "library",
+		"bom-ref": "pyyaml-15@5.3",
+		"name": "pyyaml",
+		"version": "5.3",
+		"purl": "pkg:pypi/pyyaml@5.3"
+	  },
+	  {
+		"type": "library",
+		"bom-ref": "seeds-16@1.0.0",
+		"name": "seeds",
+		"version": "1.0.0",
+		"properties": [
+		  {
+			"name": "uv:workspace:path",
+			"value": "packages/seeds"
+		  }
+		]
+	  },
+	  {
+		"type": "library",
+		"bom-ref": "six-17@1.17.0",
+		"name": "six",
+		"version": "1.17.0",
+		"purl": "pkg:pypi/six@1.17.0"
+	  },
+	  {
+		"type": "library",
+		"bom-ref": "sqlparse-18@0.5.5",
+		"name": "sqlparse",
+		"version": "0.5.5",
+		"purl": "pkg:pypi/sqlparse@0.5.5"
+	  },
+	  {
+		"type": "library",
+		"bom-ref": "typing-extensions-19@4.15.0",
+		"name": "typing-extensions",
+		"version": "4.15.0",
+		"purl": "pkg:pypi/typing-extensions@4.15.0",
+		"properties": [
+		  {
+			"name": "uv:package:marker",
+			"value": "python_full_version < '3.13'"
+		  }
+		]
+	  },
+	  {
+		"type": "library",
+		"bom-ref": "urllib3-20@1.24.3",
+		"name": "urllib3",
+		"version": "1.24.3",
+		"purl": "pkg:pypi/urllib3@1.24.3"
+	  }
+	],
+	"dependencies": [
+	  {
+		"ref": "albatross-1@0.1.0",
+		"dependsOn": [
+		  "bird-feeder-4@1.0.0",
+		  "iniconfig-9@2.3.0",
+		  "jinja2-10@2.11.2",
+		  "urllib3-20@1.24.3"
+		]
+	  },
+	  {
+		"ref": "anyio-2@4.12.1",
+		"dependsOn": [
+		  "idna-8@3.6",
+		  "typing-extensions-19@4.15.0"
+		]
+	  },
+	  {
+		"ref": "asgiref-3@3.2.10",
+		"dependsOn": []
+	  },
+	  {
+		"ref": "bird-feeder-4@1.0.0",
+		"dependsOn": [
+		  "anyio-2@4.12.1",
+		  "pillow-12@8.1.0",
+		  "pyyaml-15@5.3",
+		  "seeds-16@1.0.0"
+		]
+	  },
+	  {
+		"ref": "cffi-5@2.0.0",
+		"dependsOn": [
+		  "pycparser-13@3.0"
+		]
+	  },
+	  {
+		"ref": "cryptography-6@3.3",
+		"dependsOn": [
+		  "cffi-5@2.0.0",
+		  "six-17@1.17.0"
+		]
+	  },
+	  {
+		"ref": "django-7@3.1",
+		"dependsOn": [
+		  "asgiref-3@3.2.10",
+		  "pytz-14@2025.2",
+		  "sqlparse-18@0.5.5"
+		]
+	  },
+	  {
+		"ref": "idna-8@3.6",
+		"dependsOn": []
+	  },
+	  {
+		"ref": "iniconfig-9@2.3.0",
+		"dependsOn": []
+	  },
+	  {
+		"ref": "jinja2-10@2.11.2",
+		"dependsOn": [
+		  "markupsafe-11@3.0.3"
+		]
+	  },
+	  {
+		"ref": "markupsafe-11@3.0.3",
+		"dependsOn": []
+	  },
+	  {
+		"ref": "pillow-12@8.1.0",
+		"dependsOn": []
+	  },
+	  {
+		"ref": "pycparser-13@3.0",
+		"dependsOn": []
+	  },
+	  {
+		"ref": "pytz-14@2025.2",
+		"dependsOn": []
+	  },
+	  {
+		"ref": "pyyaml-15@5.3",
+		"dependsOn": []
+	  },
+	  {
+		"ref": "seeds-16@1.0.0",
+		"dependsOn": [
+		  "cryptography-6@3.3",
+		  "django-7@3.1",
+		  "idna-8@3.6"
+		]
+	  },
+	  {
+		"ref": "six-17@1.17.0",
+		"dependsOn": []
+	  },
+	  {
+		"ref": "sqlparse-18@0.5.5",
+		"dependsOn": []
+	  },
+	  {
+		"ref": "typing-extensions-19@4.15.0",
+		"dependsOn": []
+	  },
+	  {
+		"ref": "urllib3-20@1.24.3",
+		"dependsOn": []
+	  },
+	  {
+		"ref": "uv-workspace-21",
+		"dependsOn": [
+		  "albatross-1@0.1.0",
+		  "bird-feeder-4@1.0.0",
+		  "seeds-16@1.0.0"
+		]
+	  }
+	]
+  }

--- a/pkg/ecosystems/python/uv/testdata/workspace_sbom.json
+++ b/pkg/ecosystems/python/uv/testdata/workspace_sbom.json
@@ -1,0 +1,314 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5",
+  "version": 1,
+  "serialNumber": "urn:uuid:6cbf1267-2415-4e61-a384-cfd8b29098bb",
+  "metadata": {
+    "timestamp": "2026-06-03T06:38:46.328785000Z",
+    "tools": [
+      {
+        "vendor": "Astral Software Inc.",
+        "name": "uv",
+        "version": "0.10.9"
+      }
+    ],
+    "component": {
+      "type": "library",
+      "bom-ref": "workspace-project-21",
+      "name": "workspace-project",
+      "properties": [
+        {
+          "name": "uv:package:is_synthetic_root",
+          "value": "true"
+        }
+      ]
+    }
+  },
+  "components": [
+    {
+      "type": "library",
+      "bom-ref": "asgiref-2@3.2.10",
+      "name": "asgiref",
+      "version": "3.2.10",
+      "purl": "pkg:pypi/asgiref@3.2.10"
+    },
+    {
+      "type": "library",
+      "bom-ref": "cffi-3@2.0.0",
+      "name": "cffi",
+      "version": "2.0.0",
+      "purl": "pkg:pypi/cffi@2.0.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "cryptography-4@3.3",
+      "name": "cryptography",
+      "version": "3.3",
+      "purl": "pkg:pypi/cryptography@3.3"
+    },
+    {
+      "type": "library",
+      "bom-ref": "django-5@3.1",
+      "name": "django",
+      "version": "3.1",
+      "purl": "pkg:pypi/django@3.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "jinja2-6@2.11.2",
+      "name": "jinja2",
+      "version": "2.11.2",
+      "purl": "pkg:pypi/jinja2@2.11.2"
+    },
+    {
+      "type": "library",
+      "bom-ref": "json5-7@0.13.0",
+      "name": "json5",
+      "version": "0.13.0",
+      "purl": "pkg:pypi/json5@0.13.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "markupsafe-8@3.0.3",
+      "name": "markupsafe",
+      "version": "3.0.3",
+      "purl": "pkg:pypi/markupsafe@3.0.3"
+    },
+    {
+      "type": "library",
+      "bom-ref": "package-a-9@0.1.0",
+      "name": "package-a",
+      "version": "0.1.0",
+      "properties": [
+        {
+          "name": "uv:workspace:path",
+          "value": "packages/package_a"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "package-b-10@0.1.0",
+      "name": "package-b",
+      "version": "0.1.0",
+      "properties": [
+        {
+          "name": "uv:workspace:path",
+          "value": "packages/package_b"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "package-c-11@0.1.0",
+      "name": "package-c",
+      "version": "0.1.0",
+      "properties": [
+        {
+          "name": "uv:workspace:path",
+          "value": "packages/package_c"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pillow-12@8.1.0",
+      "name": "pillow",
+      "version": "8.1.0",
+      "purl": "pkg:pypi/pillow@8.1.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pycparser-13@3.0",
+      "name": "pycparser",
+      "version": "3.0",
+      "purl": "pkg:pypi/pycparser@3.0",
+      "properties": [
+        {
+          "name": "uv:package:marker",
+          "value": "implementation_name != 'PyPy'"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "python-dotenv-14@1.2.1",
+      "name": "python-dotenv",
+      "version": "1.2.1",
+      "purl": "pkg:pypi/python-dotenv@1.2.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pytz-15@2025.2",
+      "name": "pytz",
+      "version": "2025.2",
+      "purl": "pkg:pypi/pytz@2025.2"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pyyaml-16@5.3",
+      "name": "pyyaml",
+      "version": "5.3",
+      "purl": "pkg:pypi/pyyaml@5.3"
+    },
+    {
+      "type": "library",
+      "bom-ref": "ruff-17@0.14.14",
+      "name": "ruff",
+      "version": "0.14.14",
+      "purl": "pkg:pypi/ruff@0.14.14"
+    },
+    {
+      "type": "library",
+      "bom-ref": "six-18@1.17.0",
+      "name": "six",
+      "version": "1.17.0",
+      "purl": "pkg:pypi/six@1.17.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "sqlparse-19@0.5.5",
+      "name": "sqlparse",
+      "version": "0.5.5",
+      "purl": "pkg:pypi/sqlparse@0.5.5"
+    },
+    {
+      "type": "library",
+      "bom-ref": "urllib3-20@1.24.3",
+      "name": "urllib3",
+      "version": "1.24.3",
+      "purl": "pkg:pypi/urllib3@1.24.3"
+    },
+    {
+      "type": "library",
+      "bom-ref": "workspace-project-1@0.1.0",
+      "name": "workspace-project",
+      "version": "0.1.0",
+      "properties": [
+        {
+          "name": "uv:package:is_project_root",
+          "value": "true"
+        }
+      ]
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "asgiref-2@3.2.10",
+      "dependsOn": []
+    },
+    {
+      "ref": "cffi-3@2.0.0",
+      "dependsOn": [
+        "pycparser-13@3.0"
+      ]
+    },
+    {
+      "ref": "cryptography-4@3.3",
+      "dependsOn": [
+        "cffi-3@2.0.0",
+        "six-18@1.17.0"
+      ]
+    },
+    {
+      "ref": "django-5@3.1",
+      "dependsOn": [
+        "asgiref-2@3.2.10",
+        "pytz-15@2025.2",
+        "sqlparse-19@0.5.5"
+      ]
+    },
+    {
+      "ref": "jinja2-6@2.11.2",
+      "dependsOn": [
+        "markupsafe-8@3.0.3"
+      ]
+    },
+    {
+      "ref": "json5-7@0.13.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "markupsafe-8@3.0.3",
+      "dependsOn": []
+    },
+    {
+      "ref": "package-a-9@0.1.0",
+      "dependsOn": [
+        "package-b-10@0.1.0",
+        "urllib3-20@1.24.3"
+      ]
+    },
+    {
+      "ref": "package-b-10@0.1.0",
+      "dependsOn": [
+        "json5-7@0.13.0",
+        "pillow-12@8.1.0",
+        "pyyaml-16@5.3"
+      ]
+    },
+    {
+      "ref": "package-c-11@0.1.0",
+      "dependsOn": [
+        "cryptography-4@3.3",
+        "django-5@3.1",
+        "python-dotenv-14@1.2.1"
+      ]
+    },
+    {
+      "ref": "pillow-12@8.1.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pycparser-13@3.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "python-dotenv-14@1.2.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pytz-15@2025.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pyyaml-16@5.3",
+      "dependsOn": []
+    },
+    {
+      "ref": "ruff-17@0.14.14",
+      "dependsOn": []
+    },
+    {
+      "ref": "six-18@1.17.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "sqlparse-19@0.5.5",
+      "dependsOn": []
+    },
+    {
+      "ref": "urllib3-20@1.24.3",
+      "dependsOn": []
+    },
+    {
+      "ref": "workspace-project-1@0.1.0",
+      "dependsOn": [
+        "jinja2-6@2.11.2",
+        "json5-7@0.13.0",
+        "package-a-9@0.1.0",
+        "package-b-10@0.1.0",
+        "ruff-17@0.14.14"
+      ]
+    },
+    {
+      "ref": "workspace-project-21",
+      "dependsOn": [
+        "package-a-9@0.1.0",
+        "package-b-10@0.1.0",
+        "package-c-11@0.1.0",
+        "workspace-project-1@0.1.0"
+      ]
+    }
+  ]
+}

--- a/pkg/ecosystems/python/uv/uvclient.go
+++ b/pkg/ecosystems/python/uv/uvclient.go
@@ -64,7 +64,7 @@ func (c client) ExportSBOM(inputDir string, opts *scaecosystems.SCAPluginOptions
 	} else {
 		args = append(args, "--locked")
 	}
-	if opts.Global.AllProjects || opts.Global.ForceIncludeWorkspacePackages {
+	if shouldUseAllPackages(opts) {
 		args = append(args, "--all-packages")
 	}
 	if !opts.Global.IncludeDev {
@@ -83,6 +83,13 @@ func (c client) ExportSBOM(inputDir string, opts *scaecosystems.SCAPluginOptions
 	}
 
 	return output, nil
+}
+
+// shouldUseAllPackages determines whether the uv plugin should use the --all-packages flag.
+func shouldUseAllPackages(opts *scaecosystems.SCAPluginOptions) bool {
+	return opts.Global.AllProjects ||
+		opts.Global.ForceIncludeWorkspacePackages ||
+		(opts.Global.WorkspacePackage != nil && *opts.Global.WorkspacePackage != "")
 }
 
 // Minimal representation of a CycloneDX SBOM.

--- a/pkg/ecosystems/python/uv/uvclient_test.go
+++ b/pkg/ecosystems/python/uv/uvclient_test.go
@@ -125,6 +125,43 @@ func TestUVClient_ExportSBOM_UvWorkspacePackages(t *testing.T) {
 	assert.Equal(t, 1, callCount)
 }
 
+func TestUVClient_ExportSBOM_WorkspacePackage(t *testing.T) {
+	validSBOM := `{
+		"bomFormat": "CycloneDX",
+		"specVersion": "1.5",
+		"metadata": {
+			"component": {
+				"type": "library",
+				"bom-ref": "package-b-1@0.1.0",
+				"name": "package-b",
+				"version": "0.1.0",
+				"properties": [
+					{"name": "uv:package:is_project_root", "value": "true"}
+				]
+			}
+		}
+	}`
+
+	callCount := 0
+	mockExecutor := &mockCmdExecutor{
+		executeFunc: func(binary, dir string, args ...string) ([]byte, error) {
+			callCount++
+			assert.Equal(t, "/path/to/uv", binary)
+			assert.Equal(t, "/test/dir", dir)
+			assert.Equal(t, []string{"export", "--format", "cyclonedx1.5", "--preview", "--locked", "--all-packages", "--no-dev"}, args)
+			return []byte(validSBOM), nil
+		},
+	}
+
+	client := NewClientWithExecutor("/path/to/uv", mockExecutor)
+	result, err := client.ExportSBOM("/test/dir", ecosystems.NewPluginOptions().WithWorkspacePackage("package-b"))
+
+	assert.NoError(t, err)
+	require.NotNil(t, result)
+	assert.JSONEq(t, validSBOM, string(result))
+	assert.Equal(t, 1, callCount)
+}
+
 func TestUVClient_ExportSBOM_DevTrue_OmitsNoDevFlag(t *testing.T) {
 	validSBOM := `{"metadata": {"component": {"name": "test", "version": "1.0.0"}}}`
 


### PR DESCRIPTION
### What this does

Adds support for fetching a single dependency graph for a specific uv workspace member project. Adds the argument`--workspace-package` to specify the workspace package to fetch.

This is part of the work to support uv workspace member project scanning in SCM.

UNIFY-1412
UNIFY-1422