### PR TITLE
chore: clean up gradle flag for consistency [CMPA-588]

### DIFF
--- a/pkg/ecosystems/orchestrator/flags.go
+++ b/pkg/ecosystems/orchestrator/flags.go
@@ -11,7 +11,7 @@ var FlagUnifiedTestAPIOsCLI = flag{
 }
 
 var FlagNewGradleResolver = flag{
-	Key:   "internal_new_gradle_resolver",
+	Key:   "internal-new-gradle-resolver",
 	Value: "internal-new-gradle-resolver",
 }
 


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [X] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Cleans up the key for the gradle flag to keep consistent with bun and bazel flags
