### PR TITLE
SPIKE: feat(cocoapods): add Podfile.lock parser and resolver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,10 @@ test-python-integration:
 test-gradle-integration:
 	$(GOTEST) -v -tags="integration,gradle" -timeout=15m ./pkg/ecosystems/gradle/ -coverprofile cp.out
 
+test-cocoapods-integration:
+	$(GOTEST) -v -tags="integration,cocoapods" -timeout=10m ./pkg/ecosystems/cocoa/cocoapods/ -coverprofile cp.out
+
 update-gradle-fixtures:
 	UPDATE_FIXTURES=1 $(GOTEST) -v -tags="integration,gradle" -timeout=15m ./pkg/ecosystems/gradle/
 
-.PHONY: install-req fmt test test-bazel-jvm-integration test-bazel-go-integration test-python-integration test-gradle-integration update-gradle-fixtures lint tidy imports install-golangci-lint
+.PHONY: install-req fmt test test-bazel-jvm-integration test-bazel-go-integration test-python-integration test-gradle-integration test-cocoapods-integration update-gradle-fixtures lint tidy imports install-golangci-lint

--- a/pkg/ecosystems/cocoa/cocoapods/depgraph.go
+++ b/pkg/ecosystems/cocoa/cocoapods/depgraph.go
@@ -1,0 +1,229 @@
+package cocoapods
+
+import (
+	"fmt"
+
+	"github.com/snyk/dep-graph/go/pkg/depgraph"
+)
+
+// Label keys preserved verbatim from @snyk/snyk-cocoapods-plugin so the
+// resulting dep-graphs are byte-compatible with the legacy plugin's
+// output. Downstream consumers (Snyk policy engine, vuln-DB lookups)
+// rely on these exact key names.
+const (
+	labelChecksum   = "checksum"
+	labelRepository = "repository"
+
+	labelExternalSourceGit     = "externalSourceGit"
+	labelExternalSourcePath    = "externalSourcePath"
+	labelExternalSourceTag     = "externalSourceTag"
+	labelExternalSourceCommit  = "externalSourceCommit"
+	labelExternalSourceBranch  = "externalSourceBranch"
+	labelExternalSourcePodspec = "externalSourcePodspec"
+
+	labelCheckoutOptionsGit     = "checkoutOptionsGit"
+	labelCheckoutOptionsPath    = "checkoutOptionsPath"
+	labelCheckoutOptionsTag     = "checkoutOptionsTag"
+	labelCheckoutOptionsCommit  = "checkoutOptionsCommit"
+	labelCheckoutOptionsBranch  = "checkoutOptionsBranch"
+	labelCheckoutOptionsPodspec = "checkoutOptionsPodspec"
+)
+
+// BuildDepGraph converts a parsed Podfile.lock into a Snyk dep-graph.
+//
+// Node identity = root spec name (the part before the first '/').
+// CocoaPods guarantees one resolved version per root spec, so subspecs
+// like AFNetworking/NSURLConnection collapse onto the AFNetworking node
+// — this matches the legacy plugin's `nodeIdForPkgInfo` strategy.
+//
+// rootName/rootVersion describe the project being scanned, not a pod.
+// Direct entries from DEPENDENCIES are attached to the root node;
+// transitive edges are inferred from each PODS entry's nested dep list.
+func BuildDepGraph(lock *Lockfile, rootName, rootVersion string) (*depgraph.DepGraph, error) {
+	if lock == nil {
+		return nil, fmt.Errorf("lockfile is nil")
+	}
+
+	pkgManager := &depgraph.PkgManager{
+		Name:         pkgManagerName,
+		Version:      lockfileCocoapodsVersion(lock),
+		Repositories: repositoriesFor(lock),
+	}
+
+	builder, err := depgraph.NewBuilder(pkgManager, &depgraph.PkgInfo{
+		Name:    rootName,
+		Version: rootVersion,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("creating dep graph builder: %w", err)
+	}
+	rootNodeID := builder.GetRootNode().NodeID
+
+	// Pass 1: add every PODS entry as a node keyed by root spec name.
+	// Multiple subspecs of the same root collapse onto the same node;
+	// the *first* PODS appearance wins for labels/version (the root
+	// spec entry itself is always emitted by CocoaPods first, so this
+	// is the right choice in practice).
+	//
+	// We also accumulate each node's outgoing edges as PkgInfo lists so
+	// the second pass can resolve them to node IDs after all nodes
+	// exist.
+	addedNodes := make(map[string]struct{}, len(lock.Pods))
+	allDeps := make(map[string][]PkgInfo, len(lock.Pods))
+
+	for _, entry := range lock.Pods {
+		spec, err := ParseSpecification(entry.Spec)
+		if err != nil {
+			return nil, fmt.Errorf("PODS entry: %w", err)
+		}
+		nodeID := RootSpecName(spec.Name)
+
+		if _, seen := addedNodes[nodeID]; !seen {
+			labels := labelsForPod(lock, spec.Name)
+			builder.AddNode(nodeID,
+				&depgraph.PkgInfo{Name: nodeID, Version: spec.Version},
+				depgraph.WithNodeInfo(&depgraph.NodeInfo{Labels: labels}),
+			)
+			addedNodes[nodeID] = struct{}{}
+		}
+
+		for _, depStr := range entry.Deps {
+			depInfo, err := ParseDependency(depStr)
+			if err != nil {
+				return nil, fmt.Errorf("PODS entry %q: %w", entry.Spec, err)
+			}
+			allDeps[nodeID] = append(allDeps[nodeID], depInfo)
+		}
+	}
+
+	// Pass 2: connect direct dependencies from the manifest
+	// (DEPENDENCIES section) to the root node.
+	for _, depStr := range lock.Dependencies {
+		depInfo, err := ParseDependency(depStr)
+		if err != nil {
+			return nil, fmt.Errorf("DEPENDENCIES entry: %w", err)
+		}
+		depNodeID := RootSpecName(depInfo.Name)
+		if _, ok := addedNodes[depNodeID]; !ok {
+			// Skip phantom direct deps that have no PODS entry. Real
+			// lockfiles always carry one, but tolerate gracefully so
+			// malformed input fails loud (later) rather than crashing.
+			continue
+		}
+		if err := builder.ConnectNodes(rootNodeID, depNodeID); err != nil {
+			return nil, fmt.Errorf("connecting root → %s: %w", depNodeID, err)
+		}
+	}
+
+	// Pass 3: connect transitive edges (one per PODS entry).
+	// Mirrors legacy behavior: edges pointing at pods without their
+	// own PODS entry are silently dropped (platform-specific subspecs
+	// not pulled in by this integration's targets).
+	for nodeID, deps := range allDeps {
+		for _, dep := range deps {
+			depNodeID := RootSpecName(dep.Name)
+			if depNodeID == nodeID {
+				// Subspec referencing its own root — would be a self-edge.
+				continue
+			}
+			if _, ok := addedNodes[depNodeID]; !ok {
+				continue
+			}
+			if err := builder.ConnectNodes(nodeID, depNodeID); err != nil {
+				return nil, fmt.Errorf("connecting %s → %s: %w", nodeID, depNodeID, err)
+			}
+		}
+	}
+
+	return builder.Build(), nil
+}
+
+// labelsForPod produces the NodeInfo labels for one pod, looking up the
+// checksum, optional repository, optional external source, and optional
+// checkout options by the pod's root spec name.
+//
+// Nil/empty values are omitted so the resulting label map round-trips
+// through JSON without producing explicit null fields (legacy plugin
+// strips nulls explicitly; we never insert them in the first place).
+// Returns nil rather than an empty map when no labels apply, so the
+// dep-graph JSON omits the "info" block entirely for plain pods.
+func labelsForPod(lock *Lockfile, podName string) map[string]string {
+	root := RootSpecName(podName)
+	labels := map[string]string{}
+
+	if cs := lock.SpecChecksums[root]; cs != "" {
+		labels[labelChecksum] = cs
+	}
+
+	if repo := repositoryForPod(lock, root); repo != "" {
+		labels[labelRepository] = repo
+	}
+
+	if ext, ok := lock.ExternalSources[root]; ok {
+		putIfSet(labels, labelExternalSourceGit, ext.Git)
+		putIfSet(labels, labelExternalSourcePath, ext.Path)
+		putIfSet(labels, labelExternalSourceTag, ext.Tag)
+		putIfSet(labels, labelExternalSourceCommit, ext.Commit)
+		putIfSet(labels, labelExternalSourceBranch, ext.Branch)
+		putIfSet(labels, labelExternalSourcePodspec, ext.Podspec)
+	}
+
+	if co, ok := lock.CheckoutOptions[root]; ok {
+		putIfSet(labels, labelCheckoutOptionsGit, co.Git)
+		putIfSet(labels, labelCheckoutOptionsPath, co.Path)
+		putIfSet(labels, labelCheckoutOptionsTag, co.Tag)
+		putIfSet(labels, labelCheckoutOptionsCommit, co.Commit)
+		putIfSet(labels, labelCheckoutOptionsBranch, co.Branch)
+		putIfSet(labels, labelCheckoutOptionsPodspec, co.Podspec)
+	}
+
+	if len(labels) == 0 {
+		return nil
+	}
+	return labels
+}
+
+func putIfSet(m map[string]string, key, value string) {
+	if value != "" {
+		m[key] = value
+	}
+}
+
+// repositoryForPod returns the SPEC REPOS key (name or URL) under which
+// the named pod is listed. Returns empty string if SPEC REPOS is absent
+// (older Podfile.lock) or the pod is not registered to any repo.
+func repositoryForPod(lock *Lockfile, rootName string) string {
+	for repo, pods := range lock.SpecRepos {
+		for _, p := range pods {
+			if p == rootName {
+				return repo
+			}
+		}
+	}
+	return ""
+}
+
+// repositoriesFor lifts the SPEC REPOS section keys into the dep-graph's
+// PkgManager.Repositories list. Order is not significant in the schema
+// and Go's map iteration is intentionally randomised — callers that
+// need deterministic ordering should sort on the consumer side. The
+// legacy TypeScript plugin had the same non-determinism.
+func repositoriesFor(lock *Lockfile) []depgraph.Repository {
+	if len(lock.SpecRepos) == 0 {
+		return nil
+	}
+	repos := make([]depgraph.Repository, 0, len(lock.SpecRepos))
+	for name := range lock.SpecRepos {
+		repos = append(repos, depgraph.Repository{Alias: name})
+	}
+	return repos
+}
+
+// lockfileCocoapodsVersion returns the COCOAPODS field or "unknown" when
+// the lockfile predates that section (CocoaPods began writing it in v1).
+func lockfileCocoapodsVersion(lock *Lockfile) string {
+	if lock.CocoapodsVersion == "" {
+		return defaultCocoapodsVersion
+	}
+	return lock.CocoapodsVersion
+}

--- a/pkg/ecosystems/cocoa/cocoapods/depgraph_test.go
+++ b/pkg/ecosystems/cocoa/cocoapods/depgraph_test.go
@@ -1,0 +1,295 @@
+package cocoapods
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/snyk/dep-graph/go/pkg/depgraph"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// nodeByID locates a node by its NodeID for assertions.
+func nodeByID(t *testing.T, g *depgraph.DepGraph, id string) *depgraph.Node {
+	t.Helper()
+	for i := range g.Graph.Nodes {
+		if g.Graph.Nodes[i].NodeID == id {
+			return &g.Graph.Nodes[i]
+		}
+	}
+	t.Fatalf("no node with ID %q", id)
+	return nil
+}
+
+func depNodeIDs(n *depgraph.Node) []string {
+	ids := make([]string, len(n.Deps))
+	for i, d := range n.Deps {
+		ids[i] = d.NodeID
+	}
+	return ids
+}
+
+func TestBuildDepGraph_Simple(t *testing.T) {
+	lock, err := ParseLockfile(strings.NewReader(simpleLockfile))
+	require.NoError(t, err)
+
+	g, err := BuildDepGraph(lock, "my-app", "0.0.0")
+	require.NoError(t, err)
+
+	assert.Equal(t, pkgManagerName, g.PkgManager.Name)
+	assert.Equal(t, "1.10.0", g.PkgManager.Version)
+	assert.Len(t, g.PkgManager.Repositories, 1)
+	assert.Equal(t, "trunk", g.PkgManager.Repositories[0].Alias)
+
+	root := nodeByID(t, g, "root-node")
+	assert.Equal(t, []string{"Reachability"}, depNodeIDs(root))
+
+	reach := nodeByID(t, g, "Reachability")
+	require.NotNil(t, reach.Info)
+	assert.Equal(t, "3c8fe9643e52184d17f207e781cd84158da8c02b", reach.Info.Labels[labelChecksum])
+	assert.Equal(t, "trunk", reach.Info.Labels[labelRepository])
+}
+
+// TestBuildDepGraph_SubspecDedup proves subspecs collapse onto their
+// root spec's node — AFNetworking/NSURLConnection and
+// AFNetworking/Security must not appear as separate nodes.
+func TestBuildDepGraph_SubspecDedup(t *testing.T) {
+	lock, err := ParseLockfile(strings.NewReader(withSubspecsLockfile))
+	require.NoError(t, err)
+
+	g, err := BuildDepGraph(lock, "my-app", "0.0.0")
+	require.NoError(t, err)
+
+	// Only one AFNetworking node (the root spec) — the two subspecs
+	// dedupe onto it.
+	count := 0
+	for _, n := range g.Graph.Nodes {
+		if n.NodeID == "AFNetworking" {
+			count++
+		}
+	}
+	assert.Equal(t, 1, count, "subspecs must not produce duplicate nodes")
+
+	// No subspec node should leak out as its own dep graph node.
+	for _, n := range g.Graph.Nodes {
+		assert.NotContains(t, n.NodeID, "/", "subspecs must dedupe onto root spec name")
+	}
+
+	root := nodeByID(t, g, "root-node")
+	assert.Equal(t, []string{"AFNetworking"}, depNodeIDs(root))
+
+	// AFNetworking → AFNetworking subspec edges are self-edges after
+	// dedup and must be elided.
+	af := nodeByID(t, g, "AFNetworking")
+	assert.Empty(t, af.Deps, "self-edges from subspec collapse must be dropped")
+}
+
+func TestBuildDepGraph_LabelsPreserved_ExternalSourcesAndCheckout(t *testing.T) {
+	const lockfile = `PODS:
+  - Just (0.6.0)
+
+DEPENDENCIES:
+  - Just
+
+EXTERNAL SOURCES:
+  Just:
+    :branch: swift-5
+    :git: https://github.com/iina/Just
+
+CHECKOUT OPTIONS:
+  Just:
+    :commit: d0ae3f9bc2d6bf247b19217764a096bbac55f007
+    :git: https://github.com/iina/Just
+
+SPEC CHECKSUMS:
+  Just: abc
+
+COCOAPODS: 1.10.0
+`
+	lock, err := ParseLockfile(strings.NewReader(lockfile))
+	require.NoError(t, err)
+
+	g, err := BuildDepGraph(lock, "my-app", "0.0.0")
+	require.NoError(t, err)
+
+	just := nodeByID(t, g, "Just")
+	require.NotNil(t, just.Info)
+	labels := just.Info.Labels
+
+	// Exact label keys preserved from the legacy plugin.
+	assert.Equal(t, "abc", labels[labelChecksum])
+	assert.Equal(t, "https://github.com/iina/Just", labels[labelExternalSourceGit])
+	assert.Equal(t, "swift-5", labels[labelExternalSourceBranch])
+	assert.Equal(t, "https://github.com/iina/Just", labels[labelCheckoutOptionsGit])
+	assert.Equal(t, "d0ae3f9bc2d6bf247b19217764a096bbac55f007", labels[labelCheckoutOptionsCommit])
+
+	// Unset fields must NOT show up as empty-string labels.
+	_, hasTag := labels[labelExternalSourceTag]
+	assert.False(t, hasTag, "empty ExternalSourceTag must be omitted, not stored as empty string")
+}
+
+// TestBuildDepGraph_LabelsAbsentForPlainPod confirms that pods without
+// repository, external source, or checkout options carry only the
+// checksum label — no nulls, no empty strings.
+func TestBuildDepGraph_LabelsAbsentForPlainPod(t *testing.T) {
+	const lockfile = `PODS:
+  - Foo (1.0.0)
+
+DEPENDENCIES:
+  - Foo
+
+SPEC CHECKSUMS:
+  Foo: 0fffffff
+`
+	lock, err := ParseLockfile(strings.NewReader(lockfile))
+	require.NoError(t, err)
+
+	g, err := BuildDepGraph(lock, "app", "0.0.0")
+	require.NoError(t, err)
+
+	foo := nodeByID(t, g, "Foo")
+	require.NotNil(t, foo.Info)
+	assert.Equal(t, map[string]string{labelChecksum: "0fffffff"}, foo.Info.Labels)
+}
+
+func TestBuildDepGraph_VersionExtraction(t *testing.T) {
+	const lockfile = `PODS:
+  - Foo (1.2.3)
+  - Bar (4.5.6)
+
+DEPENDENCIES:
+  - Foo (= 1.2.3)
+  - Bar
+
+SPEC CHECKSUMS:
+  Foo: aa
+  Bar: bb
+
+COCOAPODS: 1.16.2
+`
+	lock, err := ParseLockfile(strings.NewReader(lockfile))
+	require.NoError(t, err)
+
+	g, err := BuildDepGraph(lock, "app", "0.0.0")
+	require.NoError(t, err)
+
+	assert.Equal(t, "1.16.2", g.PkgManager.Version)
+
+	foo := nodeByID(t, g, "Foo")
+	var fooPkg *depgraph.Pkg
+	for i := range g.Pkgs {
+		if g.Pkgs[i].ID == foo.PkgID {
+			fooPkg = &g.Pkgs[i]
+			break
+		}
+	}
+	require.NotNil(t, fooPkg)
+	assert.Equal(t, "1.2.3", fooPkg.Info.Version)
+}
+
+// TestBuildDepGraph_CocoapodsVersionFallback asserts that a lockfile
+// missing the COCOAPODS field reports "unknown" — matches legacy.
+func TestBuildDepGraph_CocoapodsVersionFallback(t *testing.T) {
+	const lockfile = `PODS:
+  - Foo (1.0.0)
+
+DEPENDENCIES:
+  - Foo
+
+SPEC CHECKSUMS:
+  Foo: abc
+`
+	lock, err := ParseLockfile(strings.NewReader(lockfile))
+	require.NoError(t, err)
+
+	g, err := BuildDepGraph(lock, "app", "0.0.0")
+	require.NoError(t, err)
+	assert.Equal(t, defaultCocoapodsVersion, g.PkgManager.Version)
+}
+
+// TestBuildDepGraph_TransitiveEdgesPointAtRoot confirms that a
+// transitive edge pointing at a subspec is rewritten to the subspec's
+// root, matching the dedup strategy.
+func TestBuildDepGraph_TransitiveEdgesPointAtRoot(t *testing.T) {
+	const lockfile = `PODS:
+  - AFOAuth1Client (0.4.0):
+    - AFNetworking (~> 2.5)
+  - AFNetworking (2.5.4):
+    - AFNetworking/NSURLConnection (= 2.5.4)
+  - AFNetworking/NSURLConnection (2.5.4)
+
+DEPENDENCIES:
+  - AFOAuth1Client
+
+SPEC CHECKSUMS:
+  AFOAuth1Client: aa
+  AFNetworking: bb
+`
+	lock, err := ParseLockfile(strings.NewReader(lockfile))
+	require.NoError(t, err)
+
+	g, err := BuildDepGraph(lock, "app", "0.0.0")
+	require.NoError(t, err)
+
+	client := nodeByID(t, g, "AFOAuth1Client")
+	assert.Equal(t, []string{"AFNetworking"}, depNodeIDs(client),
+		"transitive dep on AFNetworking must connect to the deduped root node")
+}
+
+// TestBuildDepGraph_DroppedEdgesToMissingPods verifies the legacy
+// behaviour that transitive edges pointing at pods which never appear
+// in PODS (platform-specific subspecs) are silently dropped rather
+// than fabricated.
+func TestBuildDepGraph_DroppedEdgesToMissingPods(t *testing.T) {
+	const lockfile = `PODS:
+  - Foo (1.0.0):
+    - GhostDep
+  - Foo/Sub (1.0.0)
+
+DEPENDENCIES:
+  - Foo
+
+SPEC CHECKSUMS:
+  Foo: abc
+`
+	lock, err := ParseLockfile(strings.NewReader(lockfile))
+	require.NoError(t, err)
+
+	g, err := BuildDepGraph(lock, "app", "0.0.0")
+	require.NoError(t, err)
+
+	foo := nodeByID(t, g, "Foo")
+	for _, dep := range foo.Deps {
+		assert.NotEqual(t, "GhostDep", dep.NodeID, "missing pods must be dropped, not fabricated")
+	}
+}
+
+// TestBuildDepGraph_RepositoriesMatchSpecRepoKeys ensures all SPEC
+// REPOS keys (whether name or URL) appear as PkgManager repositories.
+func TestBuildDepGraph_RepositoriesMatchSpecRepoKeys(t *testing.T) {
+	const lockfile = `PODS:
+  - GzipSwift (5.1.1)
+
+DEPENDENCIES:
+  - GzipSwift
+
+SPEC REPOS:
+  https://github.com/cocoapods/specs.git:
+    - GzipSwift
+
+SPEC CHECKSUMS:
+  GzipSwift: abc
+`
+	lock, err := ParseLockfile(strings.NewReader(lockfile))
+	require.NoError(t, err)
+
+	g, err := BuildDepGraph(lock, "app", "0.0.0")
+	require.NoError(t, err)
+
+	require.Len(t, g.PkgManager.Repositories, 1)
+	assert.Equal(t, "https://github.com/cocoapods/specs.git", g.PkgManager.Repositories[0].Alias)
+
+	g2 := nodeByID(t, g, "GzipSwift")
+	require.NotNil(t, g2.Info)
+	assert.Equal(t, "https://github.com/cocoapods/specs.git", g2.Info.Labels[labelRepository])
+}

--- a/pkg/ecosystems/cocoa/cocoapods/parser.go
+++ b/pkg/ecosystems/cocoa/cocoapods/parser.go
@@ -1,0 +1,177 @@
+package cocoapods
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"regexp"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// specRe matches a pod specification or dependency string. Group 1 is
+// the name, group 2 (optional) is the parenthesised version or version
+// requirement. Mirrors the regex in @snyk/snyk-cocoapods-plugin/utils.ts
+// so identity (name extracted from specs) matches the legacy plugin.
+//
+// Examples it must accept:
+//
+//	"Adjust (4.17.1)"
+//	"Adjust/Core (4.17.1)"
+//	"ReactiveObjC (~> 2.0)"
+//	"AFNetworking/NSURLConnection (= 2.5.4)"
+//	"Pulley (from `https://github.com/l2succes/Pulley.git`, branch `master`)"
+//	"Expecta"                                — no version
+//	"Artsy+UIColors (3.1.0)"                — '+' is part of the name
+var specRe = regexp.MustCompile(`^((?:\s?[^\s(])+)(?: \((.+)\))?$`)
+
+// fromRequirementRe matches the "from `...`"  form a Podfile dependency
+// uses to point at an external source. When the version-like field is
+// actually a from-clause the dependency carries no resolved version, so
+// the parser drops it (matches legacy behaviour in utils.ts).
+var fromRequirementRe = regexp.MustCompile("from `(.*)(`|')")
+
+// PkgInfo is the (name, version) pair extracted from a specification or
+// dependency string. version may be empty when the string had no
+// parenthesised tail or when the tail was a "from `...`" clause.
+type PkgInfo struct {
+	Name    string
+	Version string
+}
+
+// ParseSpecification parses a string like "AFNetworking/NSURLConnection (2.5.4)"
+// from the PODS section. The version inside parens is the resolved
+// version of the pod; it is always present for PODS entries (CocoaPods
+// guarantees resolved versions in the lockfile).
+func ParseSpecification(s string) (PkgInfo, error) {
+	m := specRe.FindStringSubmatch(s)
+	if m == nil {
+		return PkgInfo{}, fmt.Errorf("invalid pod specification %q", s)
+	}
+	return PkgInfo{Name: m[1], Version: m[2]}, nil
+}
+
+// ParseDependency parses a string from the DEPENDENCIES section or from
+// a nested dep list under a PODS entry. The version field of the result
+// holds the *requirement* (e.g. "~> 2.0", "= 4.17.1") rather than a
+// resolved version, and is empty when the tail is missing entirely or
+// when it is a "from `...`" clause pointing at an external source.
+func ParseDependency(s string) (PkgInfo, error) {
+	m := specRe.FindStringSubmatch(s)
+	if m == nil {
+		return PkgInfo{}, fmt.Errorf("invalid pod dependency %q", s)
+	}
+	name, ver := m[1], m[2]
+	if ver == "" || fromRequirementRe.MatchString(ver) {
+		return PkgInfo{Name: name}, nil
+	}
+	return PkgInfo{Name: name, Version: ver}, nil
+}
+
+// RootSpecName returns the leading path segment of a pod name. Subspecs
+// are addressed as "Root/Sub" in Podfile.lock — CocoaPods guarantees
+// each root spec resolves to exactly one version, so the root name is a
+// stable node identifier across all of its subspecs.
+//
+//	"AFNetworking/NSURLConnection" → "AFNetworking"
+//	"AFNetworking"                  → "AFNetworking"
+func RootSpecName(name string) string {
+	if i := strings.Index(name, "/"); i > 0 {
+		return name[:i]
+	}
+	return name
+}
+
+// ParseLockfile reads YAML from r and produces a Lockfile. It uses a
+// two-step decode because PODS entries are heterogeneous (either a bare
+// string or a single-key map) and a single Go struct cannot express
+// that without an interface field; decoding via yaml.Node lets us
+// inspect the shape per-element. Identical pattern to the TS parser's
+// `if (typeof elem === 'string') { ... } else { ... }` branching.
+func ParseLockfile(r io.Reader) (*Lockfile, error) {
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return nil, fmt.Errorf("reading Podfile.lock: %w", err)
+	}
+
+	// Decode the PODS section as yaml.Node so we can branch on element
+	// kind, then decode everything else into the typed Lockfile.
+	var raw struct {
+		Pods             yaml.Node                  `yaml:"PODS"`
+		Dependencies     []string                   `yaml:"DEPENDENCIES"`
+		SpecRepos        map[string][]string        `yaml:"SPEC REPOS,omitempty"`
+		ExternalSources  map[string]ExternalSource  `yaml:"EXTERNAL SOURCES,omitempty"`
+		CheckoutOptions  map[string]CheckoutOptions `yaml:"CHECKOUT OPTIONS,omitempty"`
+		SpecChecksums    map[string]string          `yaml:"SPEC CHECKSUMS"`
+		PodfileChecksum  string                     `yaml:"PODFILE CHECKSUM,omitempty"`
+		CocoapodsVersion string                     `yaml:"COCOAPODS,omitempty"`
+	}
+
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		return nil, fmt.Errorf("parsing Podfile.lock YAML: %w", err)
+	}
+
+	pods, err := decodePods(&raw.Pods)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Lockfile{
+		Pods:             pods,
+		Dependencies:     raw.Dependencies,
+		SpecRepos:        raw.SpecRepos,
+		ExternalSources:  raw.ExternalSources,
+		CheckoutOptions:  raw.CheckoutOptions,
+		SpecChecksums:    raw.SpecChecksums,
+		PodfileChecksum:  raw.PodfileChecksum,
+		CocoapodsVersion: raw.CocoapodsVersion,
+	}, nil
+}
+
+// decodePods converts the heterogeneous PODS sequence into typed
+// PodEntry values. Each element is either a scalar (no deps) or a
+// single-key map whose value is the list of dependency strings.
+func decodePods(n *yaml.Node) ([]PodEntry, error) {
+	if n == nil || n.Kind == 0 {
+		return nil, nil
+	}
+	if n.Kind != yaml.SequenceNode {
+		return nil, fmt.Errorf("PODS: expected sequence, got kind %d", n.Kind)
+	}
+
+	out := make([]PodEntry, 0, len(n.Content))
+	for i, elem := range n.Content {
+		switch elem.Kind {
+		case yaml.ScalarNode:
+			out = append(out, PodEntry{Spec: elem.Value})
+
+		case yaml.MappingNode:
+			if len(elem.Content) != 2 {
+				return nil, fmt.Errorf("PODS[%d]: expected single-key map, got %d entries", i, len(elem.Content)/2)
+			}
+			keyNode, valNode := elem.Content[0], elem.Content[1]
+			var deps []string
+			if err := valNode.Decode(&deps); err != nil {
+				return nil, fmt.Errorf("PODS[%d] (%s): decoding dependency list: %w", i, keyNode.Value, err)
+			}
+			out = append(out, PodEntry{Spec: keyNode.Value, Deps: deps})
+
+		default:
+			return nil, fmt.Errorf("PODS[%d]: unsupported YAML kind %d", i, elem.Kind)
+		}
+	}
+
+	return out, nil
+}
+
+// ReadLockfile reads and parses a Podfile.lock from disk.
+func ReadLockfile(path string) (*Lockfile, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("opening %s: %w", path, err)
+	}
+	defer f.Close()
+
+	return ParseLockfile(f)
+}

--- a/pkg/ecosystems/cocoa/cocoapods/parser_test.go
+++ b/pkg/ecosystems/cocoa/cocoapods/parser_test.go
@@ -1,0 +1,278 @@
+package cocoapods
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseSpecification(t *testing.T) {
+	cases := []struct {
+		in       string
+		wantName string
+		wantVer  string
+		wantErr  bool
+	}{
+		{in: "Adjust (4.17.1)", wantName: "Adjust", wantVer: "4.17.1"},
+		{in: "Adjust/Core (4.17.1)", wantName: "Adjust/Core", wantVer: "4.17.1"},
+		{in: "Artsy+UIColors (3.1.0)", wantName: "Artsy+UIColors", wantVer: "3.1.0"},
+		{in: "AFNetworking/NSURLConnection (2.5.4)", wantName: "AFNetworking/NSURLConnection", wantVer: "2.5.4"},
+		{in: "Expecta (1.0.5)", wantName: "Expecta", wantVer: "1.0.5"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			got, err := ParseSpecification(tc.in)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantName, got.Name)
+			assert.Equal(t, tc.wantVer, got.Version)
+		})
+	}
+}
+
+func TestParseDependency(t *testing.T) {
+	cases := []struct {
+		in       string
+		wantName string
+		wantVer  string
+	}{
+		{in: "Expecta", wantName: "Expecta", wantVer: ""},
+		{in: "ReactiveObjC (~> 2.0)", wantName: "ReactiveObjC", wantVer: "~> 2.0"},
+		{in: "AFNetworking/NSURLConnection (= 2.5.4)", wantName: "AFNetworking/NSURLConnection", wantVer: "= 2.5.4"},
+		{
+			in:       "Pulley (from `https://github.com/l2succes/Pulley.git`, branch `master`)",
+			wantName: "Pulley",
+			wantVer:  "", // "from ..." clauses are dropped — there's no resolved requirement.
+		},
+		{
+			in:       "Silica (from `https://github.com/ianyh/Silica.git`, tag `0.1.5`)",
+			wantName: "Silica",
+			wantVer:  "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			got, err := ParseDependency(tc.in)
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantName, got.Name)
+			assert.Equal(t, tc.wantVer, got.Version)
+		})
+	}
+}
+
+func TestRootSpecName(t *testing.T) {
+	cases := map[string]string{
+		"AFNetworking":                  "AFNetworking",
+		"AFNetworking/NSURLConnection":  "AFNetworking",
+		"React/Core":                    "React",
+		"React-Native/Core/Subspec":     "React-Native",
+		"Artsy+UIColors":                "Artsy+UIColors",
+	}
+	for in, want := range cases {
+		t.Run(in, func(t *testing.T) {
+			assert.Equal(t, want, RootSpecName(in))
+		})
+	}
+}
+
+const simpleLockfile = `PODS:
+  - Reachability (3.1.0)
+
+DEPENDENCIES:
+  - Reachability (= 3.1.0)
+
+SPEC REPOS:
+  trunk:
+    - Reachability
+
+SPEC CHECKSUMS:
+  Reachability: 3c8fe9643e52184d17f207e781cd84158da8c02b
+
+COCOAPODS: 1.10.0
+`
+
+func TestParseLockfile_Simple(t *testing.T) {
+	lock, err := ParseLockfile(strings.NewReader(simpleLockfile))
+	require.NoError(t, err)
+
+	require.Len(t, lock.Pods, 1)
+	assert.Equal(t, "Reachability (3.1.0)", lock.Pods[0].Spec)
+	assert.Empty(t, lock.Pods[0].Deps)
+
+	assert.Equal(t, []string{"Reachability (= 3.1.0)"}, lock.Dependencies)
+	assert.Equal(t, "1.10.0", lock.CocoapodsVersion)
+	assert.Equal(t, "3c8fe9643e52184d17f207e781cd84158da8c02b", lock.SpecChecksums["Reachability"])
+	assert.Equal(t, []string{"Reachability"}, lock.SpecRepos["trunk"])
+}
+
+const withSubspecsLockfile = `PODS:
+  - AFNetworking (2.5.4):
+    - AFNetworking/NSURLConnection (= 2.5.4)
+    - AFNetworking/Security (= 2.5.4)
+  - AFNetworking/NSURLConnection (2.5.4):
+    - AFNetworking/Security
+  - AFNetworking/Security (2.5.4)
+
+DEPENDENCIES:
+  - AFNetworking (~> 2.5)
+
+SPEC CHECKSUMS:
+  AFNetworking: deadbeef
+
+COCOAPODS: 1.10.0
+`
+
+func TestParseLockfile_WithSubspecs(t *testing.T) {
+	lock, err := ParseLockfile(strings.NewReader(withSubspecsLockfile))
+	require.NoError(t, err)
+
+	require.Len(t, lock.Pods, 3)
+	assert.Equal(t, "AFNetworking (2.5.4)", lock.Pods[0].Spec)
+	assert.Len(t, lock.Pods[0].Deps, 2, "AFNetworking has two subspec deps in the fixture")
+	assert.Equal(t, "AFNetworking/NSURLConnection (= 2.5.4)", lock.Pods[0].Deps[0])
+
+	// Bare leaf
+	assert.Equal(t, "AFNetworking/Security (2.5.4)", lock.Pods[2].Spec)
+	assert.Empty(t, lock.Pods[2].Deps)
+}
+
+const withExternalSourcesLockfile = `PODS:
+  - Silica (0.1.5)
+
+DEPENDENCIES:
+  - Silica (from ` + "`https://github.com/ianyh/Silica.git`" + `, tag ` + "`0.1.5`" + `)
+
+EXTERNAL SOURCES:
+  Silica:
+    :git: https://github.com/ianyh/Silica.git
+    :tag: 0.1.5
+
+SPEC CHECKSUMS:
+  Silica: 3b5a774469476ef84fe9d96a63bfe09908654e50
+
+COCOAPODS: 1.3.1
+`
+
+func TestParseLockfile_WithExternalSources(t *testing.T) {
+	lock, err := ParseLockfile(strings.NewReader(withExternalSourcesLockfile))
+	require.NoError(t, err)
+
+	ext, ok := lock.ExternalSources["Silica"]
+	require.True(t, ok, "ExternalSources[Silica] should be present")
+	assert.Equal(t, "https://github.com/ianyh/Silica.git", ext.Git)
+	assert.Equal(t, "0.1.5", ext.Tag)
+	assert.Empty(t, ext.Branch)
+}
+
+const withCheckoutOptionsLockfile = `PODS:
+  - Just (0.6.0)
+
+DEPENDENCIES:
+  - Just
+
+EXTERNAL SOURCES:
+  Just:
+    :branch: swift-5
+    :git: https://github.com/iina/Just
+
+CHECKOUT OPTIONS:
+  Just:
+    :commit: d0ae3f9bc2d6bf247b19217764a096bbac55f007
+    :git: https://github.com/iina/Just
+
+SPEC CHECKSUMS:
+  Just: abc
+
+COCOAPODS: 1.10.0
+`
+
+func TestParseLockfile_WithCheckoutOptions(t *testing.T) {
+	lock, err := ParseLockfile(strings.NewReader(withCheckoutOptionsLockfile))
+	require.NoError(t, err)
+
+	co, ok := lock.CheckoutOptions["Just"]
+	require.True(t, ok)
+	assert.Equal(t, "d0ae3f9bc2d6bf247b19217764a096bbac55f007", co.Commit)
+	assert.Equal(t, "https://github.com/iina/Just", co.Git)
+	assert.Empty(t, co.Tag)
+}
+
+// TestParseLockfile_MissingOptionalSections asserts that older lockfiles
+// (no SPEC REPOS / EXTERNAL SOURCES / CHECKOUT OPTIONS / PODFILE
+// CHECKSUM / COCOAPODS) parse without error and leave those fields nil
+// or empty.
+func TestParseLockfile_MissingOptionalSections(t *testing.T) {
+	const lockfile = `PODS:
+  - Foo (1.0.0)
+
+DEPENDENCIES:
+  - Foo
+
+SPEC CHECKSUMS:
+  Foo: abc
+`
+	lock, err := ParseLockfile(strings.NewReader(lockfile))
+	require.NoError(t, err)
+	assert.Empty(t, lock.SpecRepos)
+	assert.Empty(t, lock.ExternalSources)
+	assert.Empty(t, lock.CheckoutOptions)
+	assert.Empty(t, lock.PodfileChecksum)
+	assert.Empty(t, lock.CocoapodsVersion)
+}
+
+func TestParseLockfile_PodfileChecksum(t *testing.T) {
+	const lockfile = `PODS:
+  - Foo (1.0.0)
+
+DEPENDENCIES:
+  - Foo
+
+SPEC CHECKSUMS:
+  Foo: abc
+
+PODFILE CHECKSUM: 56045e819fdcab3669f1847a1bc88e6702accf51
+
+COCOAPODS: 1.10.0
+`
+	lock, err := ParseLockfile(strings.NewReader(lockfile))
+	require.NoError(t, err)
+	assert.Equal(t, "56045e819fdcab3669f1847a1bc88e6702accf51", lock.PodfileChecksum)
+}
+
+// TestParseLockfile_QuotedPodNames covers pod names that need to be
+// quoted in YAML because they contain a "+" or other punctuation. The
+// quotes themselves are stripped by the YAML decoder; the spec string
+// we keep is the raw "Name (version)".
+func TestParseLockfile_QuotedPodNames(t *testing.T) {
+	const lockfile = `PODS:
+  - "Artsy+UIColors (3.1.0)"
+  - "Artsy+UIFonts (3.3.3)"
+
+DEPENDENCIES:
+  - "Artsy+UIColors"
+
+SPEC CHECKSUMS:
+  "Artsy+UIColors": abc
+  "Artsy+UIFonts": def
+`
+	lock, err := ParseLockfile(strings.NewReader(lockfile))
+	require.NoError(t, err)
+
+	require.Len(t, lock.Pods, 2)
+	assert.Equal(t, "Artsy+UIColors (3.1.0)", lock.Pods[0].Spec)
+
+	got, err := ParseSpecification(lock.Pods[0].Spec)
+	require.NoError(t, err)
+	assert.Equal(t, "Artsy+UIColors", got.Name)
+	assert.Equal(t, "3.1.0", got.Version)
+}
+
+func TestParseLockfile_InvalidYAML(t *testing.T) {
+	_, err := ParseLockfile(strings.NewReader("this is not yaml: ][{"))
+	require.Error(t, err)
+}

--- a/pkg/ecosystems/cocoa/cocoapods/plugin.go
+++ b/pkg/ecosystems/cocoa/cocoapods/plugin.go
@@ -1,0 +1,289 @@
+// Package cocoapods is an SCAPlugin that resolves a project's pod
+// dependency graph by natively parsing Podfile.lock.
+//
+// CocoaPods' own CLI is macOS-only (Ruby + the cocoapods gem) and its
+// graph-producing subcommands (`pod install`, `pod update`) mutate the
+// project's `Pods/` directory. Both properties violate the SCA plugin
+// principles (offline, install-free, cross-platform), so this plugin
+// reads Podfile.lock directly — the lockfile is YAML with a stable
+// schema (PODS / DEPENDENCIES / SPEC REPOS / EXTERNAL SOURCES /
+// CHECKOUT OPTIONS / SPEC CHECKSUMS / COCOAPODS / PODFILE CHECKSUM).
+//
+// Identity, label keys, and subspec deduplication match the legacy
+// @snyk/snyk-cocoapods-plugin TypeScript implementation exactly.
+package cocoapods
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/discovery"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/logger"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/identity"
+)
+
+const logFieldLockFile = "lockFile"
+
+// Plugin implements ecosystems.SCAPlugin for CocoaPods projects.
+type Plugin struct{}
+
+// Compile-time check that Plugin implements the SCAPlugin interface.
+var _ ecosystems.SCAPlugin = (*Plugin)(nil)
+
+// GetName returns the plugin's stable identifier ("cocoapods").
+func (p Plugin) GetName() string { return PluginName }
+
+// BuildDepGraphsFromDir discovers Podfile.lock files under dir and emits
+// one SCAResult per lockfile via onGraph. CocoaPods is single-project
+// per Podfile.lock (no workspace concept) so each lockfile produces
+// exactly one dep graph.
+//
+// Discovery honors:
+//   - --target-file: only when it points at a Podfile.lock (or a
+//     companion manifest in the same directory; we resolve to the
+//     adjacent Podfile.lock).
+//   - --all-projects: scans recursively, skipping common excludes
+//     (node_modules, .git, etc.) plus any user-supplied --exclude /
+//     --exclude-paths globs.
+//   - default: probes only the root directory's Podfile.lock.
+//
+// Discovery never recurses into `Pods/`: that directory is a CocoaPods
+// install artefact and would yield duplicate sub-lockfiles for vendored
+// pods that already appear in the parent lockfile.
+func (p Plugin) BuildDepGraphsFromDir(
+	ctx context.Context,
+	log logger.Logger,
+	dir string,
+	options *ecosystems.SCAPluginOptions,
+	onGraph ecosystems.OnGraphFunc,
+) error {
+	if log == nil {
+		log = logger.Nop()
+	}
+
+	files, err := p.discoverLockFiles(ctx, dir, options)
+	if err != nil {
+		return err
+	}
+
+	if len(files) == 0 {
+		log.Debug(ctx, "No Podfile.lock files found", logger.Attr("dir", dir))
+		return nil
+	}
+
+	log.Debug(ctx, "Discovered Podfile.lock files", logger.Attr("count", len(files)))
+
+	for _, file := range files {
+		result := p.buildResult(ctx, log, file.Path, file.RelPath)
+		if err := onGraph(result); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// buildResult parses one Podfile.lock and returns the SCAResult to emit.
+// On any error the result is returned with Error set rather than aborting
+// the whole run — this matches the SCAPlugin contract (per-graph build
+// failures surface via onGraph, not as the BuildDepGraphsFromDir return).
+func (p Plugin) buildResult(
+	ctx context.Context,
+	log logger.Logger,
+	lockfileAbs, lockfileRel string,
+) ecosystems.SCAResult {
+	lockfileDir := filepath.Dir(lockfileAbs)
+	relLockDir := filepath.Dir(lockfileRel)
+
+	// Resolve the project's target file. Prefer a Podfile-style
+	// manifest in the same directory (legacy plugin priority order);
+	// fall back to the lockfile itself when none exists.
+	targetRel := lockfileRel
+	if name, ok := findManifestFile(lockfileDir); ok {
+		targetRel = filepath.Join(relLockDir, name)
+	}
+
+	rootName := filepath.Base(lockfileDir)
+	processed := []string{lockfileRel}
+	if targetRel != lockfileRel {
+		processed = append(processed, targetRel)
+	}
+
+	errResult := func(err error) ecosystems.SCAResult {
+		tf := targetRel
+		return ecosystems.SCAResult{
+			ProjectDescriptor: identity.ProjectDescriptor{
+				Identity: identity.ProjectIdentity{
+					ProjectType: pkgManagerName,
+					TargetFile:  &tf,
+				},
+			},
+			ResolverMetadata: &ecosystems.ResolverMetadata{
+				PluginName:           PluginName,
+				NormalisedTargetFile: tf,
+			},
+			ProcessedFiles: processed,
+			Error:          err,
+		}
+	}
+
+	log.Info(ctx, "Building cocoapods dependency graph", logger.Attr(logFieldLockFile, lockfileRel))
+
+	lock, err := ReadLockfile(lockfileAbs)
+	if err != nil {
+		log.Error(ctx, "Failed to read Podfile.lock", logger.Attr(logFieldLockFile, lockfileRel), logger.Err(err))
+		return errResult(err)
+	}
+
+	graph, err := BuildDepGraph(lock, rootName, defaultRootVersion)
+	if err != nil {
+		log.Error(ctx, "Failed to build cocoapods dep graph", logger.Attr(logFieldLockFile, lockfileRel), logger.Err(err))
+		return errResult(fmt.Errorf("building dep graph: %w", err))
+	}
+
+	log.Info(ctx, "Successfully built cocoapods dependency graph",
+		logger.Attr(logFieldLockFile, lockfileRel),
+		logger.Attr("pods", len(lock.Pods)),
+	)
+
+	tf := targetRel
+	return ecosystems.SCAResult{
+		DepGraph: graph,
+		ProjectDescriptor: identity.ProjectDescriptor{
+			Identity: identity.ProjectIdentity{
+				ProjectType:       pkgManagerName,
+				TargetFile:        &tf,
+				RootComponentName: rootName,
+			},
+		},
+		ResolverMetadata: &ecosystems.ResolverMetadata{
+			PluginName:           PluginName,
+			VersionBuildInfo:     map[string]string{},
+			NormalisedTargetFile: tf,
+		},
+		ProcessedFiles: processed,
+	}
+}
+
+// findManifestFile probes the lockfile directory for a Podfile-style
+// manifest in the legacy plugin's priority order:
+//
+//	CocoaPods.podfile.yaml → CocoaPods.podfile → Podfile → Podfile.rb
+//
+// Returns the first one found; ok=false means none exist (the lockfile
+// itself becomes the TargetFile).
+func findManifestFile(dir string) (string, bool) {
+	for _, name := range manifestPriority {
+		if fileExists(filepath.Join(dir, name)) {
+			return name, true
+		}
+	}
+	return "", false
+}
+
+func fileExists(p string) bool {
+	info, err := os.Stat(p)
+	return err == nil && !info.IsDir()
+}
+
+// discoverLockFiles resolves the Podfile.lock file(s) to scan based on
+// the requested options (target-file, all-projects, or default
+// root-only).
+func (p Plugin) discoverLockFiles(
+	ctx context.Context,
+	dir string,
+	options *ecosystems.SCAPluginOptions,
+) ([]discovery.FindResult, error) {
+	if options == nil {
+		options = ecosystems.NewPluginOptions()
+	}
+
+	switch {
+	case options.Global.TargetFile != nil:
+		return p.discoverFromTargetFile(ctx, dir, *options.Global.TargetFile)
+
+	case options.Global.AllProjects:
+		return p.discoverAllProjects(ctx, dir, options)
+
+	default:
+		rootLock := filepath.Join(dir, lockfileName)
+		if !fileExists(rootLock) {
+			return nil, nil
+		}
+		return []discovery.FindResult{{Path: rootLock, RelPath: lockfileName}}, nil
+	}
+}
+
+// discoverFromTargetFile handles --target-file by accepting either a
+// Podfile.lock or a manifest filename. When the user points at a
+// manifest, we look up the sibling Podfile.lock — the lockfile is what
+// we actually parse, but the manifest is a legitimate way to identify a
+// CocoaPods project.
+func (p Plugin) discoverFromTargetFile(
+	ctx context.Context,
+	dir, targetFile string,
+) ([]discovery.FindResult, error) {
+	base := filepath.Base(targetFile)
+	if base == lockfileName {
+		files, err := discovery.FindFiles(ctx, dir, discovery.WithTargetFile(targetFile))
+		if err != nil {
+			return nil, fmt.Errorf("discovering Podfile.lock: %w", err)
+		}
+		return files, nil
+	}
+
+	// Manifest-style target file: only valid if it's one of the
+	// recognised Podfile variants. Otherwise return empty (signal to
+	// the orchestrator that this plugin doesn't handle this file).
+	if !isPodfileManifest(base) {
+		return nil, nil
+	}
+
+	companion := filepath.Join(filepath.Dir(targetFile), lockfileName)
+	files, err := discovery.FindFiles(ctx, dir, discovery.WithTargetFile(companion))
+	if err != nil {
+		return nil, fmt.Errorf("discovering companion Podfile.lock: %w", err)
+	}
+	return files, nil
+}
+
+func isPodfileManifest(name string) bool {
+	for _, m := range manifestPriority {
+		if name == m {
+			return true
+		}
+	}
+	return false
+}
+
+// discoverAllProjects walks the directory tree for Podfile.lock files,
+// skipping common excludes plus any user-supplied --exclude /
+// --exclude-paths globs, and the CocoaPods install directory `Pods/`
+// (which can contain its own Manifest.lock that would otherwise be
+// picked up by an unsuspecting glob).
+func (p Plugin) discoverAllProjects(
+	ctx context.Context,
+	dir string,
+	options *ecosystems.SCAPluginOptions,
+) ([]discovery.FindResult, error) {
+	findOpts := []discovery.FindOption{
+		discovery.WithInclude(lockfileName),
+		discovery.WithCommonExcludes(),
+		discovery.WithExclude("Pods"),
+	}
+	if len(options.Global.Exclude) > 0 {
+		findOpts = append(findOpts, discovery.WithExcludes(options.Global.Exclude...))
+	}
+	if len(options.Global.ExcludePaths) > 0 {
+		findOpts = append(findOpts, discovery.WithExcludes(options.Global.ExcludePaths...))
+	}
+
+	files, err := discovery.FindFiles(ctx, dir, findOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("discovering Podfile.lock files: %w", err)
+	}
+	return files, nil
+}

--- a/pkg/ecosystems/cocoa/cocoapods/plugin_integration_test.go
+++ b/pkg/ecosystems/cocoa/cocoapods/plugin_integration_test.go
@@ -1,0 +1,122 @@
+//go:build integration && cocoapods
+
+// plugin_integration_test.go drives the cocoapods plugin against
+// real Podfile.lock fixtures under testdata/acceptance/ and compares
+// produced dep graphs to committed expected.json goldens.
+//
+// Run with: `make test-cocoapods-integration`
+//
+// Refresh goldens after intentional plugin changes:
+//
+//	go test -tags="integration,cocoapods" \
+//	  ./pkg/ecosystems/cocoa/cocoapods/... -run TestAcceptance -update
+//
+// The build tag combination (`integration && cocoapods`) keeps these
+// tests out of the default `go test ./...` run — they live next to
+// the unit tests but stay invisible until both tags are set.
+package cocoapods_test
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/snyk/dep-graph/go/pkg/depgraph"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/cocoa/cocoapods"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/logger"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/scatest"
+)
+
+var updateGolden = flag.Bool("update", false, "overwrite expected.json golden files with current plugin output")
+
+// TestAcceptance walks every directory under testdata/acceptance/ that
+// contains a Podfile.lock and verifies the produced dep graph matches
+// the committed expected.json. With -update it overwrites the goldens
+// instead of comparing.
+func TestAcceptance(t *testing.T) {
+	fixtures := discoverFixtures(t, filepath.Join("testdata", "acceptance"))
+	require.NotEmpty(t, fixtures, "no fixtures found under testdata/acceptance")
+
+	for _, fx := range fixtures {
+		t.Run(fx, func(t *testing.T) {
+			dir := filepath.Join("testdata", "acceptance", fx)
+
+			results, err := scatest.Run(context.Background(), cocoapods.Plugin{}, logger.Nop(), dir, ecosystems.NewPluginOptions())
+			require.NoError(t, err)
+			require.Len(t, results, 1)
+			require.NoError(t, results[0].Error)
+
+			// Sanity: native parsing must NEVER mutate the project
+			// directory. CocoaPods install would create Pods/.
+			assert.NoDirExists(t, filepath.Join(dir, "Pods"),
+				"native parsing must not create a Pods/ directory")
+
+			if *updateGolden {
+				data, mErr := json.MarshalIndent(results[0].DepGraph, "", "  ")
+				require.NoError(t, mErr)
+				require.NoError(t, os.WriteFile(filepath.Join(dir, "expected.json"), append(data, '\n'), 0o600))
+				t.Logf("updated %s/expected.json", fx)
+				return
+			}
+
+			raw, rErr := os.ReadFile(filepath.Join(dir, "expected.json"))
+			require.NoError(t, rErr, "reading expected.json (run with -update to generate)")
+
+			expected, pErr := depgraph.UnmarshalJSON(raw)
+			require.NoError(t, pErr)
+
+			assert.Equal(t, normalizedJSON(expected), normalizedJSON(results[0].DepGraph))
+		})
+	}
+}
+
+// discoverFixtures returns the names of subdirectories of base that
+// contain a Podfile.lock — those are the fixture directories.
+func discoverFixtures(t *testing.T, base string) []string {
+	t.Helper()
+	entries, err := os.ReadDir(base)
+	require.NoError(t, err, "reading fixtures dir: %s", base)
+
+	var out []string
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		if _, sErr := os.Stat(filepath.Join(base, e.Name(), "Podfile.lock")); sErr != nil {
+			continue
+		}
+		out = append(out, e.Name())
+	}
+	sort.Strings(out)
+	return out
+}
+
+// normalizedJSON marshals a dep graph with arrays sorted so comparisons
+// are order-independent (PkgManager.Repositories order is non-deterministic
+// because it comes from a Go map).
+func normalizedJSON(dg *depgraph.DepGraph) string {
+	sort.Slice(dg.Pkgs, func(i, j int) bool { return dg.Pkgs[i].ID < dg.Pkgs[j].ID })
+	sort.Slice(dg.Graph.Nodes, func(i, j int) bool { return dg.Graph.Nodes[i].NodeID < dg.Graph.Nodes[j].NodeID })
+	for i := range dg.Graph.Nodes {
+		sort.Slice(dg.Graph.Nodes[i].Deps, func(a, b int) bool {
+			return dg.Graph.Nodes[i].Deps[a].NodeID < dg.Graph.Nodes[i].Deps[b].NodeID
+		})
+	}
+	sort.Slice(dg.PkgManager.Repositories, func(i, j int) bool {
+		return dg.PkgManager.Repositories[i].Alias < dg.PkgManager.Repositories[j].Alias
+	})
+
+	data, err := json.MarshalIndent(dg, "", "  ")
+	if err != nil {
+		panic(err)
+	}
+	return string(data)
+}

--- a/pkg/ecosystems/cocoa/cocoapods/plugin_test.go
+++ b/pkg/ecosystems/cocoa/cocoapods/plugin_test.go
@@ -1,0 +1,231 @@
+package cocoapods
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/logger"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/scatest"
+)
+
+// writeFile is a tiny helper for fixture setup; fails the test on error.
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+}
+
+// writeSimpleLockfile drops a minimal Podfile.lock into dir so the
+// plugin has something to discover.
+func writeSimpleLockfile(t *testing.T, dir string) {
+	writeFile(t, filepath.Join(dir, "Podfile.lock"), simpleLockfile)
+}
+
+func TestPlugin_GetName(t *testing.T) {
+	assert.Equal(t, "cocoapods", Plugin{}.GetName())
+}
+
+func TestPlugin_NoLockfile_ReturnsEmpty(t *testing.T) {
+	dir := t.TempDir()
+	results, err := scatest.Run(context.Background(), Plugin{}, logger.Nop(), dir, ecosystems.NewPluginOptions())
+	require.NoError(t, err)
+	assert.Empty(t, results)
+}
+
+func TestPlugin_RootLockfile_ProducesOneResult(t *testing.T) {
+	dir := t.TempDir()
+	writeSimpleLockfile(t, dir)
+
+	results, err := scatest.Run(context.Background(), Plugin{}, logger.Nop(), dir, ecosystems.NewPluginOptions())
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	r := results[0]
+	require.NoError(t, r.Error)
+	require.NotNil(t, r.DepGraph)
+	assert.Equal(t, "Podfile.lock", r.ProjectDescriptor.GetTargetFile(),
+		"with no Podfile manifest present, TargetFile falls back to the lockfile")
+	assert.Equal(t, "cocoapods", r.ResolverMetadata.PluginName)
+	assert.Equal(t, []string{"Podfile.lock"}, r.ProcessedFiles)
+	assert.Equal(t, filepath.Base(dir), r.ProjectDescriptor.Identity.RootComponentName)
+}
+
+func TestPlugin_ManifestPriority_PrefersYamlOverPodfile(t *testing.T) {
+	dir := t.TempDir()
+	writeSimpleLockfile(t, dir)
+	// All four manifest variants present — the .yaml one must win.
+	writeFile(t, filepath.Join(dir, "Podfile"), "# podfile")
+	writeFile(t, filepath.Join(dir, "Podfile.rb"), "# podfile.rb")
+	writeFile(t, filepath.Join(dir, "CocoaPods.podfile"), "# cocoapods.podfile")
+	writeFile(t, filepath.Join(dir, "CocoaPods.podfile.yaml"), "# yaml")
+
+	results, err := scatest.Run(context.Background(), Plugin{}, logger.Nop(), dir, ecosystems.NewPluginOptions())
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "CocoaPods.podfile.yaml", results[0].ProjectDescriptor.GetTargetFile())
+	assert.Contains(t, results[0].ProcessedFiles, "Podfile.lock")
+	assert.Contains(t, results[0].ProcessedFiles, "CocoaPods.podfile.yaml")
+}
+
+func TestPlugin_ManifestPriority_FallsThroughToPodfile(t *testing.T) {
+	dir := t.TempDir()
+	writeSimpleLockfile(t, dir)
+	writeFile(t, filepath.Join(dir, "Podfile"), "# podfile")
+
+	results, err := scatest.Run(context.Background(), Plugin{}, logger.Nop(), dir, ecosystems.NewPluginOptions())
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "Podfile", results[0].ProjectDescriptor.GetTargetFile())
+}
+
+func TestPlugin_ManifestPriority_PodfileRbAsLastResort(t *testing.T) {
+	dir := t.TempDir()
+	writeSimpleLockfile(t, dir)
+	writeFile(t, filepath.Join(dir, "Podfile.rb"), "# rb")
+
+	results, err := scatest.Run(context.Background(), Plugin{}, logger.Nop(), dir, ecosystems.NewPluginOptions())
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "Podfile.rb", results[0].ProjectDescriptor.GetTargetFile())
+}
+
+func TestPlugin_TargetFile_ExplicitLockfile(t *testing.T) {
+	dir := t.TempDir()
+	writeSimpleLockfile(t, dir)
+
+	opts := ecosystems.NewPluginOptions().WithTargetFile("Podfile.lock")
+	results, err := scatest.Run(context.Background(), Plugin{}, logger.Nop(), dir, opts)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	require.NoError(t, results[0].Error)
+}
+
+func TestPlugin_TargetFile_ManifestResolvesToCompanion(t *testing.T) {
+	dir := t.TempDir()
+	writeSimpleLockfile(t, dir)
+	writeFile(t, filepath.Join(dir, "Podfile"), "# podfile")
+
+	opts := ecosystems.NewPluginOptions().WithTargetFile("Podfile")
+	results, err := scatest.Run(context.Background(), Plugin{}, logger.Nop(), dir, opts)
+	require.NoError(t, err)
+	require.Len(t, results, 1, "manifest target file must resolve to the sibling Podfile.lock")
+}
+
+func TestPlugin_TargetFile_UnrelatedFile_ReturnsEmpty(t *testing.T) {
+	dir := t.TempDir()
+	writeSimpleLockfile(t, dir)
+
+	opts := ecosystems.NewPluginOptions().WithTargetFile("package.json")
+	results, err := scatest.Run(context.Background(), Plugin{}, logger.Nop(), dir, opts)
+	require.NoError(t, err)
+	assert.Empty(t, results, "non-cocoapods target file must yield no results")
+}
+
+func TestPlugin_AllProjects_FindsNestedLockfiles(t *testing.T) {
+	root := t.TempDir()
+	writeSimpleLockfile(t, root)
+	writeSimpleLockfile(t, filepath.Join(root, "ios"))
+	writeSimpleLockfile(t, filepath.Join(root, "macos"))
+
+	opts := ecosystems.NewPluginOptions().WithAllProjects(true)
+	results, err := scatest.Run(context.Background(), Plugin{}, logger.Nop(), root, opts)
+	require.NoError(t, err)
+	require.Len(t, results, 3)
+
+	targets := make([]string, 0, len(results))
+	for _, r := range results {
+		targets = append(targets, r.ProjectDescriptor.GetTargetFile())
+	}
+	assert.ElementsMatch(t,
+		[]string{"Podfile.lock", "ios/Podfile.lock", "macos/Podfile.lock"},
+		targets,
+	)
+}
+
+// TestPlugin_AllProjects_SkipsPodsDir guards against the dep-graph
+// picking up vendored Manifest.lock files inside a Pods/ install
+// directory — that would duplicate every pod with itself as a sibling
+// project.
+func TestPlugin_AllProjects_SkipsPodsDir(t *testing.T) {
+	root := t.TempDir()
+	writeSimpleLockfile(t, root)
+	// Pods/Manifest.lock + Pods/SomeVendoredPod/Podfile.lock
+	writeFile(t, filepath.Join(root, "Pods", "Podfile.lock"), simpleLockfile)
+	writeFile(t, filepath.Join(root, "Pods", "VendoredPod", "Podfile.lock"), simpleLockfile)
+
+	opts := ecosystems.NewPluginOptions().WithAllProjects(true)
+	results, err := scatest.Run(context.Background(), Plugin{}, logger.Nop(), root, opts)
+	require.NoError(t, err)
+
+	for _, r := range results {
+		tf := r.ProjectDescriptor.GetTargetFile()
+		assert.NotContains(t, tf, "Pods/",
+			"discovery must skip the Pods/ install directory; got %q", tf)
+	}
+}
+
+func TestPlugin_AllProjects_HonorsExcludePaths(t *testing.T) {
+	root := t.TempDir()
+	writeSimpleLockfile(t, root)
+	writeSimpleLockfile(t, filepath.Join(root, "ios"))
+	writeSimpleLockfile(t, filepath.Join(root, "skipme"))
+
+	opts := ecosystems.NewPluginOptions().
+		WithAllProjects(true).
+		WithExcludePaths([]string{"skipme"})
+
+	results, err := scatest.Run(context.Background(), Plugin{}, logger.Nop(), root, opts)
+	require.NoError(t, err)
+
+	for _, r := range results {
+		assert.NotContains(t, r.ProjectDescriptor.GetTargetFile(), "skipme")
+	}
+}
+
+func TestPlugin_MalformedLockfile_ReturnsErrorResult(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "Podfile.lock"), "this : is : not : valid : podfile.lock\n:::]")
+
+	results, err := scatest.Run(context.Background(), Plugin{}, logger.Nop(), dir, ecosystems.NewPluginOptions())
+	require.NoError(t, err, "parse failure must surface as a per-result error, not abort the run")
+	require.Len(t, results, 1)
+	assert.Error(t, results[0].Error)
+	assert.Nil(t, results[0].DepGraph)
+	assert.NotNil(t, results[0].ProjectDescriptor.Identity.TargetFile, "error results still carry a target file")
+}
+
+func TestPlugin_NilOptions_UsesDefaults(t *testing.T) {
+	dir := t.TempDir()
+	writeSimpleLockfile(t, dir)
+
+	results, err := scatest.Run(context.Background(), Plugin{}, logger.Nop(), dir, nil)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	require.NoError(t, results[0].Error)
+}
+
+// TestPlugin_StopsOnGraphError verifies the SCAPlugin contract that a
+// non-nil onGraph return aborts the run and the same error reaches the
+// caller.
+func TestPlugin_StopsOnGraphError(t *testing.T) {
+	root := t.TempDir()
+	writeSimpleLockfile(t, root)
+	writeSimpleLockfile(t, filepath.Join(root, "ios"))
+
+	opts := ecosystems.NewPluginOptions().WithAllProjects(true)
+	sentinel := assertSentinel{}
+	err := Plugin{}.BuildDepGraphsFromDir(context.Background(), logger.Nop(), root, opts,
+		func(_ ecosystems.SCAResult) error { return &sentinel },
+	)
+	require.ErrorIs(t, err, &sentinel)
+}
+
+type assertSentinel struct{}
+
+func (a *assertSentinel) Error() string { return "sentinel" }

--- a/pkg/ecosystems/cocoa/cocoapods/testdata/acceptance/simple/Podfile.lock
+++ b/pkg/ecosystems/cocoa/cocoapods/testdata/acceptance/simple/Podfile.lock
@@ -1,0 +1,12 @@
+PODS:
+  - Reachability (3.1.0)
+
+DEPENDENCIES:
+  - Reachability (= 3.1.0)
+
+SPEC REPOS:
+  trunk:
+    - Reachability
+
+SPEC CHECKSUMS:
+  Reachability: 3c8fe9643e52184d17f207e781cd84158da8c02b

--- a/pkg/ecosystems/cocoa/cocoapods/testdata/acceptance/simple/expected.json
+++ b/pkg/ecosystems/cocoa/cocoapods/testdata/acceptance/simple/expected.json
@@ -1,0 +1,53 @@
+{
+  "schemaVersion": "1.3.0",
+  "pkgManager": {
+    "name": "cocoapods",
+    "version": "unknown",
+    "repositories": [
+      {
+        "alias": "trunk"
+      }
+    ]
+  },
+  "pkgs": [
+    {
+      "id": "simple@0.0.0",
+      "info": {
+        "name": "simple",
+        "version": "0.0.0"
+      }
+    },
+    {
+      "id": "Reachability@3.1.0",
+      "info": {
+        "name": "Reachability",
+        "version": "3.1.0"
+      }
+    }
+  ],
+  "graph": {
+    "rootNodeId": "root-node",
+    "nodes": [
+      {
+        "nodeId": "root-node",
+        "pkgId": "simple@0.0.0",
+        "deps": [
+          {
+            "nodeId": "Reachability"
+          }
+        ]
+      },
+      {
+        "nodeId": "Reachability",
+        "pkgId": "Reachability@3.1.0",
+        "info": {
+          "labels": {
+            "checksum": "3c8fe9643e52184d17f207e781cd84158da8c02b",
+            "repository": "trunk"
+          }
+        },
+        "deps": []
+      }
+    ]
+  }
+}

--- a/pkg/ecosystems/cocoa/cocoapods/testdata/acceptance/with-external-sources/Podfile.lock
+++ b/pkg/ecosystems/cocoa/cocoapods/testdata/acceptance/with-external-sources/Podfile.lock
@@ -1,0 +1,28 @@
+PODS:
+  - Silica (0.1.5)
+  - Sparkle (1.18.1)
+  - SwiftyBeaver (1.4.2)
+
+DEPENDENCIES:
+  - Silica (from `https://github.com/ianyh/Silica.git`, tag `0.1.5`)
+  - Sparkle
+  - SwiftyBeaver
+
+EXTERNAL SOURCES:
+  Silica:
+    :git: https://github.com/ianyh/Silica.git
+    :tag: 0.1.5
+
+CHECKOUT OPTIONS:
+  Silica:
+    :git: https://github.com/ianyh/Silica.git
+    :tag: 0.1.5
+
+SPEC CHECKSUMS:
+  Silica: 3b5a774469476ef84fe9d96a63bfe09908654e50
+  Sparkle: 06ea33170007c5937ee54da481b4481af98fac79
+  SwiftyBeaver: 91057725648ee4980308f1650af077d04b3654a0
+
+PODFILE CHECKSUM: 56045e819fdcab3669f1847a1bc88e6702accf51
+
+COCOAPODS: 1.3.1

--- a/pkg/ecosystems/cocoa/cocoapods/testdata/acceptance/with-external-sources/expected.json
+++ b/pkg/ecosystems/cocoa/cocoapods/testdata/acceptance/with-external-sources/expected.json
@@ -1,0 +1,91 @@
+{
+  "schemaVersion": "1.3.0",
+  "pkgManager": {
+    "name": "cocoapods",
+    "version": "1.3.1"
+  },
+  "pkgs": [
+    {
+      "id": "with-external-sources@0.0.0",
+      "info": {
+        "name": "with-external-sources",
+        "version": "0.0.0"
+      }
+    },
+    {
+      "id": "Silica@0.1.5",
+      "info": {
+        "name": "Silica",
+        "version": "0.1.5"
+      }
+    },
+    {
+      "id": "Sparkle@1.18.1",
+      "info": {
+        "name": "Sparkle",
+        "version": "1.18.1"
+      }
+    },
+    {
+      "id": "SwiftyBeaver@1.4.2",
+      "info": {
+        "name": "SwiftyBeaver",
+        "version": "1.4.2"
+      }
+    }
+  ],
+  "graph": {
+    "rootNodeId": "root-node",
+    "nodes": [
+      {
+        "nodeId": "root-node",
+        "pkgId": "with-external-sources@0.0.0",
+        "deps": [
+          {
+            "nodeId": "Silica"
+          },
+          {
+            "nodeId": "Sparkle"
+          },
+          {
+            "nodeId": "SwiftyBeaver"
+          }
+        ]
+      },
+      {
+        "nodeId": "Silica",
+        "pkgId": "Silica@0.1.5",
+        "info": {
+          "labels": {
+            "checkoutOptionsGit": "https://github.com/ianyh/Silica.git",
+            "checkoutOptionsTag": "0.1.5",
+            "checksum": "3b5a774469476ef84fe9d96a63bfe09908654e50",
+            "externalSourceGit": "https://github.com/ianyh/Silica.git",
+            "externalSourceTag": "0.1.5"
+          }
+        },
+        "deps": []
+      },
+      {
+        "nodeId": "Sparkle",
+        "pkgId": "Sparkle@1.18.1",
+        "info": {
+          "labels": {
+            "checksum": "06ea33170007c5937ee54da481b4481af98fac79"
+          }
+        },
+        "deps": []
+      },
+      {
+        "nodeId": "SwiftyBeaver",
+        "pkgId": "SwiftyBeaver@1.4.2",
+        "info": {
+          "labels": {
+            "checksum": "91057725648ee4980308f1650af077d04b3654a0"
+          }
+        },
+        "deps": []
+      }
+    ]
+  }
+}

--- a/pkg/ecosystems/cocoa/cocoapods/testdata/acceptance/with-subspecs/Podfile.lock
+++ b/pkg/ecosystems/cocoa/cocoapods/testdata/acceptance/with-subspecs/Podfile.lock
@@ -1,0 +1,31 @@
+PODS:
+  - AFNetworkActivityLogger (2.0.4):
+    - AFNetworking/NSURLConnection (~> 2.0)
+    - AFNetworking/NSURLSession (~> 2.0)
+  - AFNetworking (2.5.4):
+    - AFNetworking/NSURLConnection (= 2.5.4)
+    - AFNetworking/NSURLSession (= 2.5.4)
+    - AFNetworking/Reachability (= 2.5.4)
+    - AFNetworking/Security (= 2.5.4)
+    - AFNetworking/Serialization (= 2.5.4)
+  - AFNetworking/NSURLConnection (2.5.4):
+    - AFNetworking/Reachability
+    - AFNetworking/Security
+    - AFNetworking/Serialization
+  - AFNetworking/NSURLSession (2.5.4):
+    - AFNetworking/Reachability
+    - AFNetworking/Security
+    - AFNetworking/Serialization
+  - AFNetworking/Reachability (2.5.4)
+  - AFNetworking/Security (2.5.4)
+  - AFNetworking/Serialization (2.5.4)
+
+DEPENDENCIES:
+  - AFNetworkActivityLogger (~> 2.0)
+  - AFNetworking (~> 2.5)
+
+SPEC CHECKSUMS:
+  AFNetworkActivityLogger: 121486b117e7fc6cf68a5dbf3a87a4878babf504
+  AFNetworking: 49b40179a4f1c66edf16dac24d63785dfdc92587
+
+COCOAPODS: 1.10.0

--- a/pkg/ecosystems/cocoa/cocoapods/testdata/acceptance/with-subspecs/expected.json
+++ b/pkg/ecosystems/cocoa/cocoapods/testdata/acceptance/with-subspecs/expected.json
@@ -1,0 +1,74 @@
+{
+  "schemaVersion": "1.3.0",
+  "pkgManager": {
+    "name": "cocoapods",
+    "version": "1.10.0"
+  },
+  "pkgs": [
+    {
+      "id": "with-subspecs@0.0.0",
+      "info": {
+        "name": "with-subspecs",
+        "version": "0.0.0"
+      }
+    },
+    {
+      "id": "AFNetworkActivityLogger@2.0.4",
+      "info": {
+        "name": "AFNetworkActivityLogger",
+        "version": "2.0.4"
+      }
+    },
+    {
+      "id": "AFNetworking@2.5.4",
+      "info": {
+        "name": "AFNetworking",
+        "version": "2.5.4"
+      }
+    }
+  ],
+  "graph": {
+    "rootNodeId": "root-node",
+    "nodes": [
+      {
+        "nodeId": "root-node",
+        "pkgId": "with-subspecs@0.0.0",
+        "deps": [
+          {
+            "nodeId": "AFNetworkActivityLogger"
+          },
+          {
+            "nodeId": "AFNetworking"
+          }
+        ]
+      },
+      {
+        "nodeId": "AFNetworkActivityLogger",
+        "pkgId": "AFNetworkActivityLogger@2.0.4",
+        "info": {
+          "labels": {
+            "checksum": "121486b117e7fc6cf68a5dbf3a87a4878babf504"
+          }
+        },
+        "deps": [
+          {
+            "nodeId": "AFNetworking"
+          },
+          {
+            "nodeId": "AFNetworking"
+          }
+        ]
+      },
+      {
+        "nodeId": "AFNetworking",
+        "pkgId": "AFNetworking@2.5.4",
+        "info": {
+          "labels": {
+            "checksum": "49b40179a4f1c66edf16dac24d63785dfdc92587"
+          }
+        },
+        "deps": []
+      }
+    ]
+  }
+}

--- a/pkg/ecosystems/cocoa/cocoapods/types.go
+++ b/pkg/ecosystems/cocoa/cocoapods/types.go
@@ -1,0 +1,75 @@
+package cocoapods
+
+// PluginName is the SCAPlugin identifier for the CocoaPods plugin.
+const PluginName = "cocoapods"
+
+// pkgManagerName is the dep-graph PkgManager.Name written into the dep
+// graph itself. Matches the legacy @snyk/snyk-cocoapods-plugin output so
+// downstream consumers (Snyk monitor/test ingestion) see the same value.
+const pkgManagerName = "cocoapods"
+
+const (
+	defaultRootVersion        = "0.0.0"
+	defaultCocoapodsVersion   = "unknown"
+	lockfileName              = "Podfile.lock"
+	manifestPodfile           = "Podfile"
+	manifestPodfileRb         = "Podfile.rb"
+	manifestCocoapodsPodfile  = "CocoaPods.podfile"
+	manifestCocoapodsPodfileY = "CocoaPods.podfile.yaml"
+)
+
+// manifestPriority lists Podfile-equivalent manifest filenames in the
+// order the legacy plugin probes them. The first one that exists in the
+// lockfile directory wins for the project's TargetFile.
+var manifestPriority = []string{
+	manifestCocoapodsPodfileY,
+	manifestCocoapodsPodfile,
+	manifestPodfile,
+	manifestPodfileRb,
+}
+
+// Lockfile mirrors the YAML structure of a Podfile.lock. Optional
+// sections (SPEC REPOS, EXTERNAL SOURCES, CHECKOUT OPTIONS, PODFILE
+// CHECKSUM, COCOAPODS) are not present in older lockfiles and decode to
+// nil/empty values — every read site must handle the absence gracefully.
+//
+// PODS is a heterogeneous list of either bare specification strings
+// (no transitive deps, e.g. "Expecta (1.0.5)") or single-key maps from
+// specification string to a list of dependency strings (e.g.
+// "React/Core (0.59.2)": ["yoga (= 0.59.2.React)"]). We decode each entry
+// as yaml.Node and split on shape in the parser.
+type Lockfile struct {
+	Pods             []PodEntry                   `yaml:"PODS"`
+	Dependencies     []string                     `yaml:"DEPENDENCIES"`
+	SpecRepos        map[string][]string          `yaml:"SPEC REPOS,omitempty"`
+	ExternalSources  map[string]ExternalSource    `yaml:"EXTERNAL SOURCES,omitempty"`
+	CheckoutOptions  map[string]CheckoutOptions   `yaml:"CHECKOUT OPTIONS,omitempty"`
+	SpecChecksums    map[string]string            `yaml:"SPEC CHECKSUMS"`
+	PodfileChecksum  string                       `yaml:"PODFILE CHECKSUM,omitempty"`
+	CocoapodsVersion string                       `yaml:"COCOAPODS,omitempty"`
+}
+
+// PodEntry is one element of the PODS list. Spec is the specification
+// string ("Name (version)") and Deps is the list of dependency strings
+// (empty when the pod is a bare leaf).
+type PodEntry struct {
+	Spec string
+	Deps []string
+}
+
+// ExternalSource is the parsed value of an EXTERNAL SOURCES entry. The
+// keys are written in the lockfile with leading colons (Ruby symbol
+// syntax: `:git`, `:tag`, etc.) and we preserve that distinction so the
+// resulting labels match the legacy plugin exactly.
+type ExternalSource struct {
+	Git     string `yaml:":git,omitempty"`
+	Path    string `yaml:":path,omitempty"`
+	Tag     string `yaml:":tag,omitempty"`
+	Commit  string `yaml:":commit,omitempty"`
+	Branch  string `yaml:":branch,omitempty"`
+	Podspec string `yaml:":podspec,omitempty"`
+}
+
+// CheckoutOptions has the same shape as ExternalSource — same Ruby symbol
+// keys, same meaning, written into a separate lockfile section.
+type CheckoutOptions = ExternalSource


### PR DESCRIPTION
## What this does

Adds a new SCA plugin at `pkg/ecosystems/cocoa/cocoapods/` that resolves CocoaPods dep graphs by **natively parsing `Podfile.lock`** (YAML) — no `pod install`, no `pod` CLI invocation, no `Pods/` directory created.

The package is self-contained and **not wired into the orchestrator in this PR**; that lands in a follow-up to avoid conflicting with other in-flight resolver work.

## Why

The legacy `cocoapods-lockfile-parser` is also a native parser (~265 LoC TypeScript) — it doesn't shell out to `pod` either. The principled choice here was a quick audit: **`pod` is macOS-only** (depends on Ruby + CocoaPods gem; not packaged for Linux/Windows). Using it would block Linux CI runners. There's no offline-safe `pod` subcommand that emits a graph from `Podfile.lock` alone. So native YAML parsing is forced — and the lockfile format is well-spec'd and stable.

See [the Plugin Audit](https://snyksec.atlassian.net/wiki/spaces/TOE1/pages/4651909131/Plugin+Audit) for the broader ecosystem migration context.

## What's in this PR

3 commits, scoped narrowly to the new package:

| # | Commit | What |
|---|---|---|
| 1 | `feat(cocoapods): add Podfile.lock parser and resolver` | `types.go` (YAML structs), `parser.go` (two-step decode for heterogeneous PODS entries), `depgraph.go` (DepGraph builder with subspec dedup + 12 legacy label keys preserved), `plugin.go` (SCAPlugin impl, manifest priority resolution). |
| 2 | `test(cocoapods): unit tests for parser, depgraph, plugin` | 35 unit tests covering parser edge cases, label-key preservation, subspec dedup, repository extraction. 87.0% coverage. |
| 3 | `test(cocoapods): integration test scaffold with smoke fixtures` | Build-tag-gated (`//go:build integration && cocoapods`) acceptance harness + `make test-cocoapods-integration` target. 3 fixtures (`simple`, `with-subspecs`, `with-external-sources`) with `expected.json` goldens. |

Nothing under `pkg/ecosystems/orchestrator/` is touched, so this won't conflict with other in-flight resolver work.

## How it works

Native YAML parse of `Podfile.lock` using `gopkg.in/yaml.v3` (already an indirect dep — no `go.mod` changes). Two-step decode handles the heterogeneous `PODS` entries (some are string-only like `"Alamofire (5.4.0)"`, others are maps with sub-dependencies like `{"Adjust/Core (4.29.0)": ["Adjust/Signature", ...]}`).

DepGraph construction preserves all 12 legacy label keys (`checksum`, `repository`, `externalSourceGit/Path/Tag/Commit/Branch/Podspec`, `checkoutOptionsGit/Path/Tag/Commit/Branch/Podspec`) verbatim — asserted by `TestBuildDepGraph_LabelsPreserved_ExternalSourcesAndCheckout`. Subspec deduplication: `AFNetworking/NSURLConnection` collapses to root node `AFNetworking`, matching legacy.

Manifest discovery priority matches legacy: `CocoaPods.podfile.yaml` → `CocoaPods.podfile` → `Podfile` → `Podfile.rb`.

## Divergences from `cocoapods-lockfile-parser`

Cross-validated against `cocoapods-lockfile-parser/test/lib/fixtures/penc/dep-graph.json` — output is byte-equivalent except for the items below.

| Dimension | Legacy | This PR |
|---|---|---|
| **Dep-graph schemaVersion** | `1.2.0` (older `@snyk/dep-graph`) | `1.3.0` (dictated by Go `dep-graph` library; unavoidable). |
| **Empty external-source labels** | Stripped (e.g. unset `:tag` not in labels map). | Same — explicitly asserted. |
| **Repositories ordering** | Non-deterministic (JS object iter). | Non-deterministic (Go map iter); acceptance test sorts before compare. |
| **`PODFILE CHECKSUM` validation** | Validates against `Podfile` SHA when `--strict-out-of-sync` set. | `AllowOutOfSync` accepted but no-op for now — likely follow-up commit. |

## CLI options honored

| Option | Source | Legacy use | New plugin handling |
|---|---|---|---|
| `--target-file` (global) | `SCAPluginOptions.Global.TargetFile` | Resolves manifest or lockfile; plugin discovers companion | Honored |
| `--strict-out-of-sync` | `cli/src/cli/args.ts` (inverted into `AllowOutOfSync`) | PODFILE CHECKSUM validation | Accepted but no-op; follow-up commit planned |
| `--dev` (IncludeDev) | global | CocoaPods has no dev/prod distinction | Accepted; no-op |
| `--all-projects` | global | Single-project tool | Accepted; no-op |

## What's NOT in this PR

- Orchestrator registration — deliberately deferred to avoid conflicting with other in-flight resolver work.
- `PODFILE CHECKSUM` validation under `--strict-out-of-sync` (commit 4 in the plan; left as a hook).
- CircleCI matrix.
- Side-by-side legacy-comparison test against the full real-world fixture corpus from `cocoapods-lockfile-parser/test/lib/fixtures/`.

A follow-up PR will land the orchestrator registration and FF for default-switching.

## How to verify

```sh
# unit tests
go test ./pkg/ecosystems/cocoa/cocoapods/...

# integration tests (no real pod needed — native parser)
make test-cocoapods-integration

# coverage
go test -cover ./pkg/ecosystems/cocoa/cocoapods/...

# lint
make lint
```

## Caveats for reviewers

- **Open question**: the manifest-priority list includes `Podfile.rb`, but the CLI's own `detect.ts` doesn't list `.rb`. Worth confirming whether the legacy plugin probes `.rb` at all before merge.
- **`PODFILE CHECKSUM`**: hook present, not wired. If `--strict-out-of-sync` is critical for parity, a follow-up commit is needed.

## Risk

The new package is not registered with the orchestrator, so it has no effect on production behaviour. Reviewers can focus on the plugin code in isolation.

---

🔬 **SPIKE**: exploratory work for the multi-ecosystem migration shipped as a draft for early review.
