### PR TITLE
SPIKE: feat(swiftpm): add resolver via swift package show-dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,10 @@ test-python-integration:
 test-gradle-integration:
 	$(GOTEST) -v -tags="integration,gradle" -timeout=15m ./pkg/ecosystems/gradle/ -coverprofile cp.out
 
+test-swiftpm-integration:
+	$(GOTEST) -v -tags="integration,swiftpm" -timeout=10m ./pkg/ecosystems/swift/swiftpm/ -coverprofile cp.out
+
 update-gradle-fixtures:
 	UPDATE_FIXTURES=1 $(GOTEST) -v -tags="integration,gradle" -timeout=15m ./pkg/ecosystems/gradle/
 
-.PHONY: install-req fmt test test-bazel-jvm-integration test-bazel-go-integration test-python-integration test-gradle-integration update-gradle-fixtures lint tidy imports install-golangci-lint
+.PHONY: install-req fmt test test-bazel-jvm-integration test-bazel-go-integration test-python-integration test-gradle-integration test-swiftpm-integration update-gradle-fixtures lint tidy imports install-golangci-lint

--- a/pkg/ecosystems/swift/swiftpm/depgraph.go
+++ b/pkg/ecosystems/swift/swiftpm/depgraph.go
@@ -1,0 +1,120 @@
+package swiftpm
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	godepgraph "github.com/snyk/dep-graph/go/pkg/depgraph"
+)
+
+const pkgManager = "swift"
+
+// registryIdentityRe matches the Swift Package Registry "scope.package-name"
+// identity format (e.g. "apple.swift-argument-parser"). When swift reports a
+// dep via its registry identity rather than a URL, we map it to the
+// canonical github.com/scope/name form for vuln-lookup parity with the
+// legacy plugin.
+var registryIdentityRe = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9-]*\.[a-zA-Z0-9][a-zA-Z0-9-]*$`)
+
+// packageNameFromURL normalises a swift dep's URL/identity into the canonical
+// package name used as the dep-graph node name.
+//
+// Mirrors snyk-swiftpm-plugin/lib/compute-depgraph.ts:packageNameFromUrl:
+//
+//   - "https://github.com/apple/swift-nio.git" → "github.com/apple/swift-nio"
+//   - "http://example.com/foo.git"             → "example.com/foo"
+//   - "apple.swift-argument-parser"            → "github.com/apple/swift-argument-parser"
+//   - anything else                            → returned unchanged (path: deps, etc.)
+func packageNameFromURL(url string) string {
+	switch {
+	case strings.HasPrefix(url, "https://"):
+		return strings.TrimSuffix(strings.TrimPrefix(url, "https://"), ".git")
+	case strings.HasPrefix(url, "http://"):
+		return strings.TrimSuffix(strings.TrimPrefix(url, "http://"), ".git")
+	case registryIdentityRe.MatchString(url):
+		dot := strings.Index(url, ".")
+		return "github.com/" + url[:dot] + "/" + url[dot+1:]
+	default:
+		return url
+	}
+}
+
+// buildDepGraph converts a parsed depTreeNode tree into a @snyk/dep-graph.
+//
+// Identity contract (mirrors legacy snyk-swiftpm-plugin):
+//   - rootPkg.name comes from Package.swift's Package(name:); falls back to
+//     the JSON root's `name` field. Identity follows the same precedence.
+//   - rootPkg.version uses the swift-reported version. swift emits
+//     "unspecified" for the root and for path/branch deps — we preserve
+//     that string for parity. A truly empty version is replaced with
+//     defaultVersion to keep dep-graph builder happy.
+//   - Non-root nodes use packageNameFromURL(node.url) + "@" + node.version.
+func buildDepGraph(rootName string, root *depTreeNode) (*godepgraph.DepGraph, error) {
+	if rootName == "" {
+		rootName = root.Name
+	}
+
+	rootVersion := root.Version
+	if rootVersion == "" {
+		rootVersion = defaultVersion
+	}
+
+	builder, err := godepgraph.NewBuilder(
+		&godepgraph.PkgManager{Name: pkgManager},
+		&godepgraph.PkgInfo{Name: rootName, Version: rootVersion},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("creating dep graph builder: %w", err)
+	}
+
+	rootNodeID := builder.GetRootNode().NodeID
+	visited := make(map[string]bool)
+
+	for _, child := range root.Dependencies {
+		if err := addNode(builder, rootNodeID, child, visited); err != nil {
+			return nil, err
+		}
+	}
+
+	return builder.Build(), nil
+}
+
+// addNode adds node to the dep graph (if not already visited) and connects
+// it to parentID. The recursion is bounded by visited; cycles in the swift
+// tree (possible via path: / branch: deps) terminate cleanly.
+func addNode(
+	builder *godepgraph.Builder,
+	parentID string,
+	node *depTreeNode,
+	visited map[string]bool,
+) error {
+	name := packageNameFromURL(node.URL)
+	version := node.Version
+	if version == "" {
+		version = defaultVersion
+	}
+
+	nodeID := name + "@" + version
+
+	connect := func() error {
+		if err := builder.ConnectNodes(parentID, nodeID); err != nil {
+			return fmt.Errorf("connecting %s → %s: %w", parentID, nodeID, err)
+		}
+		return nil
+	}
+
+	if !visited[nodeID] {
+		visited[nodeID] = true
+
+		builder.AddNode(nodeID, &godepgraph.PkgInfo{Name: name, Version: version})
+
+		for _, child := range node.Dependencies {
+			if err := addNode(builder, nodeID, child, visited); err != nil {
+				return err
+			}
+		}
+	}
+
+	return connect()
+}

--- a/pkg/ecosystems/swift/swiftpm/depgraph_test.go
+++ b/pkg/ecosystems/swift/swiftpm/depgraph_test.go
@@ -1,0 +1,243 @@
+package swiftpm
+
+import (
+	"testing"
+
+	godepgraph "github.com/snyk/dep-graph/go/pkg/depgraph"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPackageNameFromURL(t *testing.T) {
+	tests := []struct {
+		url  string
+		want string
+	}{
+		{"https://github.com/apple/swift-nio.git", "github.com/apple/swift-nio"},
+		{"https://github.com/apple/swift-nio", "github.com/apple/swift-nio"},
+		{"https://gitlab.com/group/proj.git", "gitlab.com/group/proj"},
+		{"http://example.com/foo.git", "example.com/foo"},
+		{"apple.swift-argument-parser", "github.com/apple/swift-argument-parser"},
+		{"apple.foo-bar", "github.com/apple/foo-bar"},
+		// Path deps and other unknown shapes pass through unchanged.
+		{"/local/path/to/dep", "/local/path/to/dep"},
+		{"some-bare-name", "some-bare-name"},
+		// Identity format requires exactly one dot in scope.name shape — these don't match.
+		{"too.many.dots", "too.many.dots"},
+		{".leading-dot", ".leading-dot"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.url, func(t *testing.T) {
+			assert.Equal(t, tt.want, packageNameFromURL(tt.url))
+		})
+	}
+}
+
+func TestBuildDepGraph_Simple(t *testing.T) {
+	// root → grpc-swift@1.16.0 → swift-nio@2.54.0
+	root := &depTreeNode{
+		Name:    "my-app",
+		URL:     "/local/path/my-app",
+		Version: "unspecified",
+		Dependencies: []*depTreeNode{
+			{
+				Name:    "grpc-swift",
+				URL:     "https://github.com/grpc/grpc-swift.git",
+				Version: "1.16.0",
+				Dependencies: []*depTreeNode{
+					{
+						Name:    "swift-nio",
+						URL:     "https://github.com/apple/swift-nio.git",
+						Version: "2.54.0",
+					},
+				},
+			},
+		},
+	}
+
+	dg, err := buildDepGraph("my-app", root)
+	require.NoError(t, err)
+	require.NotNil(t, dg)
+
+	assert.Equal(t, "swift", dg.PkgManager.Name)
+	assert.Equal(t, "my-app", dg.GetRootPkg().Info.Name)
+	assert.Equal(t, "unspecified", dg.GetRootPkg().Info.Version)
+
+	grpcID := "github.com/grpc/grpc-swift@1.16.0"
+	nioID := "github.com/apple/swift-nio@2.54.0"
+
+	assert.Contains(t, nodeDeps(dg, "root-node"), grpcID, "root → grpc-swift")
+	assert.Contains(t, nodeDeps(dg, grpcID), nioID, "grpc → nio")
+	assert.Empty(t, nodeDeps(dg, nioID), "nio has no deps")
+}
+
+func TestBuildDepGraph_RootNameFallsBackToTreeName(t *testing.T) {
+	// When rootName is empty, the JSON `name` field is used.
+	root := &depTreeNode{
+		Name:    "from-json",
+		URL:     "/local",
+		Version: "unspecified",
+	}
+
+	dg, err := buildDepGraph("", root)
+	require.NoError(t, err)
+	assert.Equal(t, "from-json", dg.GetRootPkg().Info.Name)
+}
+
+func TestBuildDepGraph_EmptyVersionDefaulted(t *testing.T) {
+	// swift normally emits "unspecified" for unknown versions; defend against
+	// a truly empty string by replacing it with defaultVersion so the
+	// dep-graph builder doesn't reject the node.
+	root := &depTreeNode{
+		Name:    "root",
+		URL:     "/local",
+		Version: "",
+		Dependencies: []*depTreeNode{
+			{
+				Name:    "missing-version-dep",
+				URL:     "https://example.com/foo",
+				Version: "",
+			},
+		},
+	}
+
+	dg, err := buildDepGraph("root", root)
+	require.NoError(t, err)
+	assert.Equal(t, defaultVersion, dg.GetRootPkg().Info.Version)
+	assert.Contains(t, nodeDeps(dg, "root-node"), "example.com/foo@"+defaultVersion)
+}
+
+func TestBuildDepGraph_PreservesUnspecified(t *testing.T) {
+	// "unspecified" comes from swift verbatim and is the conventional
+	// version string for path: / branch: deps; preserve it for parity with
+	// the legacy plugin.
+	root := &depTreeNode{
+		Name:    "root",
+		URL:     "/local",
+		Version: "unspecified",
+		Dependencies: []*depTreeNode{
+			{
+				Name:    "local-dep",
+				URL:     "/some/local/path",
+				Version: "unspecified",
+			},
+		},
+	}
+
+	dg, err := buildDepGraph("root", root)
+	require.NoError(t, err)
+	assert.Equal(t, "unspecified", dg.GetRootPkg().Info.Version)
+	assert.Contains(t, nodeDeps(dg, "root-node"), "/some/local/path@unspecified")
+}
+
+func TestBuildDepGraph_Diamond(t *testing.T) {
+	// root → a@1, b@1; both depend on shared@1
+	shared := &depTreeNode{
+		Name:    "shared",
+		URL:     "https://github.com/x/shared.git",
+		Version: "1.0.0",
+	}
+	root := &depTreeNode{
+		Name:    "root",
+		URL:     "/local",
+		Version: "unspecified",
+		Dependencies: []*depTreeNode{
+			{
+				Name:         "a",
+				URL:          "https://github.com/x/a.git",
+				Version:      "1.0.0",
+				Dependencies: []*depTreeNode{shared},
+			},
+			{
+				Name:         "b",
+				URL:          "https://github.com/x/b.git",
+				Version:      "1.0.0",
+				Dependencies: []*depTreeNode{shared},
+			},
+		},
+	}
+
+	dg, err := buildDepGraph("root", root)
+	require.NoError(t, err)
+
+	sharedID := "github.com/x/shared@1.0.0"
+	assert.Contains(t, nodeDeps(dg, "github.com/x/a@1.0.0"), sharedID)
+	assert.Contains(t, nodeDeps(dg, "github.com/x/b@1.0.0"), sharedID)
+
+	// Shared node should appear exactly once in the pkg list.
+	count := 0
+	for _, p := range dg.Pkgs {
+		if p.ID == sharedID {
+			count++
+		}
+	}
+	assert.Equal(t, 1, count, "shared dep deduplicated")
+}
+
+func TestBuildDepGraph_CycleTerminates(t *testing.T) {
+	// a → b → a cycle: visited guard must break recursion.
+	a := &depTreeNode{
+		Name:    "a",
+		URL:     "https://github.com/x/a.git",
+		Version: "1.0.0",
+	}
+	b := &depTreeNode{
+		Name:         "b",
+		URL:          "https://github.com/x/b.git",
+		Version:      "1.0.0",
+		Dependencies: []*depTreeNode{a},
+	}
+	a.Dependencies = []*depTreeNode{b}
+
+	root := &depTreeNode{
+		Name:         "root",
+		URL:          "/local",
+		Version:      "unspecified",
+		Dependencies: []*depTreeNode{a},
+	}
+
+	dg, err := buildDepGraph("root", root)
+	require.NoError(t, err)
+
+	aID := "github.com/x/a@1.0.0"
+	bID := "github.com/x/b@1.0.0"
+	assert.Contains(t, nodeDeps(dg, "root-node"), aID)
+	assert.Contains(t, nodeDeps(dg, aID), bID)
+	assert.Contains(t, nodeDeps(dg, bID), aID, "cycle edge present, recursion bounded")
+}
+
+func TestBuildDepGraph_RegistryIdentityNormalised(t *testing.T) {
+	// Registry identities like "apple.swift-argument-parser" map to
+	// github.com/<scope>/<name> for parity with the legacy plugin.
+	root := &depTreeNode{
+		Name:    "root",
+		URL:     "/local",
+		Version: "unspecified",
+		Dependencies: []*depTreeNode{
+			{
+				Name:    "swift-argument-parser",
+				URL:     "apple.swift-argument-parser",
+				Version: "1.2.0",
+			},
+		},
+	}
+
+	dg, err := buildDepGraph("root", root)
+	require.NoError(t, err)
+	assert.Contains(t, nodeDeps(dg, "root-node"), "github.com/apple/swift-argument-parser@1.2.0")
+}
+
+// nodeDeps returns the NodeIDs of nodeID's direct dependencies in dg.
+func nodeDeps(dg *godepgraph.DepGraph, nodeID string) []string {
+	for _, n := range dg.Graph.Nodes {
+		if n.NodeID == nodeID {
+			ids := make([]string, len(n.Deps))
+			for i, d := range n.Deps {
+				ids[i] = d.NodeID
+			}
+			return ids
+		}
+	}
+	return nil
+}

--- a/pkg/ecosystems/swift/swiftpm/executor.go
+++ b/pkg/ecosystems/swift/swiftpm/executor.go
@@ -1,0 +1,146 @@
+package swiftpm
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os/exec"
+	"regexp"
+	"strings"
+
+	"golang.org/x/mod/semver"
+)
+
+// errSwiftNotFound is returned when the swift binary is not in PATH.
+var errSwiftNotFound = errors.New("swift binary not found in PATH")
+
+// errSwiftVersionTooLow is returned when the installed swift version is below
+// the minimum required for `swift package show-dependencies --format json`.
+var errSwiftVersionTooLow = errors.New("swift version below minimum required " + minSwiftVersion)
+
+// minSwiftVersion is the minimum swift toolchain version this plugin
+// supports.
+//
+// `swift package show-dependencies --format json` exists in 5.6+ and is the
+// command we delegate to. Earlier toolchains only support `text` and `dot`
+// output formats, which would require us to ship our own parser.
+const minSwiftVersion = "v5.6.0"
+
+// swiftVersionRe extracts the numeric MAJOR.MINOR.PATCH triplet from
+// `swift --version` output. The full string is multiline and starts with
+// noise like "swift-driver version: 1.84.1 Apple Swift version 5.9.2 ..." —
+// the regex anchors on "Swift version".
+var swiftVersionRe = regexp.MustCompile(`Swift version (\d+)\.(\d+)(?:\.(\d+))?`)
+
+// swiftRunner runs `swift package show-dependencies` on behalf of the plugin.
+type swiftRunner interface {
+	Run(ctx context.Context, dir string, extraArgs []string) (io.ReadCloser, error)
+}
+
+// swiftCmdExecutor is the production implementation that shells out to swift.
+type swiftCmdExecutor struct{}
+
+var _ swiftRunner = (*swiftCmdExecutor)(nil)
+
+// Run invokes `swift package --package-path <dir> show-dependencies --format json`
+// and returns a reader over its stdout JSON.
+//
+// stdout is streamed via io.Pipe so large trees don't buffer in RAM. stderr
+// is captured to a buffer and folded into the error message on failure so
+// the user can see what swift said (it logs fetch/resolve progress lines to
+// stderr even on success).
+//
+// The caller must close the returned ReadCloser to release the subprocess.
+//
+// extraArgs are appended after `package` but before `--package-path`,
+// matching the legacy plugin's `--args` passthrough position. The legacy
+// plugin only ever forwarded arbitrary args here; no `--dev`, `--exclude`
+// or other typed flags exist for swift.
+func (e *swiftCmdExecutor) Run(ctx context.Context, dir string, extraArgs []string) (io.ReadCloser, error) {
+	resolved, err := exec.LookPath("swift")
+	if err != nil {
+		return nil, errSwiftNotFound //nolint:wrapcheck // sentinel error, intentionally returned unwrapped
+	}
+
+	ver, err := detectSwiftVersion(ctx, resolved)
+	if err != nil {
+		return nil, err
+	}
+
+	if semver.Compare(ver, minSwiftVersion) < 0 {
+		return nil, errSwiftVersionTooLow //nolint:wrapcheck // sentinel error, intentionally returned unwrapped
+	}
+
+	return runSwiftShowDeps(ctx, resolved, dir, extraArgs)
+}
+
+// runSwiftShowDeps spawns swift and pipes stdout back to the caller.
+func runSwiftShowDeps(ctx context.Context, binary, dir string, extraArgs []string) (io.ReadCloser, error) {
+	args := []string{"package"}
+	args = append(args, extraArgs...)
+	args = append(args,
+		"--package-path", dir,
+		"show-dependencies",
+		"--format", "json",
+	)
+
+	cmd := exec.CommandContext(ctx, binary, args...)
+	// We intentionally do NOT set cmd.Dir to dir; --package-path drives swift's
+	// project root selection, and leaving cwd untouched avoids any subtle
+	// behaviour where swift writes ancillary files into the test cwd.
+
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	pr, pw := io.Pipe()
+	cmd.Stdout = pw
+
+	if err := cmd.Start(); err != nil {
+		pr.Close()
+		pw.Close()
+		return nil, fmt.Errorf("starting swift package: %w", err)
+	}
+
+	go func() {
+		waitErr := cmd.Wait()
+		if waitErr != nil {
+			pw.CloseWithError(fmt.Errorf("swift package show-dependencies failed: %w\nstderr: %s", waitErr, stderr.String()))
+		} else {
+			pw.Close()
+		}
+	}()
+
+	return pr, nil
+}
+
+// detectSwiftVersion runs `swift --version` and normalises the result to a Go
+// semver string (e.g. "v5.9.2"). Returns an error if swift cannot be invoked
+// or its version string is unrecognizable.
+func detectSwiftVersion(ctx context.Context, binary string) (string, error) {
+	out, err := exec.CommandContext(ctx, binary, "--version").Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to get swift version: %w", err)
+	}
+
+	return parseSwiftVersion(strings.TrimSpace(string(out)))
+}
+
+// parseSwiftVersion extracts the MAJOR.MINOR.PATCH triplet from raw
+// `swift --version` output and returns it as a canonical Go semver string
+// (e.g. "v5.9.2"). The patch component is optional — older toolchains omit
+// it (e.g. "Apple Swift version 5.6") in which case we default it to "0".
+func parseSwiftVersion(raw string) (string, error) {
+	m := swiftVersionRe.FindStringSubmatch(raw)
+	if m == nil {
+		return "", fmt.Errorf("could not parse swift version from %q", raw)
+	}
+
+	patch := m[3]
+	if patch == "" {
+		patch = "0"
+	}
+
+	return "v" + m[1] + "." + m[2] + "." + patch, nil
+}

--- a/pkg/ecosystems/swift/swiftpm/executor_test.go
+++ b/pkg/ecosystems/swift/swiftpm/executor_test.go
@@ -1,0 +1,70 @@
+package swiftpm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseSwiftVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     string
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "apple swift full",
+			raw:  "swift-driver version: 1.84.1 Apple Swift version 5.9.2 (swiftlang-5.9.2.2.56 clang-1500.1.0.2.5)\nTarget: arm64-apple-macosx14.0",
+			want: "v5.9.2",
+		},
+		{
+			name: "apple swift modern",
+			raw:  "swift-driver version: 1.148.6 Apple Swift version 6.3.2 (swiftlang-6.3.2.1.108 clang-2100.1.1.101)\nTarget: arm64-apple-macosx26.0",
+			want: "v6.3.2",
+		},
+		{
+			name: "linux swift",
+			raw:  "Swift version 5.7.3 (swift-5.7.3-RELEASE)\nTarget: x86_64-unknown-linux-gnu",
+			want: "v5.7.3",
+		},
+		{
+			name: "minimum supported",
+			raw:  "Apple Swift version 5.6",
+			want: "v5.6.0",
+		},
+		{
+			name: "swift 5.10",
+			raw:  "Apple Swift version 5.10.1",
+			want: "v5.10.1",
+		},
+		{
+			name:    "no swift version marker",
+			raw:     "swift-driver version: 1.84.1",
+			wantErr: true,
+		},
+		{
+			name:    "empty string",
+			raw:     "",
+			wantErr: true,
+		},
+		{
+			name:    "completely unparseable",
+			raw:     "not-a-version",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseSwiftVersion(tt.raw)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/ecosystems/swift/swiftpm/manifest.go
+++ b/pkg/ecosystems/swift/swiftpm/manifest.go
@@ -1,0 +1,74 @@
+package swiftpm
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+
+	snykecosystems "github.com/snyk/error-catalog-golang-public/opensource/ecosystems"
+	"github.com/snyk/error-catalog-golang-public/snyk_errors"
+)
+
+const (
+	packageManifestFile = "Package.swift"
+	packageResolvedFile = "Package.resolved"
+	defaultVersion      = "0.0.0"
+)
+
+// packageNameRe extracts the `name:` argument of `Package(...)` from a
+// Package.swift manifest.
+//
+// Swift manifests are executable Swift code, not declarative data; a
+// full-fidelity parse would require shelling out to swift itself. For our
+// purposes — preferring the manifest's declared root name over swift's
+// lower-cased identity — a regex on the well-known `Package(name: "...")`
+// constructor is sufficient. The name argument is conventionally the first
+// argument and is a string literal in every Swift package we've seen.
+//
+// We tolerate optional whitespace and the `name:` label being on its own line
+// (which is the conventional formatting).
+var packageNameRe = regexp.MustCompile(`(?m)Package\s*\(\s*name\s*:\s*"([^"]+)"`)
+
+// packageManifest captures the fields we need from Package.swift.
+type packageManifest struct {
+	Name string
+}
+
+// readPackageManifest parses the Package.swift in dir and returns the
+// declared package name. A missing file yields a typed error so the plugin
+// can surface a friendly message; a parse failure yields the unparseable-
+// manifest error type.
+func readPackageManifest(dir string) (*packageManifest, error) {
+	path := filepath.Join(dir, packageManifestFile)
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, snykecosystems.NewUnprocessableFileError(
+				fmt.Sprintf("%s not found: %v", packageManifestFile, err),
+				snyk_errors.WithCause(err),
+			)
+		}
+		return nil, fmt.Errorf("reading %s: %w", path, err)
+	}
+
+	name := parsePackageName(data)
+	if name == "" {
+		return nil, snykecosystems.NewUnparseableManifestError(
+			fmt.Sprintf("Failed to parse %s: no Package(name:...) declaration found", packageManifestFile),
+		)
+	}
+
+	return &packageManifest{Name: name}, nil
+}
+
+// parsePackageName returns the first `name:` argument of a `Package(...)`
+// call in the manifest, or "" if no such constructor is found.
+func parsePackageName(data []byte) string {
+	m := packageNameRe.FindSubmatch(data)
+	if m == nil {
+		return ""
+	}
+	return string(m[1])
+}

--- a/pkg/ecosystems/swift/swiftpm/manifest_test.go
+++ b/pkg/ecosystems/swift/swiftpm/manifest_test.go
@@ -1,0 +1,88 @@
+package swiftpm
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParsePackageName(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{
+			name: "conventional formatting",
+			src: `// swift-tools-version:5.6
+import PackageDescription
+
+let package = Package(
+    name: "my-app",
+    dependencies: []
+)`,
+			want: "my-app",
+		},
+		{
+			name: "single line",
+			src:  `let package = Package(name: "compact", dependencies: [])`,
+			want: "compact",
+		},
+		{
+			name: "extra whitespace",
+			src:  `let package = Package(   name   :   "spacey"   )`,
+			want: "spacey",
+		},
+		{
+			name: "name with hyphens and underscores",
+			src:  `Package(name: "my-cool_pkg-1")`,
+			want: "my-cool_pkg-1",
+		},
+		{
+			name: "no Package() call",
+			src:  `// just a comment`,
+			want: "",
+		},
+		{
+			name: "Package without name argument",
+			src:  `let package = Package(defaultLocalization: "en")`,
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, parsePackageName([]byte(tt.src)))
+		})
+	}
+}
+
+func TestReadPackageManifest_Missing(t *testing.T) {
+	_, err := readPackageManifest(t.TempDir())
+	require.Error(t, err)
+	// Wrapped in a typed UnprocessableFileError; the cause chain preserves
+	// the underlying os.ErrNotExist for callers that need to detect it.
+	assert.ErrorIs(t, err, os.ErrNotExist)
+}
+
+func TestReadPackageManifest_Unparseable(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, packageManifestFile),
+		[]byte("// only a comment, no Package()"), 0o600))
+
+	_, err := readPackageManifest(dir)
+	require.Error(t, err)
+}
+
+func TestReadPackageManifest_Success(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, packageManifestFile),
+		[]byte(`let package = Package(name: "ok", dependencies: [])`), 0o600))
+
+	m, err := readPackageManifest(dir)
+	require.NoError(t, err)
+	assert.Equal(t, "ok", m.Name)
+}

--- a/pkg/ecosystems/swift/swiftpm/plugin.go
+++ b/pkg/ecosystems/swift/swiftpm/plugin.go
@@ -1,0 +1,297 @@
+// Package swiftpm implements an ecosystems.SCAPlugin for Swift Package
+// Manager projects.
+//
+// It shells out to `swift package show-dependencies --format json` against a
+// directory containing Package.swift (and ideally Package.resolved so the
+// scan is fully offline). This outsources resolution to swift itself —
+// including version-resolution overrides, local-path deps, and transitive
+// merges — and avoids re-implementing the Package.resolved format in Go.
+//
+// Requires swift 5.6+ in PATH (the toolchain version that introduced
+// `--format json` for `show-dependencies`).
+//
+// Identity contract follows the legacy snyk-swiftpm-plugin with one
+// deliberate divergence: the legacy plugin reconstructed targetFile as
+// `${pathToPosix(targetFile)}Package.swift`, which produces e.g.
+// "path/toPackage.swift" (missing path separator) when the input was
+// "path/to/Package.swift". This plugin produces the correct
+// "path/to/Package.swift". See the plugin audit page for context.
+package swiftpm
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/discovery"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/logger"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/identity"
+)
+
+const (
+	// PluginName is the canonical identifier surfaced in SCAResult.ResolverMetadata.PluginName.
+	PluginName = "swiftpm"
+
+	logFieldManifest = "manifest"
+)
+
+// Plugin implements ecosystems.SCAPlugin for Swift Package Manager projects.
+type Plugin struct {
+	executor swiftRunner
+}
+
+// Compile-time check that Plugin implements the SCAPlugin interface.
+var _ ecosystems.SCAPlugin = (*Plugin)(nil)
+
+func (p Plugin) GetName() string {
+	return PluginName
+}
+
+// BuildDepGraphsFromDir discovers Package.swift files under dir and produces
+// one dep graph per package. Swift Package Manager has no first-party
+// concept of workspaces (path: deps come close but each is its own package);
+// each discovered Package.swift therefore produces a single result.
+//
+// Each result is emitted via onGraph as soon as it's built.
+func (p Plugin) BuildDepGraphsFromDir(
+	ctx context.Context,
+	log logger.Logger,
+	dir string,
+	options *ecosystems.SCAPluginOptions,
+	onGraph ecosystems.OnGraphFunc,
+) error {
+	if log == nil {
+		log = logger.Nop()
+	}
+
+	files, err := p.discoverManifests(ctx, dir, options)
+	if err != nil {
+		return err
+	}
+
+	if len(files) == 0 {
+		log.Debug(ctx, "No Package.swift files found", logger.Attr("dir", dir))
+		return nil
+	}
+
+	log.Debug(ctx, "Discovered Package.swift files", logger.Attr("count", len(files)))
+
+	exec := p.getExecutor()
+
+	for _, file := range files {
+		manifestAbsDir := filepath.Dir(file.Path)
+
+		result := p.buildResult(ctx, log, file.RelPath, manifestAbsDir, exec)
+		result.ProcessedFiles = append(result.ProcessedFiles, file.RelPath)
+
+		// Surface Package.resolved as a processed file when it exists so the
+		// caller can attribute the scan to both manifest and lockfile.
+		resolvedRelPath := filepath.Join(filepath.Dir(file.RelPath), packageResolvedFile)
+		if fileExists(filepath.Join(manifestAbsDir, packageResolvedFile)) {
+			result.ProcessedFiles = append(result.ProcessedFiles, resolvedRelPath)
+		}
+
+		if result.Error != nil {
+			log.Error(ctx, "Failed to build swiftpm dependency graph",
+				logger.Attr(logFieldManifest, file.RelPath),
+				logger.Err(result.Error),
+			)
+		}
+
+		if err := onGraph(result); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (p Plugin) buildResult(
+	ctx context.Context,
+	log logger.Logger,
+	manifestRelPath, manifestAbsDir string,
+	exec swiftRunner,
+) ecosystems.SCAResult {
+	// Note: targetFile is the relative path to Package.swift INCLUDING the
+	// "Package.swift" basename and a proper path separator between it and
+	// any parent directory. This is the audit's expected-divergence point
+	// vs the legacy plugin, which dropped the separator.
+	rootTargetFile := manifestRelPath
+
+	errResult := func(err error) ecosystems.SCAResult {
+		return ecosystems.SCAResult{
+			ProjectDescriptor: identity.ProjectDescriptor{
+				Identity: identity.ProjectIdentity{
+					ProjectType: pkgManager,
+					TargetFile:  &rootTargetFile,
+				},
+			},
+			ResolverMetadata: &ecosystems.ResolverMetadata{
+				PluginName:           PluginName,
+				NormalisedTargetFile: rootTargetFile,
+			},
+			Error: err,
+		}
+	}
+
+	log.Info(ctx, "Building swiftpm dependency graph", logger.Attr(logFieldManifest, manifestRelPath))
+
+	manifest, err := readPackageManifest(manifestAbsDir)
+	if err != nil {
+		return errResult(fmt.Errorf("reading Package.swift: %w", err))
+	}
+
+	output, err := exec.Run(ctx, manifestAbsDir, nil)
+	if err != nil {
+		return errResult(p.wrapRunError(err))
+	}
+	defer output.Close()
+
+	parsed, err := parseShowDependenciesOutput(output)
+	if err != nil {
+		return errResult(fmt.Errorf("parsing swift show-dependencies output: %w", err))
+	}
+
+	log.Debug(ctx, "Parsed swift show-dependencies output",
+		logger.Attr(logFieldManifest, manifestRelPath),
+		logger.Attr("topLevelDeps", len(parsed.Dependencies)),
+	)
+
+	graph, err := buildDepGraph(manifest.Name, parsed)
+	if err != nil {
+		return errResult(fmt.Errorf("building dep graph: %w", err))
+	}
+
+	log.Info(ctx, "Successfully built swiftpm dependency graph",
+		logger.Attr(logFieldManifest, manifestRelPath),
+	)
+
+	return ecosystems.SCAResult{
+		DepGraph: graph,
+		ProjectDescriptor: identity.ProjectDescriptor{
+			Identity: identity.ProjectIdentity{
+				ProjectType:       pkgManager,
+				TargetFile:        &rootTargetFile,
+				RootComponentName: graph.GetRootPkg().Info.Name,
+			},
+		},
+		ResolverMetadata: &ecosystems.ResolverMetadata{
+			PluginName:           PluginName,
+			VersionBuildInfo:     map[string]string{},
+			NormalisedTargetFile: rootTargetFile,
+		},
+	}
+}
+
+// parseShowDependenciesOutput consumes a streaming `swift package
+// show-dependencies --format json` reader and decodes the root node.
+//
+// swift prints its fetch/resolve progress to stderr, then writes a single
+// JSON object to stdout. We tolerate trailing whitespace; anything else in
+// the stream signals a swift bug or an upstream change worth surfacing.
+func parseShowDependenciesOutput(r io.Reader) (*depTreeNode, error) {
+	var root depTreeNode
+	if err := json.NewDecoder(r).Decode(&root); err != nil {
+		return nil, fmt.Errorf("decoding swift show-dependencies JSON: %w", err)
+	}
+	return &root, nil
+}
+
+// wrapRunError converts errors from swiftCmdExecutor.Run into user-facing
+// messages that name the binary and the minimum supported version.
+func (p Plugin) wrapRunError(err error) error {
+	if errors.Is(err, errSwiftNotFound) {
+		return fmt.Errorf(
+			"swift is not installed or not in PATH; install swift >= %s to scan this project: %w",
+			minSwiftVersion, err,
+		)
+	}
+
+	if errors.Is(err, errSwiftVersionTooLow) {
+		return fmt.Errorf(
+			"swift >= %s is required for dependency graph resolution: %w",
+			minSwiftVersion, err,
+		)
+	}
+
+	return fmt.Errorf("running swift package show-dependencies: %w", err)
+}
+
+// discoverManifests locates Package.swift files. Defaults to a single root
+// manifest; honors --target-file and --all-projects in the same shape as
+// the npm/yarn plugins.
+func (p Plugin) discoverManifests(
+	ctx context.Context,
+	dir string,
+	options *ecosystems.SCAPluginOptions,
+) ([]discovery.FindResult, error) {
+	if options == nil {
+		options = ecosystems.NewPluginOptions()
+	}
+
+	switch {
+	case options.Global.TargetFile != nil:
+		if filepath.Base(*options.Global.TargetFile) != packageManifestFile {
+			return nil, nil
+		}
+
+		files, err := discovery.FindFiles(ctx, dir, discovery.WithTargetFile(*options.Global.TargetFile))
+		if err != nil {
+			return nil, fmt.Errorf("discovering Package.swift files: %w", err)
+		}
+
+		return files, nil
+
+	case options.Global.AllProjects:
+		findOpts := []discovery.FindOption{
+			discovery.WithInclude(packageManifestFile),
+			discovery.WithCommonExcludes(),
+			// .build is already in commonExcludes; .swiftpm is swift's
+			// per-user metadata directory and can never contain a project.
+			discovery.WithExclude(".swiftpm"),
+		}
+
+		if len(options.Global.Exclude) > 0 {
+			findOpts = append(findOpts, discovery.WithExcludes(options.Global.Exclude...))
+		}
+		if len(options.Global.ExcludePaths) > 0 {
+			findOpts = append(findOpts, discovery.WithExcludes(options.Global.ExcludePaths...))
+		}
+
+		files, err := discovery.FindFiles(ctx, dir, findOpts...)
+		if err != nil {
+			return nil, fmt.Errorf("discovering Package.swift files: %w", err)
+		}
+
+		return files, nil
+
+	default:
+		rootManifest := filepath.Join(dir, packageManifestFile)
+		if !fileExists(rootManifest) {
+			return nil, nil
+		}
+
+		return []discovery.FindResult{{Path: rootManifest, RelPath: packageManifestFile}}, nil
+	}
+}
+
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
+}
+
+// getExecutor returns the configured executor or the production
+// swiftCmdExecutor. Plugin{} zero-value is valid and uses the production
+// executor by default.
+func (p Plugin) getExecutor() swiftRunner {
+	if p.executor != nil {
+		return p.executor
+	}
+
+	return &swiftCmdExecutor{}
+}

--- a/pkg/ecosystems/swift/swiftpm/plugin_integration_test.go
+++ b/pkg/ecosystems/swift/swiftpm/plugin_integration_test.go
@@ -1,0 +1,269 @@
+//go:build integration && swiftpm
+// +build integration,swiftpm
+
+package swiftpm_test
+
+// plugin_integration_test.go verifies the swiftpm plugin against golden dep
+// graphs stored in testdata/acceptance/. Each fixture directory contains a
+// Package.swift, a Package.resolved (so swift can resolve fully offline from
+// its global cache), and an expected.json capturing the dep graph the plugin
+// emits.
+//
+// Build tag `integration && swiftpm` keeps these tests out of the default
+// `go test ./...` run — they require real swift in PATH.
+//
+// Run with `make test-swiftpm-integration`, or directly via
+//
+//	go test -tags=integration,swiftpm -v ./pkg/ecosystems/swift/swiftpm/...
+//
+// Regenerate goldens with `-update`.
+//
+// Each fixture is copied to a fresh temp directory before the plugin runs.
+// swift package show-dependencies always creates a .build/ checkouts tree
+// alongside the manifest, so we cannot run it directly against the test
+// source tree without permanently dirtying the repo. The temp-dir copy keeps
+// the source untouched and lets us assert that no .build/ or .swiftpm/
+// directory has appeared in the original fixture dir afterwards — the
+// project-dir-immutability guarantee the spec calls for.
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/mod/semver"
+
+	"github.com/snyk/dep-graph/go/pkg/depgraph"
+
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/scatest"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/swift/swiftpm"
+)
+
+var updateGolden = flag.Bool("update", false, "overwrite expected.json golden files with current plugin output")
+
+type acceptanceFixture struct {
+	name string
+	dir  string
+}
+
+var testSwiftVersionRe = regexp.MustCompile(`Swift version (\d+)\.(\d+)(?:\.(\d+))?`)
+
+const minTestSwiftVersion = "v5.6.0"
+
+// requireSwift skips the test if swift is absent or older than the minimum
+// supported toolchain; fails it if `swift --version` is present but
+// unparseable.
+func requireSwift(t *testing.T) {
+	t.Helper()
+	swiftPath, err := exec.LookPath("swift")
+	if err != nil {
+		t.Skipf("swift not found in PATH — install swift >= %s to run these tests", minTestSwiftVersion)
+	}
+	out, err := exec.Command(swiftPath, "--version").Output()
+	if err != nil {
+		t.Fatalf("failed to get swift version: %v", err)
+	}
+	raw := strings.TrimSpace(string(out))
+	m := testSwiftVersionRe.FindStringSubmatch(raw)
+	if m == nil {
+		t.Fatalf("could not parse swift version from %q", raw)
+	}
+	patch := m[3]
+	if patch == "" {
+		patch = "0"
+	}
+	ver := "v" + m[1] + "." + m[2] + "." + patch
+	if semver.Compare(ver, minTestSwiftVersion) < 0 {
+		t.Skipf("swift %s is below the required minimum %s", ver, minTestSwiftVersion)
+	}
+	t.Logf("swift version: %s", ver)
+}
+
+// TestAcceptance runs the swiftpm plugin against every fixture in
+// testdata/acceptance/ and diff-checks the resulting dep graph against the
+// committed golden.
+//
+// In addition to the dep-graph comparison, each subtest asserts that the
+// source fixture directory is unmodified after the plugin runs — no
+// .build/, no .swiftpm/, no Package.resolved written if one wasn't there
+// already. The plugin must never mutate the project tree.
+func TestAcceptance(t *testing.T) {
+	requireSwift(t)
+
+	fixtures := discoverFixtures(t, filepath.Join("testdata", "acceptance"))
+	require.NotEmpty(t, fixtures, "no fixtures found")
+
+	plugin := swiftpm.Plugin{}
+
+	for _, fx := range fixtures {
+		t.Run(fx.name, func(t *testing.T) {
+			// Snapshot the source dir contents before doing anything so we
+			// can compare after the plugin runs.
+			before := snapshotDir(t, fx.dir)
+
+			// Copy the fixture to a temp directory so swift's resolved-cache
+			// side-effects (always written into .build/) don't dirty the
+			// committed fixture.
+			scratch := t.TempDir()
+			copyTree(t, fx.dir, scratch)
+
+			results, err := scatest.Run(context.Background(), plugin, nil, scratch, &ecosystems.SCAPluginOptions{})
+			require.NoError(t, err)
+			require.Len(t, results, 1)
+			require.NoError(t, results[0].Error)
+
+			// Acceptance assertion: the source fixture dir must be untouched.
+			// swift package show-dependencies, when allowed to, always
+			// creates .build/ — we route it at the temp copy so the source
+			// stays clean.
+			after := snapshotDir(t, fx.dir)
+			assert.Equal(t, before, after,
+				"source fixture must not be mutated; .build/ or .swiftpm/ would indicate the plugin is running swift against the source")
+			assert.NoDirExists(t, filepath.Join(fx.dir, ".build"),
+				"no .build/ directory must appear in the source fixture")
+			assert.NoDirExists(t, filepath.Join(fx.dir, ".swiftpm"),
+				"no .swiftpm/ directory must appear in the source fixture")
+
+			if *updateGolden {
+				writeGolden(t, filepath.Join(fx.dir, "expected.json"), results[0].DepGraph)
+				return
+			}
+
+			raw, err := os.ReadFile(filepath.Join(fx.dir, "expected.json"))
+			require.NoError(t, err, "reading expected.json")
+
+			expected, err := depgraph.UnmarshalJSON(raw)
+			require.NoError(t, err, "parsing expected.json")
+
+			assert.Equal(t, normalizedJSON(expected), normalizedJSON(results[0].DepGraph))
+		})
+	}
+}
+
+// writeGolden persists a dep graph to the given path as canonical JSON.
+func writeGolden(t *testing.T, path string, dg *depgraph.DepGraph) {
+	t.Helper()
+	data, err := json.MarshalIndent(dg, "", "  ")
+	require.NoError(t, err, "marshaling dep graph")
+	require.NoError(t, os.WriteFile(path, append(data, '\n'), 0o600), "writing %s", path)
+	t.Logf("updated %s", path)
+}
+
+// normalizedJSON marshals a dep graph to JSON with all arrays sorted, so
+// comparisons are order-independent.
+func normalizedJSON(dg *depgraph.DepGraph) string {
+	sort.Slice(dg.Pkgs, func(i, j int) bool { return dg.Pkgs[i].ID < dg.Pkgs[j].ID })
+	sort.Slice(dg.Graph.Nodes, func(i, j int) bool { return dg.Graph.Nodes[i].NodeID < dg.Graph.Nodes[j].NodeID })
+
+	for i := range dg.Graph.Nodes {
+		sort.Slice(dg.Graph.Nodes[i].Deps, func(a, b int) bool {
+			return dg.Graph.Nodes[i].Deps[a].NodeID < dg.Graph.Nodes[i].Deps[b].NodeID
+		})
+	}
+
+	data, err := json.MarshalIndent(dg, "", "  ")
+	if err != nil {
+		panic(fmt.Errorf("marshaling normalised dep graph: %w", err))
+	}
+	return string(data)
+}
+
+// discoverFixtures finds all fixture dirs that contain a Package.swift. We
+// don't filter on expected.json so `-update` can seed brand-new fixtures.
+func discoverFixtures(t *testing.T, base string) []acceptanceFixture {
+	t.Helper()
+
+	entries, err := os.ReadDir(base)
+	require.NoError(t, err, "reading fixtures dir: %s", base)
+
+	var fixtures []acceptanceFixture
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+
+		fxDir := filepath.Join(base, entry.Name())
+		if _, err := os.Stat(filepath.Join(fxDir, "Package.swift")); err != nil {
+			continue
+		}
+
+		fixtures = append(fixtures, acceptanceFixture{name: entry.Name(), dir: fxDir})
+	}
+
+	sort.Slice(fixtures, func(i, j int) bool { return fixtures[i].name < fixtures[j].name })
+
+	return fixtures
+}
+
+// snapshotDir returns a sorted list of "relpath" entries under dir so two
+// snapshots compare cleanly. Compares structure only, not content — the
+// only mutation we're guarding against is swift creating .build/ /
+// .swiftpm/ checkout caches.
+func snapshotDir(t *testing.T, dir string) []string {
+	t.Helper()
+	var entries []string
+	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, relErr := filepath.Rel(dir, path)
+		if relErr != nil {
+			return relErr
+		}
+		if rel == "." {
+			return nil
+		}
+		entries = append(entries, rel)
+		return nil
+	})
+	require.NoError(t, err)
+	sort.Strings(entries)
+	return entries
+}
+
+// copyTree mirrors src into dst, preserving file modes.
+func copyTree(t *testing.T, src, dst string) {
+	t.Helper()
+	require.NoError(t, filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, relErr := filepath.Rel(src, path)
+		if relErr != nil {
+			return relErr
+		}
+		target := filepath.Join(dst, rel)
+		if info.IsDir() {
+			return os.MkdirAll(target, info.Mode())
+		}
+		return copyFile(path, target, info.Mode())
+	}))
+}
+
+func copyFile(src, dst string, mode os.FileMode) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+	_, err = io.Copy(out, in)
+	return err
+}

--- a/pkg/ecosystems/swift/swiftpm/plugin_test.go
+++ b/pkg/ecosystems/swift/swiftpm/plugin_test.go
@@ -1,0 +1,299 @@
+package swiftpm
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/logger"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/scatest"
+)
+
+// fakeExecutor returns canned JSON output for `swift package show-dependencies`.
+type fakeExecutor struct {
+	json string
+	err  error
+
+	// gotDir / gotArgs capture what the plugin passed to Run for argument-
+	// propagation assertions.
+	gotDir  string
+	gotArgs []string
+}
+
+func (f *fakeExecutor) Run(_ context.Context, dir string, extraArgs []string) (io.ReadCloser, error) {
+	f.gotDir = dir
+	f.gotArgs = append([]string(nil), extraArgs...)
+	if f.err != nil {
+		return nil, f.err
+	}
+	return io.NopCloser(bytes.NewReader([]byte(f.json))), nil
+}
+
+func newPlugin(exec swiftRunner) Plugin {
+	return Plugin{executor: exec}
+}
+
+// writeSwiftProject writes a minimal Package.swift declaring the given name.
+func writeSwiftProject(t *testing.T, dir, name string) {
+	t.Helper()
+	manifest := `// swift-tools-version:5.6
+import PackageDescription
+let package = Package(name: "` + name + `", dependencies: [])
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, packageManifestFile), []byte(manifest), 0o600))
+}
+
+func TestPlugin_GetName(t *testing.T) {
+	assert.Equal(t, "swiftpm", Plugin{}.GetName())
+}
+
+func TestPlugin_Simple(t *testing.T) {
+	tmp := t.TempDir()
+	writeSwiftProject(t, tmp, "my-app")
+
+	showDepsJSON := `{
+		"identity": "my-app",
+		"name": "my-app",
+		"url": "/tmp/my-app",
+		"version": "unspecified",
+		"dependencies": [
+			{
+				"identity": "grpc-swift",
+				"name": "grpc-swift",
+				"url": "https://github.com/grpc/grpc-swift.git",
+				"version": "1.16.0",
+				"dependencies": [
+					{
+						"identity": "swift-nio",
+						"name": "swift-nio",
+						"url": "https://github.com/apple/swift-nio.git",
+						"version": "2.54.0",
+						"dependencies": []
+					}
+				]
+			}
+		]
+	}`
+
+	exec := &fakeExecutor{json: showDepsJSON}
+	plugin := newPlugin(exec)
+	results, err := scatest.Run(context.Background(), plugin, logger.Nop(), tmp, ecosystems.NewPluginOptions())
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	r := results[0]
+	require.NoError(t, r.Error)
+	require.NotNil(t, r.DepGraph)
+
+	assert.Equal(t, "my-app", r.DepGraph.GetRootPkg().Info.Name)
+	assert.Equal(t, "swift", r.DepGraph.PkgManager.Name)
+	assert.Equal(t, packageManifestFile, r.ProjectDescriptor.GetTargetFile())
+	assert.ElementsMatch(t, []string{packageManifestFile}, r.ProcessedFiles)
+
+	require.NotNil(t, r.ResolverMetadata)
+	assert.Equal(t, "swiftpm", r.ResolverMetadata.PluginName)
+	assert.Equal(t, packageManifestFile, r.ResolverMetadata.NormalisedTargetFile)
+
+	pkgIDs := make(map[string]bool)
+	for _, p := range r.DepGraph.Pkgs {
+		pkgIDs[p.ID] = true
+	}
+	assert.True(t, pkgIDs["github.com/grpc/grpc-swift@1.16.0"])
+	assert.True(t, pkgIDs["github.com/apple/swift-nio@2.54.0"])
+
+	// Plugin should hand the manifest's parent directory to the executor.
+	assert.Equal(t, tmp, exec.gotDir)
+	assert.Empty(t, exec.gotArgs, "plugin currently does not forward extra args")
+}
+
+func TestPlugin_Simple_WithPackageResolved_AddedToProcessedFiles(t *testing.T) {
+	tmp := t.TempDir()
+	writeSwiftProject(t, tmp, "my-app")
+	require.NoError(t, os.WriteFile(filepath.Join(tmp, packageResolvedFile),
+		[]byte(`{"pins":[],"version":2}`), 0o600))
+
+	plugin := newPlugin(&fakeExecutor{json: `{"name":"my-app","url":"/tmp","version":"unspecified","dependencies":[]}`})
+	results, err := scatest.Run(context.Background(), plugin, logger.Nop(), tmp, ecosystems.NewPluginOptions())
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.ElementsMatch(t, []string{packageManifestFile, packageResolvedFile}, results[0].ProcessedFiles)
+}
+
+// TestPlugin_TargetFileSeparatorFixed exercises the audit fix.
+//
+// Legacy snyk-swiftpm-plugin (lib/index.ts) reconstructed targetFile as
+// `${pathToPosix(targetFile)}Package.swift`, which produces e.g.
+// "subdir/Package.swift" → "subdirPackage.swift" (missing separator).
+// The new plugin uses the discovered manifest's relPath directly, which
+// includes the separator. This test pins down that intentional divergence.
+func TestPlugin_TargetFileSeparatorFixed(t *testing.T) {
+	tmp := t.TempDir()
+	subdir := filepath.Join(tmp, "subdir")
+	require.NoError(t, os.MkdirAll(subdir, 0o755))
+	writeSwiftProject(t, subdir, "nested-app")
+
+	targetFile := filepath.Join(subdir, packageManifestFile)
+	plugin := newPlugin(&fakeExecutor{json: `{"name":"nested-app","url":"/tmp","version":"unspecified","dependencies":[]}`})
+	opts := ecosystems.NewPluginOptions().WithTargetFile(targetFile)
+
+	results, err := scatest.Run(context.Background(), plugin, logger.Nop(), tmp, opts)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	tf := results[0].ProjectDescriptor.GetTargetFile()
+	// The legacy bug would have produced "subdirPackage.swift".
+	// The fixed behaviour produces "subdir/Package.swift" on POSIX
+	// (or "subdir\Package.swift" on Windows — both still have a separator).
+	assert.Equal(t, filepath.Join("subdir", packageManifestFile), tf,
+		"separator between dir and basename must be preserved (audit fix vs legacy)")
+	assert.NotEqual(t, "subdirPackage.swift", tf,
+		"must not regress to the legacy bug shape")
+}
+
+func TestPlugin_NoManifest_ReturnsEmpty(t *testing.T) {
+	plugin := newPlugin(&fakeExecutor{json: `{}`})
+	results, err := scatest.Run(context.Background(), plugin, logger.Nop(), t.TempDir(), ecosystems.NewPluginOptions())
+	require.NoError(t, err)
+	assert.Empty(t, results)
+}
+
+func TestPlugin_TargetFileNotPackageSwift_ReturnsEmpty(t *testing.T) {
+	tmp := t.TempDir()
+	writeSwiftProject(t, tmp, "x")
+
+	plugin := newPlugin(&fakeExecutor{json: `{}`})
+	opts := ecosystems.NewPluginOptions().WithTargetFile("package.json")
+	results, err := scatest.Run(context.Background(), plugin, logger.Nop(), tmp, opts)
+	require.NoError(t, err)
+	assert.Empty(t, results)
+}
+
+func TestPlugin_SwiftNotFound_ReturnsErrorResult(t *testing.T) {
+	tmp := t.TempDir()
+	writeSwiftProject(t, tmp, "x")
+
+	plugin := newPlugin(&fakeExecutor{err: errSwiftNotFound})
+	results, err := scatest.Run(context.Background(), plugin, logger.Nop(), tmp, ecosystems.NewPluginOptions())
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.ErrorIs(t, results[0].Error, errSwiftNotFound)
+	require.NotNil(t, results[0].ResolverMetadata)
+	assert.Equal(t, "swiftpm", results[0].ResolverMetadata.PluginName)
+}
+
+func TestPlugin_SwiftVersionTooLow_ReturnsErrorResult(t *testing.T) {
+	tmp := t.TempDir()
+	writeSwiftProject(t, tmp, "x")
+
+	plugin := newPlugin(&fakeExecutor{err: errSwiftVersionTooLow})
+	results, err := scatest.Run(context.Background(), plugin, logger.Nop(), tmp, ecosystems.NewPluginOptions())
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.ErrorIs(t, results[0].Error, errSwiftVersionTooLow)
+}
+
+func TestPlugin_SwiftRunFailure_ReturnsErrorResult(t *testing.T) {
+	tmp := t.TempDir()
+	writeSwiftProject(t, tmp, "x")
+
+	plugin := newPlugin(&fakeExecutor{err: errors.New("swift package show-dependencies failed: exit status 1")})
+	results, err := scatest.Run(context.Background(), plugin, logger.Nop(), tmp, ecosystems.NewPluginOptions())
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Error(t, results[0].Error)
+}
+
+func TestPlugin_MissingPackageSwiftWithJunk_ReturnsErrorResult(t *testing.T) {
+	tmp := t.TempDir()
+	// No Package.swift at all but Package.resolved present — discovery
+	// returns nothing, so we get an empty result set.
+	require.NoError(t, os.WriteFile(filepath.Join(tmp, packageResolvedFile), []byte(`{}`), 0o600))
+
+	plugin := newPlugin(&fakeExecutor{json: `{}`})
+	results, err := scatest.Run(context.Background(), plugin, logger.Nop(), tmp, ecosystems.NewPluginOptions())
+	require.NoError(t, err)
+	assert.Empty(t, results)
+}
+
+func TestPlugin_UnparseableSwiftOutput_ReturnsErrorResult(t *testing.T) {
+	tmp := t.TempDir()
+	writeSwiftProject(t, tmp, "x")
+
+	plugin := newPlugin(&fakeExecutor{json: `not json`})
+	results, err := scatest.Run(context.Background(), plugin, logger.Nop(), tmp, ecosystems.NewPluginOptions())
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	require.Error(t, results[0].Error)
+	assert.Contains(t, results[0].Error.Error(), "parsing swift show-dependencies output")
+}
+
+func TestPlugin_DiscoverManifests_HonorsExcludePaths(t *testing.T) {
+	tmpDir := t.TempDir()
+	for _, rel := range []string{"Package.swift", "a/Package.swift", "b/Package.swift"} {
+		full := filepath.Join(tmpDir, rel)
+		require.NoError(t, os.MkdirAll(filepath.Dir(full), 0o755))
+		require.NoError(t, os.WriteFile(full, []byte(""), 0o600))
+	}
+
+	opts := ecosystems.NewPluginOptions().
+		WithAllProjects(true).
+		WithExcludePaths([]string{"a/Package.swift"})
+
+	got, err := Plugin{}.discoverManifests(t.Context(), tmpDir, opts)
+	require.NoError(t, err)
+
+	rels := make([]string, len(got))
+	for i, r := range got {
+		rels[i] = r.RelPath
+	}
+	assert.NotContains(t, rels, "a/Package.swift")
+	assert.Contains(t, rels, "Package.swift")
+	assert.Contains(t, rels, "b/Package.swift")
+}
+
+func TestPlugin_DiscoverManifests_ExcludesBuildAndSwiftpm(t *testing.T) {
+	tmpDir := t.TempDir()
+	for _, rel := range []string{
+		"Package.swift",
+		".build/checkouts/sub/Package.swift",
+		".swiftpm/config/Package.swift",
+	} {
+		full := filepath.Join(tmpDir, rel)
+		require.NoError(t, os.MkdirAll(filepath.Dir(full), 0o755))
+		require.NoError(t, os.WriteFile(full, []byte(""), 0o600))
+	}
+
+	opts := ecosystems.NewPluginOptions().WithAllProjects(true)
+	got, err := Plugin{}.discoverManifests(t.Context(), tmpDir, opts)
+	require.NoError(t, err)
+
+	rels := make([]string, len(got))
+	for i, r := range got {
+		rels[i] = r.RelPath
+	}
+	assert.ElementsMatch(t, []string{"Package.swift"}, rels,
+		".build and .swiftpm subtrees must not yield discovered manifests")
+}
+
+func TestPlugin_DefaultDiscovery_NoSubdirRecursion(t *testing.T) {
+	// Without --all-projects, only the root Package.swift is considered.
+	tmp := t.TempDir()
+	writeSwiftProject(t, tmp, "root")
+	subdir := filepath.Join(tmp, "sub")
+	require.NoError(t, os.MkdirAll(subdir, 0o755))
+	writeSwiftProject(t, subdir, "sub-pkg")
+
+	plugin := newPlugin(&fakeExecutor{json: `{"name":"root","url":"/tmp","version":"unspecified","dependencies":[]}`})
+	results, err := scatest.Run(context.Background(), plugin, logger.Nop(), tmp, ecosystems.NewPluginOptions())
+	require.NoError(t, err)
+	require.Len(t, results, 1, "default mode yields only the root manifest")
+	assert.Equal(t, "root", results[0].DepGraph.GetRootPkg().Info.Name)
+}

--- a/pkg/ecosystems/swift/swiftpm/testdata/acceptance/simple/Package.resolved
+++ b/pkg/ecosystems/swift/swiftpm/testdata/acceptance/simple/Package.resolved
@@ -1,0 +1,185 @@
+{
+  "pins" : [
+    {
+      "identity" : "grpc-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/grpc/grpc-swift.git",
+      "state" : {
+        "revision" : "9e464a75079928366aa7041769a271fac89271bf",
+        "version" : "1.0.0"
+      }
+    },
+    {
+      "identity" : "swift-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-algorithms.git",
+      "state" : {
+        "revision" : "87e50f483c54e6efd60e885f7f5aa946cee68023",
+        "version" : "1.2.1"
+      }
+    },
+    {
+      "identity" : "swift-asn1",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-asn1.git",
+      "state" : {
+        "revision" : "a9a5efd40eaf558a2bcd48d64b1d1646be686008",
+        "version" : "1.7.1"
+      }
+    },
+    {
+      "identity" : "swift-async-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-async-algorithms.git",
+      "state" : {
+        "revision" : "d0b4a06d0f173a2f3be27d3ea21b3c3aa18db440",
+        "version" : "1.1.4"
+      }
+    },
+    {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics.git",
+      "state" : {
+        "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-certificates",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-certificates.git",
+      "state" : {
+        "revision" : "bde8ca32a096825dfce37467137c903418c1893d",
+        "version" : "1.19.1"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "fea17c02d767f46b23070fdfdacc28a03a39232a",
+        "version" : "1.5.1"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "1b6b2e274e85105bfa155183145a1dcfd63331f1",
+        "version" : "4.5.0"
+      }
+    },
+    {
+      "identity" : "swift-http-structured-headers",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-structured-headers.git",
+      "state" : {
+        "revision" : "933538faa42c432d385f02e07df0ace7c5ecfc47",
+        "version" : "1.7.0"
+      }
+    },
+    {
+      "identity" : "swift-http-types",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-types.git",
+      "state" : {
+        "revision" : "db774a277f60063a32d854f2980299caf06da041",
+        "version" : "1.6.0"
+      }
+    },
+    {
+      "identity" : "swift-log",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-log.git",
+      "state" : {
+        "revision" : "2aed77ae5ec9a86d8fe42c12275e4c2653a286ee",
+        "version" : "1.13.1"
+      }
+    },
+    {
+      "identity" : "swift-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio.git",
+      "state" : {
+        "revision" : "77b84ac2cd2ac9e4ac67d19f045fd5b434f56967",
+        "version" : "2.101.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-extras",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-extras.git",
+      "state" : {
+        "revision" : "d2eeec0339074034f11a040a74aa2a341a2c4506",
+        "version" : "1.34.1"
+      }
+    },
+    {
+      "identity" : "swift-nio-http2",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-http2.git",
+      "state" : {
+        "revision" : "61d1b44f6e4e118792be1cff88ee2bc0267c6f9a",
+        "version" : "1.44.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-ssl",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-ssl.git",
+      "state" : {
+        "revision" : "407d82d5b6cc00e1c3fb83a81b1539b70c788c5e",
+        "version" : "2.37.1"
+      }
+    },
+    {
+      "identity" : "swift-nio-transport-services",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-transport-services.git",
+      "state" : {
+        "revision" : "67787bb645a5e67d2edcdfbe48a216cc549222d5",
+        "version" : "1.28.0"
+      }
+    },
+    {
+      "identity" : "swift-numerics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-numerics.git",
+      "state" : {
+        "revision" : "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
+        "version" : "1.1.1"
+      }
+    },
+    {
+      "identity" : "swift-protobuf",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-protobuf.git",
+      "state" : {
+        "revision" : "f6506eaa86ed2e01cb0ae14a75035b7fdbf0918f",
+        "version" : "1.38.0"
+      }
+    },
+    {
+      "identity" : "swift-service-lifecycle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swift-server/swift-service-lifecycle.git",
+      "state" : {
+        "revision" : "9829955b385e5bb88128b73f1b8389e9b9c3191a",
+        "version" : "2.11.0"
+      }
+    },
+    {
+      "identity" : "swift-system",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-system.git",
+      "state" : {
+        "revision" : "669763cfd5806a67e21972d7e5e2d6b80b1ea985",
+        "version" : "1.6.5"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/pkg/ecosystems/swift/swiftpm/testdata/acceptance/simple/Package.swift
+++ b/pkg/ecosystems/swift/swiftpm/testdata/acceptance/simple/Package.swift
@@ -1,0 +1,15 @@
+// swift-tools-version:5.6
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "basic-swift",
+    
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+        // .package(url: /* package url */, from: "1.0.0"),
+        .package(url: "https://github.com/grpc/grpc-swift.git", exact: "1.0.0"),
+
+    ]
+)

--- a/pkg/ecosystems/swift/swiftpm/testdata/acceptance/simple/expected.json
+++ b/pkg/ecosystems/swift/swiftpm/testdata/acceptance/simple/expected.json
@@ -1,0 +1,382 @@
+{
+  "schemaVersion": "1.3.0",
+  "pkgManager": {
+    "name": "swift"
+  },
+  "pkgs": [
+    {
+      "id": "basic-swift@unspecified",
+      "info": {
+        "name": "basic-swift",
+        "version": "unspecified"
+      }
+    },
+    {
+      "id": "github.com/grpc/grpc-swift@1.0.0",
+      "info": {
+        "name": "github.com/grpc/grpc-swift",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "github.com/apple/swift-nio@2.101.0",
+      "info": {
+        "name": "github.com/apple/swift-nio",
+        "version": "2.101.0"
+      }
+    },
+    {
+      "id": "github.com/apple/swift-atomics@1.3.0",
+      "info": {
+        "name": "github.com/apple/swift-atomics",
+        "version": "1.3.0"
+      }
+    },
+    {
+      "id": "github.com/apple/swift-collections@1.5.1",
+      "info": {
+        "name": "github.com/apple/swift-collections",
+        "version": "1.5.1"
+      }
+    },
+    {
+      "id": "github.com/apple/swift-system@1.6.5",
+      "info": {
+        "name": "github.com/apple/swift-system",
+        "version": "1.6.5"
+      }
+    },
+    {
+      "id": "github.com/apple/swift-nio-http2@1.44.0",
+      "info": {
+        "name": "github.com/apple/swift-nio-http2",
+        "version": "1.44.0"
+      }
+    },
+    {
+      "id": "github.com/apple/swift-nio-ssl@2.37.1",
+      "info": {
+        "name": "github.com/apple/swift-nio-ssl",
+        "version": "2.37.1"
+      }
+    },
+    {
+      "id": "github.com/apple/swift-nio-transport-services@1.28.0",
+      "info": {
+        "name": "github.com/apple/swift-nio-transport-services",
+        "version": "1.28.0"
+      }
+    },
+    {
+      "id": "github.com/apple/swift-nio-extras@1.34.1",
+      "info": {
+        "name": "github.com/apple/swift-nio-extras",
+        "version": "1.34.1"
+      }
+    },
+    {
+      "id": "github.com/apple/swift-http-types@1.6.0",
+      "info": {
+        "name": "github.com/apple/swift-http-types",
+        "version": "1.6.0"
+      }
+    },
+    {
+      "id": "github.com/apple/swift-http-structured-headers@1.7.0",
+      "info": {
+        "name": "github.com/apple/swift-http-structured-headers",
+        "version": "1.7.0"
+      }
+    },
+    {
+      "id": "github.com/apple/swift-algorithms@1.2.1",
+      "info": {
+        "name": "github.com/apple/swift-algorithms",
+        "version": "1.2.1"
+      }
+    },
+    {
+      "id": "github.com/apple/swift-numerics@1.1.1",
+      "info": {
+        "name": "github.com/apple/swift-numerics",
+        "version": "1.1.1"
+      }
+    },
+    {
+      "id": "github.com/apple/swift-certificates@1.19.1",
+      "info": {
+        "name": "github.com/apple/swift-certificates",
+        "version": "1.19.1"
+      }
+    },
+    {
+      "id": "github.com/apple/swift-crypto@4.5.0",
+      "info": {
+        "name": "github.com/apple/swift-crypto",
+        "version": "4.5.0"
+      }
+    },
+    {
+      "id": "github.com/apple/swift-asn1@1.7.1",
+      "info": {
+        "name": "github.com/apple/swift-asn1",
+        "version": "1.7.1"
+      }
+    },
+    {
+      "id": "github.com/swift-server/swift-service-lifecycle@2.11.0",
+      "info": {
+        "name": "github.com/swift-server/swift-service-lifecycle",
+        "version": "2.11.0"
+      }
+    },
+    {
+      "id": "github.com/apple/swift-log@1.13.1",
+      "info": {
+        "name": "github.com/apple/swift-log",
+        "version": "1.13.1"
+      }
+    },
+    {
+      "id": "github.com/apple/swift-async-algorithms@1.1.4",
+      "info": {
+        "name": "github.com/apple/swift-async-algorithms",
+        "version": "1.1.4"
+      }
+    },
+    {
+      "id": "github.com/apple/swift-protobuf@1.38.0",
+      "info": {
+        "name": "github.com/apple/swift-protobuf",
+        "version": "1.38.0"
+      }
+    }
+  ],
+  "graph": {
+    "rootNodeId": "root-node",
+    "nodes": [
+      {
+        "nodeId": "root-node",
+        "pkgId": "basic-swift@unspecified",
+        "deps": [
+          {
+            "nodeId": "github.com/grpc/grpc-swift@1.0.0"
+          }
+        ]
+      },
+      {
+        "nodeId": "github.com/grpc/grpc-swift@1.0.0",
+        "pkgId": "github.com/grpc/grpc-swift@1.0.0",
+        "deps": [
+          {
+            "nodeId": "github.com/apple/swift-nio@2.101.0"
+          },
+          {
+            "nodeId": "github.com/apple/swift-nio-http2@1.44.0"
+          },
+          {
+            "nodeId": "github.com/apple/swift-nio-ssl@2.37.1"
+          },
+          {
+            "nodeId": "github.com/apple/swift-nio-transport-services@1.28.0"
+          },
+          {
+            "nodeId": "github.com/apple/swift-nio-extras@1.34.1"
+          },
+          {
+            "nodeId": "github.com/apple/swift-protobuf@1.38.0"
+          },
+          {
+            "nodeId": "github.com/apple/swift-log@1.13.1"
+          }
+        ]
+      },
+      {
+        "nodeId": "github.com/apple/swift-nio@2.101.0",
+        "pkgId": "github.com/apple/swift-nio@2.101.0",
+        "deps": [
+          {
+            "nodeId": "github.com/apple/swift-atomics@1.3.0"
+          },
+          {
+            "nodeId": "github.com/apple/swift-collections@1.5.1"
+          },
+          {
+            "nodeId": "github.com/apple/swift-system@1.6.5"
+          }
+        ]
+      },
+      {
+        "nodeId": "github.com/apple/swift-atomics@1.3.0",
+        "pkgId": "github.com/apple/swift-atomics@1.3.0",
+        "deps": []
+      },
+      {
+        "nodeId": "github.com/apple/swift-collections@1.5.1",
+        "pkgId": "github.com/apple/swift-collections@1.5.1",
+        "deps": []
+      },
+      {
+        "nodeId": "github.com/apple/swift-system@1.6.5",
+        "pkgId": "github.com/apple/swift-system@1.6.5",
+        "deps": []
+      },
+      {
+        "nodeId": "github.com/apple/swift-nio-http2@1.44.0",
+        "pkgId": "github.com/apple/swift-nio-http2@1.44.0",
+        "deps": [
+          {
+            "nodeId": "github.com/apple/swift-nio@2.101.0"
+          },
+          {
+            "nodeId": "github.com/apple/swift-atomics@1.3.0"
+          }
+        ]
+      },
+      {
+        "nodeId": "github.com/apple/swift-nio-ssl@2.37.1",
+        "pkgId": "github.com/apple/swift-nio-ssl@2.37.1",
+        "deps": [
+          {
+            "nodeId": "github.com/apple/swift-nio@2.101.0"
+          }
+        ]
+      },
+      {
+        "nodeId": "github.com/apple/swift-nio-transport-services@1.28.0",
+        "pkgId": "github.com/apple/swift-nio-transport-services@1.28.0",
+        "deps": [
+          {
+            "nodeId": "github.com/apple/swift-nio@2.101.0"
+          },
+          {
+            "nodeId": "github.com/apple/swift-atomics@1.3.0"
+          }
+        ]
+      },
+      {
+        "nodeId": "github.com/apple/swift-nio-extras@1.34.1",
+        "pkgId": "github.com/apple/swift-nio-extras@1.34.1",
+        "deps": [
+          {
+            "nodeId": "github.com/apple/swift-nio@2.101.0"
+          },
+          {
+            "nodeId": "github.com/apple/swift-nio-http2@1.44.0"
+          },
+          {
+            "nodeId": "github.com/apple/swift-http-types@1.6.0"
+          },
+          {
+            "nodeId": "github.com/apple/swift-http-structured-headers@1.7.0"
+          },
+          {
+            "nodeId": "github.com/apple/swift-atomics@1.3.0"
+          },
+          {
+            "nodeId": "github.com/apple/swift-algorithms@1.2.1"
+          },
+          {
+            "nodeId": "github.com/apple/swift-certificates@1.19.1"
+          },
+          {
+            "nodeId": "github.com/apple/swift-nio-ssl@2.37.1"
+          },
+          {
+            "nodeId": "github.com/apple/swift-asn1@1.7.1"
+          },
+          {
+            "nodeId": "github.com/swift-server/swift-service-lifecycle@2.11.0"
+          },
+          {
+            "nodeId": "github.com/apple/swift-async-algorithms@1.1.4"
+          },
+          {
+            "nodeId": "github.com/apple/swift-log@1.13.1"
+          }
+        ]
+      },
+      {
+        "nodeId": "github.com/apple/swift-http-types@1.6.0",
+        "pkgId": "github.com/apple/swift-http-types@1.6.0",
+        "deps": []
+      },
+      {
+        "nodeId": "github.com/apple/swift-http-structured-headers@1.7.0",
+        "pkgId": "github.com/apple/swift-http-structured-headers@1.7.0",
+        "deps": []
+      },
+      {
+        "nodeId": "github.com/apple/swift-algorithms@1.2.1",
+        "pkgId": "github.com/apple/swift-algorithms@1.2.1",
+        "deps": [
+          {
+            "nodeId": "github.com/apple/swift-numerics@1.1.1"
+          }
+        ]
+      },
+      {
+        "nodeId": "github.com/apple/swift-numerics@1.1.1",
+        "pkgId": "github.com/apple/swift-numerics@1.1.1",
+        "deps": []
+      },
+      {
+        "nodeId": "github.com/apple/swift-certificates@1.19.1",
+        "pkgId": "github.com/apple/swift-certificates@1.19.1",
+        "deps": [
+          {
+            "nodeId": "github.com/apple/swift-crypto@4.5.0"
+          },
+          {
+            "nodeId": "github.com/apple/swift-asn1@1.7.1"
+          }
+        ]
+      },
+      {
+        "nodeId": "github.com/apple/swift-crypto@4.5.0",
+        "pkgId": "github.com/apple/swift-crypto@4.5.0",
+        "deps": [
+          {
+            "nodeId": "github.com/apple/swift-asn1@1.7.1"
+          }
+        ]
+      },
+      {
+        "nodeId": "github.com/apple/swift-asn1@1.7.1",
+        "pkgId": "github.com/apple/swift-asn1@1.7.1",
+        "deps": []
+      },
+      {
+        "nodeId": "github.com/swift-server/swift-service-lifecycle@2.11.0",
+        "pkgId": "github.com/swift-server/swift-service-lifecycle@2.11.0",
+        "deps": [
+          {
+            "nodeId": "github.com/apple/swift-log@1.13.1"
+          },
+          {
+            "nodeId": "github.com/apple/swift-async-algorithms@1.1.4"
+          }
+        ]
+      },
+      {
+        "nodeId": "github.com/apple/swift-log@1.13.1",
+        "pkgId": "github.com/apple/swift-log@1.13.1",
+        "deps": []
+      },
+      {
+        "nodeId": "github.com/apple/swift-async-algorithms@1.1.4",
+        "pkgId": "github.com/apple/swift-async-algorithms@1.1.4",
+        "deps": [
+          {
+            "nodeId": "github.com/apple/swift-collections@1.5.1"
+          }
+        ]
+      },
+      {
+        "nodeId": "github.com/apple/swift-protobuf@1.38.0",
+        "pkgId": "github.com/apple/swift-protobuf@1.38.0",
+        "deps": []
+      }
+    ]
+  }
+}

--- a/pkg/ecosystems/swift/swiftpm/types.go
+++ b/pkg/ecosystems/swift/swiftpm/types.go
@@ -1,0 +1,30 @@
+package swiftpm
+
+// depTreeNode is one node in `swift package show-dependencies --format json`.
+//
+// The top-level node describes the root project; nested `Dependencies` form
+// the transitive tree. Cycles are possible because Swift packages can depend
+// on each other through path: / branch: links; the dep-graph build pass
+// guards against this with a visited set.
+//
+// Field meanings (from `swift-package-manager` sources, file
+// Sources/Commands/PackageCommands/ShowDependencies.swift):
+//
+//   - Identity:    Lower-cased canonical identity computed from the package's
+//                  resolved URL (e.g. "swift-argument-parser").
+//   - Name:        The `name` from the manifest's Package(name:) initializer.
+//   - URL:         The original URL (git remote, local path, or registry
+//                  identity like "apple.swift-argument-parser").
+//   - Version:     Resolved semver, or "unspecified" for the root and for
+//                  path: / branch: deps.
+//   - Path:        On-disk path to the resolved checkout. We only use this
+//                  for diagnostics; identity comes from URL + Version.
+//   - Dependencies: Direct dependencies — recursively populated.
+type depTreeNode struct {
+	Identity     string         `json:"identity,omitempty"`
+	Name         string         `json:"name"`
+	URL          string         `json:"url"`
+	Version      string         `json:"version"`
+	Path         string         `json:"path,omitempty"`
+	Dependencies []*depTreeNode `json:"dependencies"`
+}


### PR DESCRIPTION
## What this does

Adds a new SCA plugin at `pkg/ecosystems/swift/swiftpm/` that resolves Swift Package Manager dep graphs by delegating to `swift package show-dependencies --format json` against an existing `Package.swift` + `Package.resolved`. No `swift package resolve`, no network fetch unless the resolved file is missing.

The package is self-contained and **not wired into the orchestrator in this PR**; that lands in a follow-up to avoid conflicting with other in-flight resolver work.

## Why

The legacy `snyk-swiftpm-plugin` is a thin wrapper around the same `swift package show-dependencies --format json` invocation, so there's no resolver to re-implement — this PR migrates the wrapper to Go alongside the rest of the ecosystem moves planned in [the Plugin Audit](https://snyksec.atlassian.net/wiki/spaces/TOE1/pages/4651909131/Plugin+Audit).

It also fixes the audit-flagged bug in legacy `snyk-swiftpm-plugin/lib/index.ts:50` where `path/to/Package.swift` becomes `path/toPackage.swift` (missing separator). The new plugin produces the correct path and pins the divergence with a regression test.

## What's in this PR

3 commits, scoped narrowly to the new package:

| # | Commit | What |
|---|---|---|
| 1 | `feat(swiftpm): add resolver via swift package show-dependencies --format json` | `types.go`, `executor.go` (io.Pipe streaming), `depgraph.go`, `manifest.go` (Package.swift regex reader), `plugin.go` (SCAPlugin impl, discovery). |
| 2 | `test(swiftpm): unit tests for executor, depgraph, plugin` | Pure unit tests with stubbed runner. 27 tests across 102 cases including `parseSwiftVersion` (8 cases), `packageNameFromURL`, depTreeNode → DepGraph conversion, and `TestPlugin_TargetFileSeparatorFixed` pinning the audit bug fix. |
| 3 | `test(swiftpm): integration test scaffold with smoke fixtures` | Build-tag-gated (`//go:build integration && swiftpm`) acceptance test + `make test-swiftpm-integration` target. One fixture (`simple`, grpc-swift@1.0.0 with 18 transitive packages) with committed `expected.json` golden. |

Nothing under `pkg/ecosystems/orchestrator/` is touched, so this won't conflict with other in-flight resolver work.

## How it works

```
swift package show-dependencies --format json --package-path <dir>
```

Reads `Package.swift` + `Package.resolved` if present. Output is a tree of `{identity, name, url, version, path, dependencies[]}` nodes which the plugin walks into a dep-graph, using `packageNameFromURL` to normalise package identity when the URL is set but the name isn't.

`Package.swift` is parsed via a small regex reader to extract the root `Package(name:)` (used for root pkg name and `targetFile` reconstruction). No Swift parser involved — we only need the `name:` field.

## Divergences from `snyk-swiftpm-plugin`

These behavioural differences are deliberate and reviewers should be aware of them before this plugin is ever made the default for swift. Verified against `snyk-swiftpm-plugin/lib/index.ts` + `compute-depgraph.ts`.

| Dimension | Legacy | This PR |
|---|---|---|
| **`targetFile` reconstruction** | `pathToPosix(targetFile) + 'Package.swift'` — `subdir/Package.swift` becomes `subdirPackage.swift` (missing separator). | Uses the discovered manifest's `RelPath` directly → always `subdir/Package.swift`. **Intentional bug fix.** Pinned by `TestPlugin_TargetFileSeparatorFixed`. |
| **Tool delegation** | Shells to `swift package show-dependencies --format json --package-path` (Node child_process). | Shells to the same command (Go `exec.Command`); output streamed via `io.Pipe`. |
| **Root pkg name** | From parsed `Package.swift` `Package(name:)`. | Same. |
| **`--args` passthrough** | Legacy accepts arbitrary `additionalArgs` appended after `--package-path` (undocumented). | Hook present (`extraArgs []string` on the runner) but plugin currently passes `nil`. Straightforward follow-up if needed. |

## CLI options honored

| Option | Source | Legacy use | New plugin handling |
|---|---|---|---|
| `--target-file` (global) | `SCAPluginOptions.Global.TargetFile` | Resolves to `Package.swift` | Honored |
| `--args` | `snyk-swiftpm-plugin/lib/compute-depgraph.ts:68-86` | Arbitrary append to swift command | Hook present, currently inert |

## What's NOT in this PR

- Orchestrator registration — deliberately deferred to avoid conflicting with other in-flight resolver work in this area.
- CircleCI matrix (Swift versions × macOS/Linux).
- Side-by-side legacy-comparison test against full real-world fixture corpus.
- Wiring of `--args` passthrough into the CLI shim.

A follow-up PR will land the orchestrator registration and FF for default-switching.

## How to verify

```sh
# unit tests (no real swift needed)
go test ./pkg/ecosystems/swift/swiftpm/...

# integration tests against host swift
make test-swiftpm-integration

# lint
make lint
```

## Caveats for reviewers

- **`.build/` mutation**: `swift package show-dependencies` unconditionally creates `.build/` in the target dir. The integration test sandboxes the fixture by copying to `t.TempDir()` before running, so the no-mutation principle holds at the fixture level — but the tool itself does mutate when run against a real project. Worth noting in user-facing docs.
- **`Package.swift` parser**: regex-based, handles the common `Package(name: "Foo", ...)` shape. Edge cases with comments or complex string literals may not parse — fallback to directory name.

## Risk

The new package is not registered with the orchestrator, so it has no effect on production behaviour. Reviewers can focus on the plugin code in isolation.

---

🔬 **SPIKE**: exploratory work for the multi-ecosystem migration shipped as a draft for early review.
