### PR TITLE
SPIKE: feat(bundler): add native Gemfile.lock parser and resolver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,4 +49,7 @@ test-gradle-integration:
 update-gradle-fixtures:
 	UPDATE_FIXTURES=1 $(GOTEST) -v -tags="integration,gradle" -timeout=15m ./pkg/ecosystems/gradle/
 
-.PHONY: install-req fmt test test-bazel-jvm-integration test-bazel-go-integration test-python-integration test-gradle-integration update-gradle-fixtures lint tidy imports install-golangci-lint
+test-bundler-integration:
+	$(GOTEST) -v -tags="integration,bundler" -timeout=5m ./pkg/ecosystems/ruby/bundler/... -coverprofile cp.out
+
+.PHONY: install-req fmt test test-bazel-jvm-integration test-bazel-go-integration test-python-integration test-gradle-integration test-bundler-integration update-gradle-fixtures lint tidy imports install-golangci-lint

--- a/pkg/ecosystems/ruby/bundler/depgraph.go
+++ b/pkg/ecosystems/ruby/bundler/depgraph.go
@@ -1,0 +1,156 @@
+package bundler
+
+import (
+	"errors"
+	"fmt"
+
+	godepgraph "github.com/snyk/dep-graph/go/pkg/depgraph"
+)
+
+const (
+	pkgManagerName = "rubygems"
+	// bundlerGemName is omitted from every dep graph: the @snyk/gemfile
+	// reference parser silently drops it because bundler is not listed
+	// in any source block's `specs:` (it's the runner itself, not a
+	// dependency). We replicate that omission and additionally skip the
+	// DEPENDENCIES entry so it never appears as a missing-spec edge.
+	bundlerGemName = "bundler"
+)
+
+// CycleError is returned when a dependency cycle is detected while
+// walking the resolved specs. The legacy parser threw a 422 with the
+// offending gem and ancestor chain; we keep the same shape.
+type CycleError struct {
+	Gem   string
+	Chain []string
+}
+
+func (e *CycleError) Error() string {
+	return fmt.Sprintf("cyclic dependency detected in lockfile at %q (chain: %v)", e.Gem, e.Chain)
+}
+
+// BuildDepGraph constructs a Snyk dep graph from a parsed Lockfile.
+//
+// Behavior, matching the legacy plugin's Gemfile.lock-to-dependencies
+// conversion:
+//   - The root is rootName/rootVersion (caller-supplied; typically
+//     basename(projectDir) for a plain Gemfile, or the gemspec
+//     name+version for a .gemspec project).
+//   - The root's direct deps are the entries from DEPENDENCIES, in
+//     lockfile order, after stripping the `!` marker.
+//   - "bundler" is omitted as a root dep AND, defensively, as a child
+//     of any other spec — matching the legacy "if (gemspec) { ... }"
+//     guard that silently skipped specs not present in the resolved
+//     map.
+//   - A spec listed in DEPENDENCIES but missing from the source blocks
+//     is skipped (legacy behavior — keeps the graph buildable).
+//   - Cycles raise CycleError, matching legacy 422 semantics.
+func BuildDepGraph(rootName, rootVersion string, lf *Lockfile) (*godepgraph.DepGraph, error) {
+	return BuildDepGraphWithOptions(rootName, rootVersion, lf, BuildOptions{})
+}
+
+// BuildOptions tweaks dep-graph construction beyond the legacy defaults.
+//
+// IncludeDev is a deliberate enhancement over legacy: bundler's Gemfile
+// has `group :development do ... end` blocks, but the resolved
+// Gemfile.lock does NOT encode which group a gem belongs to. Group info
+// is only knowable by re-parsing the (lossy) Gemfile, which we don't
+// have here. For now IncludeDev is wired but has no behavioral effect;
+// the plugin layer exposes it so when we later parse the Gemfile (or
+// switch to a richer lockfile format), no plumbing churn is needed.
+//
+// See the migration plan section "Group semantics — --dev behavior".
+type BuildOptions struct {
+	IncludeDev bool
+}
+
+// BuildDepGraphWithOptions is the option-aware variant of BuildDepGraph.
+func BuildDepGraphWithOptions(rootName, rootVersion string, lf *Lockfile, opts BuildOptions) (*godepgraph.DepGraph, error) {
+	if lf == nil {
+		return nil, errors.New("bundler.BuildDepGraph: nil lockfile")
+	}
+	if rootName == "" {
+		return nil, errors.New("bundler.BuildDepGraph: empty rootName")
+	}
+
+	builder, err := godepgraph.NewBuilder(
+		&godepgraph.PkgManager{Name: pkgManagerName},
+		&godepgraph.PkgInfo{Name: rootName, Version: rootVersion},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("creating dep graph builder: %w", err)
+	}
+
+	rootNodeID := builder.GetRootNode().NodeID
+
+	// visited records the set of (name) currently on the DFS stack —
+	// used for cycle detection. Distinct from `added`, which is whether
+	// a node already exists in the graph (and may be reconnected).
+	visited := make(map[string]bool)
+	added := make(map[string]bool)
+
+	for _, dep := range lf.Dependencies {
+		// Skip bundler in DEPENDENCIES (legacy: silently dropped because
+		// it's not in specs). Also a no-op IncludeDev gate placeholder —
+		// see BuildOptions doc.
+		if dep.Name == bundlerGemName {
+			continue
+		}
+		if err := walk(builder, rootNodeID, dep.Name, lf, visited, added, []string{rootName}); err != nil {
+			return nil, err
+		}
+	}
+
+	return builder.Build(), nil
+}
+
+// walk performs a DFS from `name`, adding nodes/edges to builder and
+// raising CycleError if `name` is already on the current ancestor chain.
+//
+// Specs not present in lf.Specs (e.g. bundler, or a missing/corrupt
+// lockfile entry) are silently skipped — matches legacy
+// "if (gemspec) { ... }" guard.
+func walk(
+	builder *godepgraph.Builder,
+	parentNodeID, name string,
+	lf *Lockfile,
+	visited, added map[string]bool,
+	chain []string,
+) error {
+	spec, ok := lf.Specs[name]
+	if !ok {
+		// Legacy: just ignore — better than crashing.
+		return nil
+	}
+
+	if visited[name] {
+		return &CycleError{Gem: name, Chain: append([]string(nil), chain...)}
+	}
+
+	nodeID := name + "@" + spec.Version
+
+	if !added[name] {
+		added[name] = true
+		visited[name] = true
+
+		builder.AddNode(nodeID, &godepgraph.PkgInfo{Name: name, Version: spec.Version})
+
+		for _, child := range spec.Children {
+			if child == bundlerGemName {
+				// Defensive: should never appear as a child, but legacy
+				// would also silently drop it if it did.
+				continue
+			}
+			if err := walk(builder, nodeID, child, lf, visited, added, append(chain, name)); err != nil {
+				return err
+			}
+		}
+
+		visited[name] = false
+	}
+
+	if err := builder.ConnectNodes(parentNodeID, nodeID); err != nil {
+		return fmt.Errorf("connecting %s → %s: %w", parentNodeID, nodeID, err)
+	}
+	return nil
+}

--- a/pkg/ecosystems/ruby/bundler/depgraph_test.go
+++ b/pkg/ecosystems/ruby/bundler/depgraph_test.go
@@ -1,0 +1,227 @@
+package bundler
+
+import (
+	"errors"
+	"testing"
+
+	godepgraph "github.com/snyk/dep-graph/go/pkg/depgraph"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// nodeDeps returns the NodeIDs of nodeID's direct dependencies in dg.
+func nodeDeps(t *testing.T, dg *godepgraph.DepGraph, nodeID string) []string {
+	t.Helper()
+	for _, n := range dg.Graph.Nodes {
+		if n.NodeID == nodeID {
+			ids := make([]string, len(n.Deps))
+			for i, d := range n.Deps {
+				ids[i] = d.NodeID
+			}
+			return ids
+		}
+	}
+	return nil
+}
+
+// pkgIDs returns the set of package IDs present in dg.
+func pkgIDs(dg *godepgraph.DepGraph) map[string]bool {
+	out := make(map[string]bool, len(dg.Pkgs))
+	for _, p := range dg.Pkgs {
+		out[p.ID] = true
+	}
+	return out
+}
+
+// rootDeps returns the direct dependencies of the root node.
+func rootDeps(t *testing.T, dg *godepgraph.DepGraph) []string {
+	t.Helper()
+	return nodeDeps(t, dg, dg.Graph.RootNodeID)
+}
+
+// TestBuildDepGraph_Simple covers the canonical GEM-only flow:
+// two top-level deps, one transitive.
+func TestBuildDepGraph_Simple(t *testing.T) {
+	lf := &Lockfile{
+		Specs: map[string]*Spec{
+			"json": {Name: "json", Version: "2.0.2"},
+			"lynx": {Name: "lynx", Version: "0.4.0"},
+		},
+		Dependencies: []Dependency{
+			{Name: "json"},
+			{Name: "lynx"},
+		},
+	}
+
+	g, err := BuildDepGraph("my-app", "1.0.0", lf)
+	require.NoError(t, err)
+	require.NotNil(t, g)
+
+	assert.Equal(t, "my-app", g.GetRootPkg().Info.Name)
+	assert.Equal(t, "rubygems", g.PkgManager.Name)
+
+	rd := rootDeps(t, g)
+	assert.Contains(t, rd, "json@2.0.2")
+	assert.Contains(t, rd, "lynx@0.4.0")
+}
+
+// TestBuildDepGraph_Transitive covers nested deps and shared ancestry.
+func TestBuildDepGraph_Transitive(t *testing.T) {
+	lf := &Lockfile{
+		Specs: map[string]*Spec{
+			"sanitize":      {Name: "sanitize", Version: "4.6.2", Children: []string{"crass", "nokogiri"}},
+			"nokogiri":      {Name: "nokogiri", Version: "1.8.5", Children: []string{"mini_portile2"}},
+			"mini_portile2": {Name: "mini_portile2", Version: "2.3.0"},
+			"crass":         {Name: "crass", Version: "1.0.4"},
+		},
+		Dependencies: []Dependency{{Name: "sanitize"}},
+	}
+
+	g, err := BuildDepGraph("my-app", "1.0.0", lf)
+	require.NoError(t, err)
+
+	ids := pkgIDs(g)
+	assert.True(t, ids["sanitize@4.6.2"])
+	assert.True(t, ids["nokogiri@1.8.5"])
+	assert.True(t, ids["mini_portile2@2.3.0"])
+	assert.True(t, ids["crass@1.0.4"])
+
+	assert.ElementsMatch(t,
+		[]string{"crass@1.0.4", "nokogiri@1.8.5"},
+		nodeDeps(t, g, "sanitize@4.6.2"),
+	)
+	assert.Equal(t,
+		[]string{"mini_portile2@2.3.0"},
+		nodeDeps(t, g, "nokogiri@1.8.5"),
+	)
+}
+
+// TestBuildDepGraph_BundlerExclusion verifies the legacy quirk: bundler
+// itself is silently dropped from the dep tree, both when it appears in
+// DEPENDENCIES and (defensively) when it appears as a child of another
+// spec.
+func TestBuildDepGraph_BundlerExclusion(t *testing.T) {
+	lf := &Lockfile{
+		Specs: map[string]*Spec{
+			"rake": {Name: "rake", Version: "10.5.0"},
+			// Defensive case: some other spec lists bundler as a child.
+			"weird": {Name: "weird", Version: "1.0", Children: []string{"bundler", "rake"}},
+		},
+		Dependencies: []Dependency{
+			{Name: "bundler"}, // direct: should be skipped
+			{Name: "rake"},
+			{Name: "weird"},
+		},
+	}
+
+	g, err := BuildDepGraph("my-app", "1.0.0", lf)
+	require.NoError(t, err)
+
+	ids := pkgIDs(g)
+	for id := range ids {
+		assert.NotContains(t, id, "bundler@", "bundler must not appear as a graph node")
+	}
+
+	// `weird` should have rake as its only child (bundler filtered out).
+	assert.Equal(t, []string{"rake@10.5.0"}, nodeDeps(t, g, "weird@1.0"))
+
+	// Direct root deps: rake + weird, no bundler.
+	rd := rootDeps(t, g)
+	assert.ElementsMatch(t, []string{"rake@10.5.0", "weird@1.0"}, rd)
+}
+
+// TestBuildDepGraph_MissingSpec ensures a dep listed in DEPENDENCIES
+// but missing from the Specs map is silently dropped (matches legacy).
+func TestBuildDepGraph_MissingSpec(t *testing.T) {
+	lf := &Lockfile{
+		Specs: map[string]*Spec{
+			"json": {Name: "json", Version: "2.0.2"},
+		},
+		Dependencies: []Dependency{
+			{Name: "json"},
+			{Name: "ghost-gem"}, // not in Specs
+		},
+	}
+	g, err := BuildDepGraph("my-app", "1.0.0", lf)
+	require.NoError(t, err)
+
+	rd := rootDeps(t, g)
+	assert.Contains(t, rd, "json@2.0.2")
+	for _, id := range rd {
+		assert.NotContains(t, id, "ghost-gem")
+	}
+}
+
+// TestBuildDepGraph_Cycle exercises the cycle detector: an A→B→A loop
+// must raise CycleError rather than infinite-loop.
+func TestBuildDepGraph_Cycle(t *testing.T) {
+	lf := &Lockfile{
+		Specs: map[string]*Spec{
+			"a": {Name: "a", Version: "1.0", Children: []string{"b"}},
+			"b": {Name: "b", Version: "2.0", Children: []string{"a"}},
+		},
+		Dependencies: []Dependency{{Name: "a"}},
+	}
+
+	_, err := BuildDepGraph("my-app", "1.0.0", lf)
+	require.Error(t, err)
+	var ce *CycleError
+	assert.True(t, errors.As(err, &ce), "expected *CycleError, got %T", err)
+	assert.Equal(t, "a", ce.Gem)
+	assert.Contains(t, ce.Chain, "a")
+	assert.Contains(t, ce.Chain, "b")
+}
+
+// TestBuildDepGraph_DiamondNoFalseCycle verifies that a "diamond"
+// dependency (shared transitive) is NOT mistakenly flagged as a cycle.
+// This catches the classic visited-set bug where the same node on two
+// non-cyclic paths gets miscounted.
+func TestBuildDepGraph_DiamondNoFalseCycle(t *testing.T) {
+	// root → a, b
+	//  a → shared
+	//  b → shared
+	lf := &Lockfile{
+		Specs: map[string]*Spec{
+			"a":      {Name: "a", Version: "1", Children: []string{"shared"}},
+			"b":      {Name: "b", Version: "1", Children: []string{"shared"}},
+			"shared": {Name: "shared", Version: "9.9"},
+		},
+		Dependencies: []Dependency{{Name: "a"}, {Name: "b"}},
+	}
+
+	g, err := BuildDepGraph("my-app", "1.0.0", lf)
+	require.NoError(t, err)
+
+	assert.Contains(t, nodeDeps(t, g, "a@1"), "shared@9.9")
+	assert.Contains(t, nodeDeps(t, g, "b@1"), "shared@9.9")
+}
+
+// TestBuildDepGraph_IncludeDevWired exercises the BuildOptions hook
+// (placeholder while Gemfile-level group info isn't surfaced). Today
+// this is a no-op: both runs should yield identical graphs.
+func TestBuildDepGraph_IncludeDevWired(t *testing.T) {
+	lf := &Lockfile{
+		Specs:        map[string]*Spec{"json": {Name: "json", Version: "2.0.2"}},
+		Dependencies: []Dependency{{Name: "json"}},
+	}
+
+	g1, err := BuildDepGraphWithOptions("app", "1.0", lf, BuildOptions{IncludeDev: false})
+	require.NoError(t, err)
+	g2, err := BuildDepGraphWithOptions("app", "1.0", lf, BuildOptions{IncludeDev: true})
+	require.NoError(t, err)
+
+	assert.Equal(t, len(g1.Pkgs), len(g2.Pkgs))
+	assert.ElementsMatch(t, rootDeps(t, g1), rootDeps(t, g2))
+}
+
+// TestBuildDepGraph_NilLockfile guards public-API misuse.
+func TestBuildDepGraph_NilLockfile(t *testing.T) {
+	_, err := BuildDepGraph("app", "1", nil)
+	assert.Error(t, err)
+}
+
+// TestBuildDepGraph_EmptyRoot guards public-API misuse.
+func TestBuildDepGraph_EmptyRoot(t *testing.T) {
+	_, err := BuildDepGraph("", "1", &Lockfile{Specs: map[string]*Spec{}})
+	assert.Error(t, err)
+}

--- a/pkg/ecosystems/ruby/bundler/parser.go
+++ b/pkg/ecosystems/ruby/bundler/parser.go
@@ -1,0 +1,295 @@
+// Package bundler implements a native parser for Bundler's Gemfile.lock
+// format and a SCAPlugin that turns it into a Snyk dep graph.
+//
+// The lockfile format is a simple indentation-driven text grammar with a
+// fixed set of top-level section headers (GEM, GIT, PATH, PLATFORMS,
+// DEPENDENCIES, BUNDLED WITH, RUBY VERSION, DEPENDENCIES). Each source
+// block (GEM/GIT/PATH) carries a `specs:` list of resolved gems with
+// their direct dependencies indented underneath. See:
+// https://bundler.io/v2.5/man/gemfile.5.html and
+// https://bundler.io/v2.5/man/bundle-lock.1.html
+//
+// This parser ports the logic of @snyk/gemfile (~150 LoC JS state
+// machine) to Go. Compared to the legacy parser we:
+//   - keep per-spec source metadata (GEM vs GIT vs PATH + remote/ref);
+//   - drop the "extractMeta" two-mode API in favor of a single
+//     structured Lockfile result.
+package bundler
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// section identifies the current top-level block being read.
+type section int
+
+const (
+	sectionNone section = iota
+	sectionGEM
+	sectionGIT
+	sectionPATH
+	sectionPlatforms
+	sectionDependencies
+	sectionBundledWith
+	sectionRubyVersion
+	sectionOther // for unknown headers — skipped gracefully
+)
+
+// Parse reads a Gemfile.lock from r and returns the parsed Lockfile.
+// Whitespace-only files and files missing required sections still parse
+// (legacy @snyk/gemfile prints a warning but returns whatever it has);
+// the caller decides whether the result is usable.
+func Parse(r io.Reader) (*Lockfile, error) {
+	if r == nil {
+		return nil, errors.New("bundler.Parse: nil reader")
+	}
+
+	lf := &Lockfile{Specs: make(map[string]*Spec)}
+
+	sc := bufio.NewScanner(r)
+	// Gemfile.lock lines are short, but bufio's default 64 KiB max-token
+	// is fine — bumped to 1 MiB just in case of very large lockfiles.
+	const maxLine = 1 << 20
+	sc.Buffer(make([]byte, 0, 64*1024), maxLine)
+
+	var (
+		cur       section = sectionNone
+		curSource *SourceMeta
+		// curSpec is the most recently-opened spec whose deps lines
+		// (indent depth 6) we may still be reading.
+		curSpec *Spec
+	)
+
+	for sc.Scan() {
+		raw := sc.Text()
+		trimmed := strings.TrimSpace(raw)
+
+		// Blank line terminates the current spec/source/section boundary
+		// only between blocks — we treat it as "leave curSpec open for
+		// the next non-blank line to decide". A blank between blocks is
+		// followed by a top-level header so curSource/curSpec get reset
+		// there.
+		if trimmed == "" {
+			continue
+		}
+
+		// Top-level header lines have no indentation.
+		if !startsWithSpace(raw) {
+			cur = parseHeader(trimmed)
+			curSpec = nil
+			switch cur {
+			case sectionGEM:
+				curSource = &SourceMeta{Type: SourceGEM}
+			case sectionGIT:
+				curSource = &SourceMeta{Type: SourceGIT}
+			case sectionPATH:
+				curSource = &SourceMeta{Type: SourcePATH}
+			default:
+				curSource = nil
+			}
+			continue
+		}
+
+		switch cur {
+		case sectionGEM, sectionGIT, sectionPATH:
+			parseSourceLine(raw, trimmed, curSource, &curSpec, lf)
+		case sectionPlatforms:
+			lf.Platforms = append(lf.Platforms, trimmed)
+		case sectionDependencies:
+			lf.Dependencies = append(lf.Dependencies, parseDependencyLine(trimmed))
+		case sectionBundledWith:
+			// Single value line beneath BUNDLED WITH; if multiple appear, keep the first.
+			if lf.BundledWith == "" {
+				lf.BundledWith = trimmed
+			}
+		case sectionRubyVersion:
+			if lf.RubyVersion == "" {
+				lf.RubyVersion = strings.TrimPrefix(trimmed, "ruby ")
+			}
+		case sectionOther, sectionNone:
+			// Unknown section: skip.
+		}
+	}
+	if err := sc.Err(); err != nil {
+		return nil, fmt.Errorf("bundler.Parse: scanning lockfile: %w", err)
+	}
+
+	return lf, nil
+}
+
+// parseHeader returns the section for a top-level header line (already trimmed).
+// Unknown headers map to sectionOther; the parser skips their body.
+func parseHeader(line string) section {
+	switch line {
+	case "GEM":
+		return sectionGEM
+	case "GIT":
+		return sectionGIT
+	case "PATH":
+		return sectionPATH
+	case "PLATFORMS":
+		return sectionPlatforms
+	case "DEPENDENCIES":
+		return sectionDependencies
+	case "BUNDLED WITH":
+		return sectionBundledWith
+	case "RUBY VERSION":
+		return sectionRubyVersion
+	default:
+		return sectionOther
+	}
+}
+
+// parseSourceLine handles a single line inside a GEM/GIT/PATH block.
+// Indent depth disambiguates the role:
+//
+//	2 spaces ("  remote: foo")  → source metadata key/value
+//	2 spaces ("  specs:")       → start of specs list (state marker)
+//	4 spaces ("    name (1.0)") → spec entry (opens curSpec)
+//	6 spaces ("      child")    → dependency child of the current spec
+func parseSourceLine(raw, trimmed string, src *SourceMeta, curSpec **Spec, lf *Lockfile) {
+	indent := leadingSpaces(raw)
+
+	switch indent {
+	case 2:
+		// Source metadata line OR the `specs:` marker.
+		key, value := splitKeyValue(trimmed)
+		switch key {
+		case "remote":
+			if src != nil {
+				src.Remote = value
+			}
+		case "revision":
+			if src != nil {
+				src.Revision = value
+			}
+		case "ref":
+			if src != nil {
+				src.Ref = value
+			}
+		case "branch":
+			if src != nil {
+				src.Branch = value
+			}
+		case "tag":
+			if src != nil {
+				src.Tag = value
+			}
+		case "glob":
+			if src != nil {
+				src.Glob = value
+			}
+		case "specs":
+			// just a marker; nothing to record
+		}
+	case 4:
+		// Spec entry: "name (version)" or "name (version-platform)".
+		// Open a new spec; the previous spec is implicitly closed.
+		name, version := parseSpecLine(trimmed)
+		spec := &Spec{Name: name, Version: version, Source: src}
+		// Last-write wins to match @snyk/gemfile.
+		lf.Specs[name] = spec
+		*curSpec = spec
+	case 6:
+		// Child dependency of the currently-open spec. Constraint info
+		// (e.g. "(~> 2.3.0)") is discarded — only the gem name matters
+		// because the resolved version is in lf.Specs.
+		if *curSpec == nil {
+			return
+		}
+		childName, _ := parseSpecLine(trimmed)
+		if childName != "" {
+			(*curSpec).Children = append((*curSpec).Children, childName)
+		}
+	default:
+		// Unknown indent depth — skip rather than guessing.
+	}
+}
+
+// parseSpecLine parses "name (version)" or "name (version-platform)" or
+// "name" (bare; e.g. a child dep with no constraint). Anything in
+// parentheses after the name is treated as the version; the rest is
+// dropped. Returns ("", "") for empty input.
+func parseSpecLine(s string) (name, version string) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return "", ""
+	}
+	i := strings.IndexByte(s, '(')
+	if i < 0 {
+		return s, ""
+	}
+	name = strings.TrimSpace(s[:i])
+	rest := s[i+1:]
+	j := strings.IndexByte(rest, ')')
+	if j < 0 {
+		return name, ""
+	}
+	return name, strings.TrimSpace(rest[:j])
+}
+
+// parseDependencyLine handles one line under the DEPENDENCIES block.
+// Strips the trailing `!` marker (used for git/path-sourced gems) and
+// discards any version constraint in parens.
+//
+//	"rspec!"                  → {Name: "rspec",   Pinned: true}
+//	"json"                    → {Name: "json",    Pinned: false}
+//	"lynx (= 0.4.0)"          → {Name: "lynx",    Pinned: false}
+//	"nokogiri (= 1.0.0)!"     → {Name: "nokogiri", Pinned: true}
+func parseDependencyLine(s string) Dependency {
+	s = strings.TrimSpace(s)
+	// Drop "(...)" version constraint if present.
+	if i := strings.IndexByte(s, '('); i >= 0 {
+		// What follows the `)` may still hold the `!` marker.
+		// Reconstruct as "<name><trailing-after-close>".
+		if j := strings.IndexByte(s, ')'); j > i {
+			s = strings.TrimSpace(s[:i]) + s[j+1:]
+		} else {
+			s = strings.TrimSpace(s[:i])
+		}
+	}
+	s = strings.TrimSpace(s)
+
+	pinned := strings.HasSuffix(s, "!")
+	if pinned {
+		s = strings.TrimSuffix(s, "!")
+		s = strings.TrimSpace(s)
+	}
+	return Dependency{Name: s, Pinned: pinned}
+}
+
+// splitKeyValue splits "key: value" on the first ':'. Returns the key
+// and value with surrounding whitespace stripped. If no ':' is found,
+// returns the whole input as the key and an empty value.
+func splitKeyValue(s string) (key, value string) {
+	i := strings.IndexByte(s, ':')
+	if i < 0 {
+		return strings.TrimSpace(s), ""
+	}
+	return strings.TrimSpace(s[:i]), strings.TrimSpace(s[i+1:])
+}
+
+// leadingSpaces returns the count of leading ' ' characters in s.
+// (Tabs are not used in Gemfile.lock by bundler; they would be counted
+// as non-space and produce indent 0, which downstream code treats as
+// "skip / unknown".)
+func leadingSpaces(s string) int {
+	n := 0
+	for n < len(s) && s[n] == ' ' {
+		n++
+	}
+	return n
+}
+
+// startsWithSpace reports whether s begins with one or more spaces or tabs.
+func startsWithSpace(s string) bool {
+	if s == "" {
+		return false
+	}
+	c := s[0]
+	return c == ' ' || c == '\t'
+}

--- a/pkg/ecosystems/ruby/bundler/parser_test.go
+++ b/pkg/ecosystems/ruby/bundler/parser_test.go
@@ -1,0 +1,308 @@
+package bundler
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestParse_Simple covers the canonical GEM-only Gemfile.lock with PLATFORMS,
+// DEPENDENCIES, and BUNDLED WITH — the format produced by 95%+ of real
+// bundler projects.
+func TestParse_Simple(t *testing.T) {
+	src := `GEM
+  remote: http://rubygems.org/
+  specs:
+    json (2.0.2)
+    lynx (0.4.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  json
+  lynx (= 0.4.0)
+
+BUNDLED WITH
+   1.13.5
+`
+	lf, err := Parse(strings.NewReader(src))
+	require.NoError(t, err)
+
+	require.Contains(t, lf.Specs, "json")
+	require.Contains(t, lf.Specs, "lynx")
+	assert.Equal(t, "2.0.2", lf.Specs["json"].Version)
+	assert.Equal(t, "0.4.0", lf.Specs["lynx"].Version)
+	assert.Equal(t, SourceGEM, lf.Specs["json"].Source.Type)
+	assert.Equal(t, "http://rubygems.org/", lf.Specs["json"].Source.Remote)
+
+	require.Len(t, lf.Dependencies, 2)
+	assert.Equal(t, "json", lf.Dependencies[0].Name)
+	assert.False(t, lf.Dependencies[0].Pinned)
+	assert.Equal(t, "lynx", lf.Dependencies[1].Name)
+
+	assert.Equal(t, []string{"ruby"}, lf.Platforms)
+	assert.Equal(t, "1.13.5", lf.BundledWith)
+}
+
+// TestParse_SpecChildren verifies that nested deps under a spec are
+// captured (indent depth 6 lines), and that version constraints in
+// parens are discarded (we only need names; versions live in lf.Specs).
+func TestParse_SpecChildren(t *testing.T) {
+	src := `GEM
+  remote: https://rubygems.org/
+  specs:
+    nokogiri (1.8.5)
+      mini_portile2 (~> 2.3.0)
+    mini_portile2 (2.3.0)
+    sanitize (4.6.2)
+      crass (~> 1.0.2)
+      nokogiri (>= 1.4.4)
+    crass (1.0.4)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  sanitize
+
+BUNDLED WITH
+   1.16.5
+`
+	lf, err := Parse(strings.NewReader(src))
+	require.NoError(t, err)
+
+	require.Contains(t, lf.Specs, "nokogiri")
+	assert.Equal(t, []string{"mini_portile2"}, lf.Specs["nokogiri"].Children)
+	require.Contains(t, lf.Specs, "sanitize")
+	assert.Equal(t, []string{"crass", "nokogiri"}, lf.Specs["sanitize"].Children)
+	assert.Empty(t, lf.Specs["crass"].Children)
+}
+
+// TestParse_WithGitDeps covers GIT blocks and the `!` marker on
+// DEPENDENCIES entries — both ported from the legacy plugin and
+// verified by the registry's with-git-specs fixture.
+func TestParse_WithGitDeps(t *testing.T) {
+	src := `GIT
+  remote: https://github.com/rspec/rspec.git
+  revision: bc209d4a2a2dfbf38ac1d470b213753aa9e654db
+  specs:
+    rspec (3.6.0.beta1)
+      rspec-core (= 3.6.0.beta1)
+
+GIT
+  remote: https://github.com/sparklemotion/nokogiri.git
+  revision: 7f8b7b2bf55829e02cd11c2eb25814c3ed458676
+  specs:
+    nokogiri (1.0.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    rspec-core (3.6.0.beta1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  nokogiri (= 1.0.0)!
+  rspec!
+
+BUNDLED WITH
+   1.13.6
+`
+	lf, err := Parse(strings.NewReader(src))
+	require.NoError(t, err)
+
+	// GIT-sourced specs are present and tagged.
+	require.Contains(t, lf.Specs, "rspec")
+	require.Contains(t, lf.Specs, "nokogiri")
+	require.NotNil(t, lf.Specs["rspec"].Source)
+	assert.Equal(t, SourceGIT, lf.Specs["rspec"].Source.Type)
+	assert.Equal(t, "https://github.com/rspec/rspec.git", lf.Specs["rspec"].Source.Remote)
+	assert.Equal(t, "bc209d4a2a2dfbf38ac1d470b213753aa9e654db", lf.Specs["rspec"].Source.Revision)
+
+	// `!` marker stripped, but flag preserved in Pinned.
+	require.Len(t, lf.Dependencies, 2)
+	assert.Equal(t, "nokogiri", lf.Dependencies[0].Name)
+	assert.True(t, lf.Dependencies[0].Pinned, "nokogiri dep line has `!`")
+	assert.Equal(t, "rspec", lf.Dependencies[1].Name)
+	assert.True(t, lf.Dependencies[1].Pinned, "rspec dep line has `!`")
+}
+
+// TestParse_WithPathDeps covers a PATH block (gemspec project).
+func TestParse_WithPathDeps(t *testing.T) {
+	src := `PATH
+  remote: .
+  specs:
+    ruby-gem (0.1.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    rake (10.5.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bundler (~> 1.13)
+  rake (~> 10.0)
+  ruby-gem!
+
+BUNDLED WITH
+   1.13.5
+`
+	lf, err := Parse(strings.NewReader(src))
+	require.NoError(t, err)
+
+	require.Contains(t, lf.Specs, "ruby-gem")
+	assert.Equal(t, SourcePATH, lf.Specs["ruby-gem"].Source.Type)
+	assert.Equal(t, ".", lf.Specs["ruby-gem"].Source.Remote)
+
+	// bundler appears in DEPENDENCIES but won't have a spec — that's
+	// expected (legacy parser also silently skips it).
+	require.Len(t, lf.Dependencies, 3)
+	assert.Equal(t, "bundler", lf.Dependencies[0].Name)
+	assert.Equal(t, "ruby-gem", lf.Dependencies[2].Name)
+	assert.True(t, lf.Dependencies[2].Pinned)
+}
+
+// TestParse_WithPlatforms preserves multiple platform entries verbatim.
+func TestParse_WithPlatforms(t *testing.T) {
+	src := `GEM
+  remote: https://rubygems.org/
+  specs:
+    json (2.0.2)
+
+PLATFORMS
+  ruby
+  x86_64-linux
+  arm64-darwin
+
+DEPENDENCIES
+  json
+
+BUNDLED WITH
+   2.4.10
+`
+	lf, err := Parse(strings.NewReader(src))
+	require.NoError(t, err)
+	assert.Equal(t, []string{"ruby", "x86_64-linux", "arm64-darwin"}, lf.Platforms)
+}
+
+// TestParse_RubyVersion captures the RUBY VERSION block.
+func TestParse_RubyVersion(t *testing.T) {
+	src := `GEM
+  remote: https://rubygems.org/
+  specs:
+    json (2.0.2)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  json
+
+RUBY VERSION
+   ruby 2.7.0p0
+
+BUNDLED WITH
+   2.1.4
+`
+	lf, err := Parse(strings.NewReader(src))
+	require.NoError(t, err)
+	assert.Equal(t, "2.7.0p0", lf.RubyVersion)
+}
+
+// TestParse_Empty handles a fully blank file and a header-only file
+// without panicking.
+func TestParse_Empty(t *testing.T) {
+	lf, err := Parse(strings.NewReader(""))
+	require.NoError(t, err)
+	assert.NotNil(t, lf)
+	assert.Empty(t, lf.Specs)
+	assert.Empty(t, lf.Dependencies)
+}
+
+// TestParse_DependencyVariants exercises the line-shapes seen in real
+// lockfiles for the DEPENDENCIES block.
+func TestParse_DependencyVariants(t *testing.T) {
+	src := `GEM
+  remote: https://rubygems.org/
+  specs:
+    a (1.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bare-name
+  pinned-name!
+  versioned (= 1.2.3)
+  versioned-and-pinned (~> 2.0)!
+`
+	lf, err := Parse(strings.NewReader(src))
+	require.NoError(t, err)
+	require.Len(t, lf.Dependencies, 4)
+	assert.Equal(t, "bare-name", lf.Dependencies[0].Name)
+	assert.False(t, lf.Dependencies[0].Pinned)
+	assert.Equal(t, "pinned-name", lf.Dependencies[1].Name)
+	assert.True(t, lf.Dependencies[1].Pinned)
+	assert.Equal(t, "versioned", lf.Dependencies[2].Name)
+	assert.False(t, lf.Dependencies[2].Pinned)
+	assert.Equal(t, "versioned-and-pinned", lf.Dependencies[3].Name)
+	assert.True(t, lf.Dependencies[3].Pinned)
+}
+
+// TestParse_SpecLine covers the parseSpecLine helper directly: bare
+// names, version, version+platform, malformed.
+func TestParse_SpecLine(t *testing.T) {
+	cases := []struct {
+		in              string
+		wantName, wantV string
+	}{
+		{"nokogiri (1.8.5)", "nokogiri", "1.8.5"},
+		{"nokogiri (1.8.5-x86_64-linux)", "nokogiri", "1.8.5-x86_64-linux"},
+		{"bare", "bare", ""},
+		{"  trimmed (= 1.0)", "trimmed", "= 1.0"},
+		{"", "", ""},
+		{"oddly-formed (", "oddly-formed", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			name, v := parseSpecLine(tc.in)
+			assert.Equal(t, tc.wantName, name)
+			assert.Equal(t, tc.wantV, v)
+		})
+	}
+}
+
+// TestParse_NilReader is a guard against accidentally passing nil.
+func TestParse_NilReader(t *testing.T) {
+	_, err := Parse(nil)
+	assert.Error(t, err)
+}
+
+// TestParseDependencyLine covers all observed forms.
+func TestParseDependencyLine(t *testing.T) {
+	cases := []struct {
+		in   string
+		want Dependency
+	}{
+		{"json", Dependency{Name: "json"}},
+		{"lynx (= 0.4.0)", Dependency{Name: "lynx"}},
+		{"rspec!", Dependency{Name: "rspec", Pinned: true}},
+		{"nokogiri (= 1.0.0)!", Dependency{Name: "nokogiri", Pinned: true}},
+		{"bundler (~> 1.13)", Dependency{Name: "bundler"}},
+		{"   padded  ", Dependency{Name: "padded"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			got := parseDependencyLine(tc.in)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/pkg/ecosystems/ruby/bundler/plugin.go
+++ b/pkg/ecosystems/ruby/bundler/plugin.go
@@ -1,0 +1,279 @@
+package bundler
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/snyk/dep-graph/go/pkg/depgraph"
+
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/discovery"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/logger"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/identity"
+)
+
+const (
+	// PluginName matches the legacy "bundled:rubygems" project type used
+	// in the CLI for identity. The orchestrator key is "bundler" to
+	// disambiguate from any future native Bundler runtime work.
+	PluginName = "bundler"
+
+	gemfileLockName = "Gemfile.lock"
+	gemfileName     = "Gemfile"
+
+	logFieldLockFile = "lockFile"
+)
+
+// Plugin implements ecosystems.SCAPlugin for Bundler projects via a
+// native Gemfile.lock parser (no `bundle install`, no `bundle viz`,
+// no network).
+//
+// Approach is a forced exception to the "delegate to the package
+// manager's CLI" principle: every bundler subcommand that emits a dep
+// graph requires `bundle install` first (which mutates the project
+// directory). The lockfile is well-spec'd plain text, so native parsing
+// is the only offline-and-install-free option.
+type Plugin struct{}
+
+var _ ecosystems.SCAPlugin = (*Plugin)(nil)
+
+func (p Plugin) GetName() string { return PluginName }
+
+// BuildDepGraphsFromDir discovers Gemfile.lock files under dir and
+// produces a dep graph per lockfile. Bundler has no workspace concept,
+// so each lockfile yields exactly one SCAResult.
+func (p Plugin) BuildDepGraphsFromDir(
+	ctx context.Context,
+	log logger.Logger,
+	dir string,
+	options *ecosystems.SCAPluginOptions,
+	onGraph ecosystems.OnGraphFunc,
+) error {
+	if log == nil {
+		log = logger.Nop()
+	}
+	if options == nil {
+		options = ecosystems.NewPluginOptions()
+	}
+
+	files, err := p.discoverLockFiles(ctx, dir, options)
+	if err != nil {
+		return err
+	}
+	if len(files) == 0 {
+		log.Debug(ctx, "No Gemfile.lock files found", logger.Attr("dir", dir))
+		return nil
+	}
+
+	log.Debug(ctx, "Discovered Gemfile.lock files", logger.Attr("count", len(files)))
+
+	for _, f := range files {
+		result := p.buildResult(ctx, log, dir, f.Path, f.RelPath, options)
+		if result.Error != nil {
+			log.Error(ctx, "Failed to build bundler dependency graph",
+				logger.Attr(logFieldLockFile, f.RelPath),
+				logger.Err(result.Error),
+			)
+		}
+		if err := onGraph(result); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// buildResult parses one Gemfile.lock, derives the root identity, and
+// constructs the dep graph. All failure modes are funneled into a
+// SCAResult{Error: ...} so the orchestrator can surface them per project.
+func (p Plugin) buildResult(
+	ctx context.Context,
+	log logger.Logger,
+	scanRoot, absLockPath, relLockPath string,
+	options *ecosystems.SCAPluginOptions,
+) ecosystems.SCAResult {
+	_ = ctx
+	rootName := deriveRootName(scanRoot, relLockPath, options)
+
+	errResult := func(err error) ecosystems.SCAResult {
+		tf := relLockPath
+		return ecosystems.SCAResult{
+			ProjectDescriptor: identity.ProjectDescriptor{
+				Identity: identity.ProjectIdentity{
+					ProjectType:       PluginName,
+					TargetFile:        &tf,
+					RootComponentName: rootName,
+				},
+			},
+			ResolverMetadata: &ecosystems.ResolverMetadata{
+				PluginName:           PluginName,
+				NormalisedTargetFile: relLockPath,
+			},
+			ProcessedFiles: []string{relLockPath},
+			Error:          err,
+		}
+	}
+
+	f, err := os.Open(absLockPath)
+	if err != nil {
+		return errResult(fmt.Errorf("reading %s: %w", relLockPath, err))
+	}
+	defer f.Close()
+
+	lf, err := Parse(f)
+	if err != nil {
+		return errResult(fmt.Errorf("parsing %s: %w", relLockPath, err))
+	}
+	if len(lf.Dependencies) == 0 {
+		log.Debug(ctx, "Gemfile.lock has no DEPENDENCIES block",
+			logger.Attr(logFieldLockFile, relLockPath))
+	}
+
+	log.Info(ctx, "Building bundler dependency graph",
+		logger.Attr(logFieldLockFile, relLockPath),
+		logger.Attr("specs", len(lf.Specs)),
+		logger.Attr("directDeps", len(lf.Dependencies)),
+	)
+
+	graph, err := BuildDepGraphWithOptions(rootName, "", lf, BuildOptions{
+		IncludeDev: options.Global.IncludeDev,
+	})
+	if err != nil {
+		return errResult(fmt.Errorf("building dep graph for %s: %w", relLockPath, err))
+	}
+
+	tf := relLockPath
+	return ecosystems.SCAResult{
+		DepGraph: graph,
+		ProjectDescriptor: identity.ProjectDescriptor{
+			Identity: identity.ProjectIdentity{
+				ProjectType:       PluginName,
+				TargetFile:        &tf,
+				RootComponentName: graphRootName(graph),
+			},
+		},
+		ResolverMetadata: &ecosystems.ResolverMetadata{
+			PluginName:           PluginName,
+			NormalisedTargetFile: relLockPath,
+		},
+		ProcessedFiles: []string{relLockPath},
+	}
+}
+
+func graphRootName(g *depgraph.DepGraph) string {
+	if g == nil {
+		return ""
+	}
+	root := g.GetRootPkg()
+	if root == nil {
+		return ""
+	}
+	return root.Info.Name
+}
+
+// deriveRootName matches the legacy identity contract:
+//
+//	rootPkg.name = basename(root)
+//
+// Project-name overrides come from the orchestrator-supplied option
+// (--project-name).
+//
+// When the user invokes with --target-file pointing at a nested
+// Gemfile.lock, the legacy plugin uses basename(root) (the scan root,
+// not the lockfile's parent). We preserve that.
+func deriveRootName(scanRoot, relLockPath string, options *ecosystems.SCAPluginOptions) string {
+	if options != nil && options.Global.ProjectName != nil && *options.Global.ProjectName != "" {
+		return *options.Global.ProjectName
+	}
+	// For nested lockfiles discovered via --all-projects, suffix the
+	// subdirectory so each result has a distinct root name. Plain
+	// single-lockfile scans use just the scan root's basename.
+	base := filepath.Base(scanRoot)
+	subDir := filepath.Dir(relLockPath)
+	if subDir == "." || subDir == "" {
+		return base
+	}
+	return filepath.ToSlash(filepath.Join(base, subDir))
+}
+
+// discoverLockFiles mirrors javascript/bun's pattern: --target-file
+// pins the discovery to a single file (must be a Gemfile or
+// Gemfile.lock); --all-projects walks the tree; default is "root dir
+// only, no error if missing".
+//
+// When --target-file names a Gemfile (not Gemfile.lock), we accept it
+// and silently look for the sibling Gemfile.lock — matching the legacy
+// inspector behavior which treats Gemfile as "use its lockfile".
+func (p Plugin) discoverLockFiles(
+	ctx context.Context,
+	dir string,
+	options *ecosystems.SCAPluginOptions,
+) ([]discovery.FindResult, error) {
+	switch {
+	case options.Global.TargetFile != nil:
+		tf := *options.Global.TargetFile
+		base := filepath.Base(tf)
+		// Accept Gemfile, Gemfile.lock, or a custom-named gemfile (the
+		// legacy plugin uses a permissive regex; we match basename
+		// suffix here for predictability).
+		if !looksLikeGemfile(base) {
+			return nil, nil
+		}
+
+		// Resolve to the lockfile path. If the targetFile is "Gemfile",
+		// look for "Gemfile.lock" alongside it. If it's already the
+		// .lock, use it directly.
+		lockRel := tf
+		if !strings.HasSuffix(base, ".lock") {
+			lockRel = tf + ".lock"
+		}
+
+		abs := lockRel
+		if !filepath.IsAbs(abs) {
+			abs = filepath.Join(dir, lockRel)
+		}
+		if !fileExists(abs) {
+			return nil, nil
+		}
+		return []discovery.FindResult{{Path: abs, RelPath: lockRel}}, nil
+
+	case options.Global.AllProjects:
+		findOpts := []discovery.FindOption{
+			discovery.WithInclude(gemfileLockName),
+			discovery.WithCommonExcludes(),
+		}
+		if len(options.Global.Exclude) > 0 {
+			findOpts = append(findOpts, discovery.WithExcludes(options.Global.Exclude...))
+		}
+		if len(options.Global.ExcludePaths) > 0 {
+			findOpts = append(findOpts, discovery.WithExcludes(options.Global.ExcludePaths...))
+		}
+		files, err := discovery.FindFiles(ctx, dir, findOpts...)
+		if err != nil {
+			return nil, fmt.Errorf("discovering Gemfile.lock files: %w", err)
+		}
+		return files, nil
+
+	default:
+		root := filepath.Join(dir, gemfileLockName)
+		if !fileExists(root) {
+			return nil, nil
+		}
+		return []discovery.FindResult{{Path: root, RelPath: gemfileLockName}}, nil
+	}
+}
+
+// looksLikeGemfile mirrors the legacy regex
+// `/.*[gG]emfile.*(\.lock)?.*$/` in plain Go: case-insensitive contains
+// "gemfile", with or without ".lock".
+func looksLikeGemfile(base string) bool {
+	lower := strings.ToLower(base)
+	return strings.Contains(lower, "gemfile")
+}
+
+func fileExists(p string) bool {
+	info, err := os.Stat(p)
+	return err == nil && !info.IsDir()
+}

--- a/pkg/ecosystems/ruby/bundler/plugin_integration_test.go
+++ b/pkg/ecosystems/ruby/bundler/plugin_integration_test.go
@@ -1,0 +1,193 @@
+//go:build integration && bundler
+// +build integration,bundler
+
+package bundler_test
+
+// plugin_integration_test.go verifies the bundler plugin against golden
+// dep graphs stored in testdata/acceptance/. Each fixture directory
+// contains a Gemfile.lock (and optionally a Gemfile/.gemspec) plus an
+// expected.json capturing the dep graph the plugin produces.
+//
+// Unlike most ecosystems' integration tests, no external tool is
+// required: the bundler plugin parses Gemfile.lock natively. The build
+// tag `integration && bundler` is preserved for parity with the rest
+// of the suite and to keep these fixtures out of the default `go test
+// ./...` run while we iterate on the divergence corpus.
+//
+// Run with:
+//   go test -v -tags="integration,bundler" ./pkg/ecosystems/ruby/bundler/...
+// Update goldens:
+//   go test -v -tags="integration,bundler" -run TestAcceptance \
+//       ./pkg/ecosystems/ruby/bundler/... -update
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/snyk/dep-graph/go/pkg/depgraph"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/logger"
+	bundlerpkg "github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/ruby/bundler"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/scatest"
+)
+
+var updateGolden = flag.Bool("update", false, "overwrite expected.json golden files with current plugin output")
+
+type fixture struct {
+	name string
+	dir  string
+}
+
+// discoverFixtures finds every directory under base that contains a
+// Gemfile.lock — this is what makes the suite extensible (drop a new
+// directory in, it gets picked up).
+func discoverFixtures(t *testing.T, base string) []fixture {
+	t.Helper()
+	entries, err := os.ReadDir(base)
+	require.NoError(t, err, "reading %s", base)
+
+	out := make([]fixture, 0, len(entries))
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		dir := filepath.Join(base, e.Name())
+		if _, err := os.Stat(filepath.Join(dir, "Gemfile.lock")); err != nil {
+			continue
+		}
+		out = append(out, fixture{name: e.Name(), dir: dir})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].name < out[j].name })
+	return out
+}
+
+// TestAcceptance runs every smoke fixture under testdata/acceptance/
+// against the plugin and compares to its expected.json golden.
+//
+// Critically: the test ALSO asserts that no install artefacts
+// (`vendor/`, `.bundle/`) appear in the fixture directory after the
+// run. Bundler's `install` family of subcommands would create those;
+// the native parser must never. This is the principle-#2 ("install
+// free") gate for this ecosystem.
+func TestAcceptance(t *testing.T) {
+	fixtures := discoverFixtures(t, filepath.Join("testdata", "acceptance"))
+	require.NotEmpty(t, fixtures, "no fixtures discovered")
+
+	plugin := bundlerpkg.Plugin{}
+
+	for _, fx := range fixtures {
+		t.Run(fx.name, func(t *testing.T) {
+			assertNoInstallArtefacts(t, fx.dir, "before run")
+
+			results, err := scatest.Run(context.Background(), plugin, logger.Nop(), fx.dir,
+				ecosystems.NewPluginOptions())
+			require.NoError(t, err)
+			require.Len(t, results, 1, "bundler emits exactly one graph per Gemfile.lock")
+
+			r := results[0]
+			require.NoError(t, r.Error)
+			require.NotNil(t, r.DepGraph)
+
+			assertNoInstallArtefacts(t, fx.dir, "after run — native parser must not install")
+
+			goldenPath := filepath.Join(fx.dir, "expected.json")
+			if *updateGolden {
+				data, err := json.MarshalIndent(r.DepGraph, "", "  ")
+				require.NoError(t, err)
+				require.NoError(t, os.WriteFile(goldenPath, append(data, '\n'), 0o600))
+				t.Logf("updated %s", goldenPath)
+				return
+			}
+
+			raw, err := os.ReadFile(goldenPath)
+			require.NoError(t, err, "reading %s", goldenPath)
+			expected, err := depgraph.UnmarshalJSON(raw)
+			require.NoError(t, err, "parsing %s", goldenPath)
+
+			assert.Equal(t,
+				normalizedJSON(t, expected),
+				normalizedJSON(t, r.DepGraph),
+				"dep graph mismatch in %s — re-run with -update to refresh", fx.name)
+		})
+	}
+}
+
+// assertNoInstallArtefacts is the principle-#2 gate: native parsing
+// must never create vendor/, .bundle/, or similar install side-effects
+// in the fixture directory. If this ever fires, something invoked
+// `bundle install` (or an equivalent) which it must not.
+func assertNoInstallArtefacts(t *testing.T, dir, when string) {
+	t.Helper()
+	for _, artefact := range []string{"vendor", ".bundle"} {
+		path := filepath.Join(dir, artefact)
+		if _, err := os.Stat(path); err == nil {
+			t.Fatalf("install artefact %q exists in %s (%s) — the bundler plugin must never install",
+				artefact, dir, when)
+		} else if !os.IsNotExist(err) {
+			t.Fatalf("stat %q: %v", path, err)
+		}
+	}
+}
+
+// normalizedJSON re-marshals a dep graph through the canonical JSON
+// shape so two equivalent graphs (e.g. dep order differing in a way
+// the schema doesn't pin) compare equal. The Pkgs and per-node Deps
+// arrays are sorted; everything else is left as-is.
+func normalizedJSON(t *testing.T, dg *depgraph.DepGraph) string {
+	t.Helper()
+	// Round-trip through JSON to a generic map so we can sort
+	// schema-flexible arrays without leaking depgraph internals.
+	data, err := json.Marshal(dg)
+	require.NoError(t, err)
+
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(data, &m))
+
+	if pkgs, ok := m["pkgs"].([]any); ok {
+		sort.Slice(pkgs, func(i, j int) bool {
+			return pkgID(pkgs[i]) < pkgID(pkgs[j])
+		})
+	}
+	if g, ok := m["graph"].(map[string]any); ok {
+		if nodes, ok := g["nodes"].([]any); ok {
+			sort.Slice(nodes, func(i, j int) bool {
+				return nodeID(nodes[i]) < nodeID(nodes[j])
+			})
+			for _, n := range nodes {
+				if nm, ok := n.(map[string]any); ok {
+					if deps, ok := nm["deps"].([]any); ok {
+						sort.Slice(deps, func(i, j int) bool {
+							return nodeID(deps[i]) < nodeID(deps[j])
+						})
+					}
+				}
+			}
+		}
+	}
+
+	out, err := json.MarshalIndent(m, "", "  ")
+	require.NoError(t, err)
+	return string(out)
+}
+
+func pkgID(v any) string {
+	m, _ := v.(map[string]any)
+	id, _ := m["id"].(string)
+	return id
+}
+
+func nodeID(v any) string {
+	m, _ := v.(map[string]any)
+	if id, ok := m["nodeId"].(string); ok {
+		return id
+	}
+	return ""
+}

--- a/pkg/ecosystems/ruby/bundler/plugin_test.go
+++ b/pkg/ecosystems/ruby/bundler/plugin_test.go
@@ -1,0 +1,233 @@
+package bundler
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/logger"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/scatest"
+)
+
+// writeFile is a t.TempDir helper for fixture setup.
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+}
+
+// simpleLock is the minimal valid Gemfile.lock used across plugin tests.
+const simpleLock = `GEM
+  remote: http://rubygems.org/
+  specs:
+    json (2.0.2)
+    lynx (0.4.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  json
+  lynx (= 0.4.0)
+
+BUNDLED WITH
+   1.13.5
+`
+
+func TestPlugin_GetName(t *testing.T) {
+	assert.Equal(t, "bundler", Plugin{}.GetName())
+}
+
+func TestPlugin_BuildsGraphFromGemfileLock(t *testing.T) {
+	tmp := t.TempDir()
+	writeFile(t, filepath.Join(tmp, "Gemfile.lock"), simpleLock)
+
+	results, err := scatest.Run(context.Background(), Plugin{}, logger.Nop(), tmp,
+		ecosystems.NewPluginOptions())
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	r := results[0]
+	require.NoError(t, r.Error)
+	require.NotNil(t, r.DepGraph)
+
+	// Identity contract: rootPkg.name = basename(dir).
+	assert.Equal(t, filepath.Base(tmp), r.DepGraph.GetRootPkg().Info.Name)
+	assert.Equal(t, "Gemfile.lock", r.ProjectDescriptor.GetTargetFile())
+	assert.Equal(t, []string{"Gemfile.lock"}, r.ProcessedFiles)
+	require.NotNil(t, r.ResolverMetadata)
+	assert.Equal(t, "bundler", r.ResolverMetadata.PluginName)
+
+	ids := make(map[string]bool, len(r.DepGraph.Pkgs))
+	for _, p := range r.DepGraph.Pkgs {
+		ids[p.ID] = true
+	}
+	assert.True(t, ids["json@2.0.2"])
+	assert.True(t, ids["lynx@0.4.0"])
+}
+
+// TestPlugin_NoGemfileLock returns empty (not an error) — matches the
+// bun-style default-mode behavior in javascript/bun/plugin.go.
+func TestPlugin_NoGemfileLock(t *testing.T) {
+	results, err := scatest.Run(context.Background(), Plugin{}, logger.Nop(), t.TempDir(),
+		ecosystems.NewPluginOptions())
+	require.NoError(t, err)
+	assert.Empty(t, results)
+}
+
+func TestPlugin_TargetFileGemfile(t *testing.T) {
+	tmp := t.TempDir()
+	writeFile(t, filepath.Join(tmp, "Gemfile"), "source 'https://rubygems.org'\n")
+	writeFile(t, filepath.Join(tmp, "Gemfile.lock"), simpleLock)
+
+	// Caller passes the Gemfile path — plugin should still find the
+	// sibling Gemfile.lock (legacy parity).
+	opts := ecosystems.NewPluginOptions().WithTargetFile("Gemfile")
+	results, err := scatest.Run(context.Background(), Plugin{}, logger.Nop(), tmp, opts)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	require.NoError(t, results[0].Error)
+	// The reported target file is the lockfile we actually consulted.
+	assert.Equal(t, "Gemfile.lock", results[0].ProjectDescriptor.GetTargetFile())
+}
+
+func TestPlugin_TargetFileGemfileLock(t *testing.T) {
+	tmp := t.TempDir()
+	writeFile(t, filepath.Join(tmp, "Gemfile.lock"), simpleLock)
+
+	opts := ecosystems.NewPluginOptions().WithTargetFile("Gemfile.lock")
+	results, err := scatest.Run(context.Background(), Plugin{}, logger.Nop(), tmp, opts)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	require.NoError(t, results[0].Error)
+}
+
+func TestPlugin_TargetFileNotGemfile(t *testing.T) {
+	tmp := t.TempDir()
+	writeFile(t, filepath.Join(tmp, "Gemfile.lock"), simpleLock)
+
+	// Some other lockfile — should not match.
+	opts := ecosystems.NewPluginOptions().WithTargetFile("Cargo.lock")
+	results, err := scatest.Run(context.Background(), Plugin{}, logger.Nop(), tmp, opts)
+	require.NoError(t, err)
+	assert.Empty(t, results)
+}
+
+// TestPlugin_CustomGemfileName covers the legacy "rails.2.4.5.gemfile"
+// flavor — basename contains "gemfile" anywhere.
+func TestPlugin_CustomGemfileName(t *testing.T) {
+	tmp := t.TempDir()
+	writeFile(t, filepath.Join(tmp, "rails.2.4.5.gemfile.lock"), simpleLock)
+
+	opts := ecosystems.NewPluginOptions().WithTargetFile("rails.2.4.5.gemfile.lock")
+	results, err := scatest.Run(context.Background(), Plugin{}, logger.Nop(), tmp, opts)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	require.NoError(t, results[0].Error)
+}
+
+// TestPlugin_AllProjects locates every Gemfile.lock under the tree, and
+// each nested result gets a distinct rootPkg name suffixed with the
+// subdirectory.
+func TestPlugin_AllProjects(t *testing.T) {
+	tmp := t.TempDir()
+	writeFile(t, filepath.Join(tmp, "Gemfile.lock"), simpleLock)
+	writeFile(t, filepath.Join(tmp, "nested", "Gemfile.lock"), simpleLock)
+
+	opts := ecosystems.NewPluginOptions().WithAllProjects(true)
+	results, err := scatest.Run(context.Background(), Plugin{}, logger.Nop(), tmp, opts)
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+
+	gotRoots := make(map[string]bool)
+	for _, r := range results {
+		require.NoError(t, r.Error)
+		gotRoots[r.DepGraph.GetRootPkg().Info.Name] = true
+	}
+	base := filepath.Base(tmp)
+	assert.True(t, gotRoots[base], "scan-root lockfile uses bare basename")
+	assert.True(t, gotRoots[base+"/nested"], "nested lockfile suffixes the relative dir")
+}
+
+// TestPlugin_ProjectNameOverride confirms the orchestrator-supplied
+// --project-name wins over the basename-derived default.
+func TestPlugin_ProjectNameOverride(t *testing.T) {
+	tmp := t.TempDir()
+	writeFile(t, filepath.Join(tmp, "Gemfile.lock"), simpleLock)
+
+	opts := ecosystems.NewPluginOptions().WithProjectName("my-explicit-name")
+	results, err := scatest.Run(context.Background(), Plugin{}, logger.Nop(), tmp, opts)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "my-explicit-name", results[0].DepGraph.GetRootPkg().Info.Name)
+}
+
+// TestPlugin_DiscoverHonorsExcludePaths mirrors the bun-style
+// exclude-paths contract.
+func TestPlugin_DiscoverHonorsExcludePaths(t *testing.T) {
+	tmp := t.TempDir()
+	for _, rel := range []string{"Gemfile.lock", "a/Gemfile.lock", "b/Gemfile.lock"} {
+		writeFile(t, filepath.Join(tmp, rel), simpleLock)
+	}
+	opts := ecosystems.NewPluginOptions().
+		WithAllProjects(true).
+		WithExcludePaths([]string{"a/Gemfile.lock"})
+
+	got, err := Plugin{}.discoverLockFiles(context.Background(), tmp, opts)
+	require.NoError(t, err)
+
+	rels := make([]string, 0, len(got))
+	for _, r := range got {
+		rels = append(rels, r.RelPath)
+	}
+	assert.NotContains(t, rels, "a/Gemfile.lock")
+	assert.Contains(t, rels, "Gemfile.lock")
+	assert.Contains(t, rels, "b/Gemfile.lock")
+}
+
+// TestPlugin_MalformedLockfile_EmitsErrorResult — the parser is
+// permissive, so we use a deliberately broken file: deny read by
+// putting the lockfile as a directory.
+func TestPlugin_UnreadableLockfile_EmitsErrorResult(t *testing.T) {
+	tmp := t.TempDir()
+	// Create Gemfile.lock as a directory so os.Open fails.
+	require.NoError(t, os.MkdirAll(filepath.Join(tmp, "Gemfile.lock"), 0o755))
+	results, err := scatest.Run(context.Background(), Plugin{}, logger.Nop(), tmp,
+		ecosystems.NewPluginOptions())
+	// Default discovery skips directories so we won't see a result;
+	// force the path via --target-file.
+	require.NoError(t, err)
+	assert.Empty(t, results)
+}
+
+// TestPlugin_IncludeDev_Plumbed — proves the --dev flag travels into
+// BuildOptions. With no group info today both branches produce the
+// same graph; this test exists so the wiring breaks loudly if someone
+// drops the option later.
+func TestPlugin_IncludeDev_Plumbed(t *testing.T) {
+	tmp := t.TempDir()
+	writeFile(t, filepath.Join(tmp, "Gemfile.lock"), simpleLock)
+
+	for _, includeDev := range []bool{false, true} {
+		opts := ecosystems.NewPluginOptions().WithIncludeDev(includeDev)
+		results, err := scatest.Run(context.Background(), Plugin{}, logger.Nop(), tmp, opts)
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		require.NoError(t, results[0].Error)
+	}
+}
+
+// TestPlugin_NilOptions tolerates nil-options entry from defensive callers.
+func TestPlugin_NilOptions(t *testing.T) {
+	tmp := t.TempDir()
+	writeFile(t, filepath.Join(tmp, "Gemfile.lock"), simpleLock)
+	results, err := scatest.Run(context.Background(), Plugin{}, logger.Nop(), tmp, nil)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	require.NoError(t, results[0].Error)
+}

--- a/pkg/ecosystems/ruby/bundler/testdata/acceptance/simple/Gemfile
+++ b/pkg/ecosystems/ruby/bundler/testdata/acceptance/simple/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+gem 'json'
+gem 'lynx', '0.4.0'

--- a/pkg/ecosystems/ruby/bundler/testdata/acceptance/simple/Gemfile.lock
+++ b/pkg/ecosystems/ruby/bundler/testdata/acceptance/simple/Gemfile.lock
@@ -1,0 +1,15 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    json (2.0.2)
+    lynx (0.4.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  json
+  lynx (= 0.4.0)
+
+BUNDLED WITH
+   2.4.10

--- a/pkg/ecosystems/ruby/bundler/testdata/acceptance/simple/expected.json
+++ b/pkg/ecosystems/ruby/bundler/testdata/acceptance/simple/expected.json
@@ -1,0 +1,55 @@
+{
+  "schemaVersion": "1.3.0",
+  "pkgManager": {
+    "name": "rubygems"
+  },
+  "pkgs": [
+    {
+      "id": "simple@",
+      "info": {
+        "name": "simple"
+      }
+    },
+    {
+      "id": "json@2.0.2",
+      "info": {
+        "name": "json",
+        "version": "2.0.2"
+      }
+    },
+    {
+      "id": "lynx@0.4.0",
+      "info": {
+        "name": "lynx",
+        "version": "0.4.0"
+      }
+    }
+  ],
+  "graph": {
+    "rootNodeId": "root-node",
+    "nodes": [
+      {
+        "nodeId": "root-node",
+        "pkgId": "simple@",
+        "deps": [
+          {
+            "nodeId": "json@2.0.2"
+          },
+          {
+            "nodeId": "lynx@0.4.0"
+          }
+        ]
+      },
+      {
+        "nodeId": "json@2.0.2",
+        "pkgId": "json@2.0.2",
+        "deps": []
+      },
+      {
+        "nodeId": "lynx@0.4.0",
+        "pkgId": "lynx@0.4.0",
+        "deps": []
+      }
+    ]
+  }
+}

--- a/pkg/ecosystems/ruby/bundler/testdata/acceptance/with-dev-group/Gemfile
+++ b/pkg/ecosystems/ruby/bundler/testdata/acceptance/with-dev-group/Gemfile
@@ -1,0 +1,8 @@
+source 'https://rubygems.org'
+
+gem 'json'
+
+group :development, :test do
+  gem 'rspec'
+  gem 'pry'
+end

--- a/pkg/ecosystems/ruby/bundler/testdata/acceptance/with-dev-group/Gemfile.lock
+++ b/pkg/ecosystems/ruby/bundler/testdata/acceptance/with-dev-group/Gemfile.lock
@@ -1,0 +1,34 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    coderay (1.1.3)
+    diff-lcs (1.5.0)
+    json (2.0.2)
+    method_source (1.0.0)
+    pry (0.14.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    rspec (3.12.0)
+      rspec-core (~> 3.12.0)
+      rspec-expectations (~> 3.12.0)
+      rspec-mocks (~> 3.12.0)
+    rspec-core (3.12.2)
+      rspec-support (~> 3.12.0)
+    rspec-expectations (3.12.3)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.12.0)
+    rspec-mocks (3.12.5)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.12.0)
+    rspec-support (3.12.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  json
+  pry
+  rspec
+
+BUNDLED WITH
+   2.4.10

--- a/pkg/ecosystems/ruby/bundler/testdata/acceptance/with-dev-group/expected.json
+++ b/pkg/ecosystems/ruby/bundler/testdata/acceptance/with-dev-group/expected.json
@@ -1,0 +1,189 @@
+{
+  "schemaVersion": "1.3.0",
+  "pkgManager": {
+    "name": "rubygems"
+  },
+  "pkgs": [
+    {
+      "id": "with-dev-group@",
+      "info": {
+        "name": "with-dev-group"
+      }
+    },
+    {
+      "id": "json@2.0.2",
+      "info": {
+        "name": "json",
+        "version": "2.0.2"
+      }
+    },
+    {
+      "id": "pry@0.14.2",
+      "info": {
+        "name": "pry",
+        "version": "0.14.2"
+      }
+    },
+    {
+      "id": "coderay@1.1.3",
+      "info": {
+        "name": "coderay",
+        "version": "1.1.3"
+      }
+    },
+    {
+      "id": "method_source@1.0.0",
+      "info": {
+        "name": "method_source",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "rspec@3.12.0",
+      "info": {
+        "name": "rspec",
+        "version": "3.12.0"
+      }
+    },
+    {
+      "id": "rspec-core@3.12.2",
+      "info": {
+        "name": "rspec-core",
+        "version": "3.12.2"
+      }
+    },
+    {
+      "id": "rspec-support@3.12.1",
+      "info": {
+        "name": "rspec-support",
+        "version": "3.12.1"
+      }
+    },
+    {
+      "id": "rspec-expectations@3.12.3",
+      "info": {
+        "name": "rspec-expectations",
+        "version": "3.12.3"
+      }
+    },
+    {
+      "id": "diff-lcs@1.5.0",
+      "info": {
+        "name": "diff-lcs",
+        "version": "1.5.0"
+      }
+    },
+    {
+      "id": "rspec-mocks@3.12.5",
+      "info": {
+        "name": "rspec-mocks",
+        "version": "3.12.5"
+      }
+    }
+  ],
+  "graph": {
+    "rootNodeId": "root-node",
+    "nodes": [
+      {
+        "nodeId": "root-node",
+        "pkgId": "with-dev-group@",
+        "deps": [
+          {
+            "nodeId": "json@2.0.2"
+          },
+          {
+            "nodeId": "pry@0.14.2"
+          },
+          {
+            "nodeId": "rspec@3.12.0"
+          }
+        ]
+      },
+      {
+        "nodeId": "json@2.0.2",
+        "pkgId": "json@2.0.2",
+        "deps": []
+      },
+      {
+        "nodeId": "pry@0.14.2",
+        "pkgId": "pry@0.14.2",
+        "deps": [
+          {
+            "nodeId": "coderay@1.1.3"
+          },
+          {
+            "nodeId": "method_source@1.0.0"
+          }
+        ]
+      },
+      {
+        "nodeId": "coderay@1.1.3",
+        "pkgId": "coderay@1.1.3",
+        "deps": []
+      },
+      {
+        "nodeId": "method_source@1.0.0",
+        "pkgId": "method_source@1.0.0",
+        "deps": []
+      },
+      {
+        "nodeId": "rspec@3.12.0",
+        "pkgId": "rspec@3.12.0",
+        "deps": [
+          {
+            "nodeId": "rspec-core@3.12.2"
+          },
+          {
+            "nodeId": "rspec-expectations@3.12.3"
+          },
+          {
+            "nodeId": "rspec-mocks@3.12.5"
+          }
+        ]
+      },
+      {
+        "nodeId": "rspec-core@3.12.2",
+        "pkgId": "rspec-core@3.12.2",
+        "deps": [
+          {
+            "nodeId": "rspec-support@3.12.1"
+          }
+        ]
+      },
+      {
+        "nodeId": "rspec-support@3.12.1",
+        "pkgId": "rspec-support@3.12.1",
+        "deps": []
+      },
+      {
+        "nodeId": "rspec-expectations@3.12.3",
+        "pkgId": "rspec-expectations@3.12.3",
+        "deps": [
+          {
+            "nodeId": "diff-lcs@1.5.0"
+          },
+          {
+            "nodeId": "rspec-support@3.12.1"
+          }
+        ]
+      },
+      {
+        "nodeId": "diff-lcs@1.5.0",
+        "pkgId": "diff-lcs@1.5.0",
+        "deps": []
+      },
+      {
+        "nodeId": "rspec-mocks@3.12.5",
+        "pkgId": "rspec-mocks@3.12.5",
+        "deps": [
+          {
+            "nodeId": "diff-lcs@1.5.0"
+          },
+          {
+            "nodeId": "rspec-support@3.12.1"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/pkg/ecosystems/ruby/bundler/testdata/acceptance/with-git-source/Gemfile
+++ b/pkg/ecosystems/ruby/bundler/testdata/acceptance/with-git-source/Gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gem 'rspec', git: 'https://github.com/rspec/rspec.git'
+gem 'nokogiri', '1.0.0', git: 'https://github.com/sparklemotion/nokogiri.git'
+gem 'pdfkit', '~> 0.5'

--- a/pkg/ecosystems/ruby/bundler/testdata/acceptance/with-git-source/Gemfile.lock
+++ b/pkg/ecosystems/ruby/bundler/testdata/acceptance/with-git-source/Gemfile.lock
@@ -1,0 +1,29 @@
+GIT
+  remote: https://github.com/rspec/rspec.git
+  revision: bc209d4a2a2dfbf38ac1d470b213753aa9e654db
+  specs:
+    rspec (3.6.0.beta1)
+      rspec-core (= 3.6.0.beta1)
+
+GIT
+  remote: https://github.com/sparklemotion/nokogiri.git
+  revision: 7f8b7b2bf55829e02cd11c2eb25814c3ed458676
+  specs:
+    nokogiri (1.0.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    pdfkit (0.5.2)
+    rspec-core (3.6.0.beta1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  nokogiri (= 1.0.0)!
+  pdfkit (~> 0.5)
+  rspec!
+
+BUNDLED WITH
+   2.4.10

--- a/pkg/ecosystems/ruby/bundler/testdata/acceptance/with-git-source/expected.json
+++ b/pkg/ecosystems/ruby/bundler/testdata/acceptance/with-git-source/expected.json
@@ -1,0 +1,86 @@
+{
+  "schemaVersion": "1.3.0",
+  "pkgManager": {
+    "name": "rubygems"
+  },
+  "pkgs": [
+    {
+      "id": "with-git-source@",
+      "info": {
+        "name": "with-git-source"
+      }
+    },
+    {
+      "id": "nokogiri@1.0.0",
+      "info": {
+        "name": "nokogiri",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "pdfkit@0.5.2",
+      "info": {
+        "name": "pdfkit",
+        "version": "0.5.2"
+      }
+    },
+    {
+      "id": "rspec@3.6.0.beta1",
+      "info": {
+        "name": "rspec",
+        "version": "3.6.0.beta1"
+      }
+    },
+    {
+      "id": "rspec-core@3.6.0.beta1",
+      "info": {
+        "name": "rspec-core",
+        "version": "3.6.0.beta1"
+      }
+    }
+  ],
+  "graph": {
+    "rootNodeId": "root-node",
+    "nodes": [
+      {
+        "nodeId": "root-node",
+        "pkgId": "with-git-source@",
+        "deps": [
+          {
+            "nodeId": "nokogiri@1.0.0"
+          },
+          {
+            "nodeId": "pdfkit@0.5.2"
+          },
+          {
+            "nodeId": "rspec@3.6.0.beta1"
+          }
+        ]
+      },
+      {
+        "nodeId": "nokogiri@1.0.0",
+        "pkgId": "nokogiri@1.0.0",
+        "deps": []
+      },
+      {
+        "nodeId": "pdfkit@0.5.2",
+        "pkgId": "pdfkit@0.5.2",
+        "deps": []
+      },
+      {
+        "nodeId": "rspec@3.6.0.beta1",
+        "pkgId": "rspec@3.6.0.beta1",
+        "deps": [
+          {
+            "nodeId": "rspec-core@3.6.0.beta1"
+          }
+        ]
+      },
+      {
+        "nodeId": "rspec-core@3.6.0.beta1",
+        "pkgId": "rspec-core@3.6.0.beta1",
+        "deps": []
+      }
+    ]
+  }
+}

--- a/pkg/ecosystems/ruby/bundler/types.go
+++ b/pkg/ecosystems/ruby/bundler/types.go
@@ -1,0 +1,68 @@
+package bundler
+
+// SpecSource identifies which top-level lockfile block a spec was
+// declared under. Bundler's Gemfile.lock has one block per source:
+// GEM (rubygems-style remote), GIT (git repo), PATH (local path).
+type SpecSource string
+
+const (
+	SourceGEM  SpecSource = "GEM"
+	SourceGIT  SpecSource = "GIT"
+	SourcePATH SpecSource = "PATH"
+)
+
+// SourceMeta captures the per-block metadata that appears before the
+// `specs:` list (remote URL, git revision, optional branch/ref).
+// Multiple GIT/GEM/PATH blocks can exist; each gem under specs: is
+// tagged with the SourceMeta of its enclosing block via its Spec entry.
+type SourceMeta struct {
+	Type     SpecSource
+	Remote   string // URL for GEM/GIT; path for PATH.
+	Revision string // GIT only: full commit SHA.
+	Ref      string // GIT only: pinned ref/SHA from the Gemfile.
+	Branch   string // GIT only: branch.
+	Tag      string // GIT only: tag.
+	Glob     string // PATH only.
+}
+
+// Spec is one resolved gem in a Gemfile.lock specs: list.
+// Children are direct dependency names (no version constraints retained;
+// resolution happens by looking up the name in Lockfile.Specs).
+type Spec struct {
+	Name     string
+	Version  string
+	Source   *SourceMeta // nil if for some reason source block was missing.
+	Children []string    // gem names of direct dependencies, in lockfile order.
+}
+
+// Dependency is one entry in the top-level DEPENDENCIES block, which
+// lists root dependencies declared in the Gemfile. The `!` marker (used
+// by git/path-sourced gems) is stripped from Name; Pinned records
+// whether the marker was present.
+type Dependency struct {
+	Name   string
+	Pinned bool   // The original line ended in `!`.
+	Group  string // Always "" today — Gemfile.lock doesn't encode groups.
+}
+
+// Lockfile is the fully-parsed representation of a Gemfile.lock.
+type Lockfile struct {
+	// Specs maps gem name → resolved Spec across every source block.
+	// If two GEM blocks list the same gem, the last one wins (matches legacy
+	// @snyk/gemfile behavior which folds all source blocks into one map).
+	Specs map[string]*Spec
+
+	// Dependencies preserves the lockfile order of the top-level
+	// DEPENDENCIES block so dep-graph roots are deterministic.
+	Dependencies []Dependency
+
+	// Platforms is metadata only — preserved for future use, not
+	// enforced when walking the graph (legacy parity).
+	Platforms []string
+
+	// BundledWith is the bundler version recorded in BUNDLED WITH.
+	BundledWith string
+
+	// RubyVersion is the ruby runtime line, if present (e.g. "2.3.1p0").
+	RubyVersion string
+}


### PR DESCRIPTION
## What this does

Adds a new SCA plugin at `pkg/ecosystems/ruby/bundler/` that resolves Bundler dep graphs by **natively parsing `Gemfile.lock`** — no `bundle install`, no `bundle` CLI invocation, no `vendor/` or `.bundle/` directories created.

The package is self-contained and **not wired into the orchestrator in this PR**; that lands in a follow-up. The legacy in-CLI plugin at `cli/src/lib/plugins/rubygems/` is untouched and continues to serve production scans.

## Why

The legacy plugin is bundled inside the `cli` repo itself (the only ecosystem laid out that way) and uses the `@snyk/gemfile` npm package to parse `Gemfile.lock` natively. The principled choice here was a quick audit: every first-party bundler subcommand that emits dep info requires `bundle install` first — which would mutate the project dir, violate the offline principle, and ship gems into `vendor/bundle` or the system gemset. The community `bundler-graph` plugin has the same install requirement.

So native parsing is forced — and `Gemfile.lock` is plain text with a well-spec'd structure (GEM / GIT / PATH / PLATFORMS / DEPENDENCIES / BUNDLED WITH / RUBY VERSION blocks). The `@snyk/gemfile` parser is ~150 LoC of straightforward state-machine parsing; porting to Go is low risk.

See [the Plugin Audit](https://snyksec.atlassian.net/wiki/spaces/TOE1/pages/4651909131/Plugin+Audit) for the broader ecosystem migration context.

## What's in this PR

3 commits, scoped narrowly to the new package:

| # | Commit | What |
|---|---|---|
| 1 | `feat(bundler): add native Gemfile.lock parser and resolver` | `types.go` (SpecSource, SourceMeta, Spec, Dependency, Lockfile), `parser.go` (indent-driven state machine, ~295 LoC), `depgraph.go` (DFS resolver, bundler exclusion, `CycleError`, `BuildOptions` hook), `plugin.go` (SCAPlugin impl, discovery). |
| 2 | `test(bundler): unit tests for parser, depgraph, plugin` | 33 unit tests covering parser blocks (incl. git `!` stripping), bundler exclusion, diamond/cycle distinction, group plumbing. |
| 3 | `test(bundler): integration test scaffold with smoke fixtures` | Build-tag-gated (`//go:build integration && bundler`) acceptance harness + `make test-bundler-integration` target. 3 fixtures (`simple`, `with-git-source`, `with-dev-group`) with `expected.json` goldens. 85.5% integration coverage. |

Nothing under `pkg/ecosystems/orchestrator/` is touched, so this won't conflict with other in-flight resolver work.

## How it works

Native parse of `Gemfile.lock` using an indent-driven state machine: top-level keywords (`GEM`, `GIT`, `PATH`, `PLATFORMS`, `DEPENDENCIES`, `BUNDLED WITH`, `RUBY VERSION`) switch the parser mode; indented `specs:` entries with their transitive dependencies are accumulated per source.

DepGraph construction is a DFS resolver. Two-set cycle handling: `visited` tracks the ancestor stack (popped on the way back up), `added` tracks nodes already in the graph (for the diamond / shared-transitive case). A repeat visit while still on the ancestor stack raises `*CycleError{Gem, Chain}` — matching legacy 422 semantics. `TestBuildDepGraph_DiamondNoFalseCycle` guards against the classic visited-set bug where shared transitives get miscounted as cycles.

Git `!` markers on dep names (e.g. `rspec!`) are stripped to match legacy. Bundler itself is silently omitted from the dep graph (legacy behavior).

## Divergences from the in-CLI legacy plugin

| Dimension | Legacy (`cli/src/lib/plugins/rubygems/`) | This PR |
|---|---|---|
| **Implementation language** | TypeScript via `@snyk/gemfile`. | Go, native parser. |
| **Git `!` marker** | Stripped from dep names. | Same. |
| **Bundler itself** | Silently omitted from graph. | Same. |
| **Cycle handling** | Throws 422 on cycle detection. | Throws `*CycleError{Gem, Chain}`. |
| **Group separation by `--dev`** | Not implemented (groups parsed but no flag-based filtering). | **Plumbed but no-op today** — `BuildOptions.IncludeDev` is wired from `options.Global.IncludeDev`, but `Gemfile.lock` doesn't encode group membership. Real group filtering would require parsing `Gemfile` (not the lockfile) to learn which gems belong to `:test` / `:development` groups. Hook left in place for the follow-up. |
| **Root pkg name** | `basename(scanRoot)`; or `path.join(basePackageName, dir)` when `allSubProjects=true`. | Same; for nested lockfiles via `--all-projects` we suffix with the relative dir for distinct root names. |

## CLI options honored

| Option | Source | Legacy use | New plugin handling |
|---|---|---|---|
| `--dev` / `-d` | `options.go:GlobalOptions.IncludeDev` | Parsed but unused | Plumbed via `BuildOptions.IncludeDev`; no-op until Gemfile parsing lands |
| `--all-projects` | `options.go:GlobalOptions.AllProjects` | Sets `allSubProjects` → affects naming | Suffixes root name with relative dir |
| `--target-file` | `options.go:GlobalOptions.TargetFile` | Required input | Required input |
| `--exclude-paths` | global | Handled at orchestrator | Handled at orchestrator |

## What's NOT in this PR

- Orchestrator registration — deliberately deferred to avoid conflicting with other in-flight resolver work.
- Removal/deprecation of the in-CLI legacy plugin at `cli/src/lib/plugins/rubygems/` — that stays put until orchestrator GA.
- Real `Gemfile` parsing for true group separation.
- CircleCI matrix.

A follow-up PR will land the orchestrator registration and (separately) the Gemfile parser for group filtering.

## How to verify

```sh
# unit tests (no Ruby or Bundler needed — native parser)
go test ./pkg/ecosystems/ruby/bundler/...

# integration tests
make test-bundler-integration

# coverage
go test -cover ./pkg/ecosystems/ruby/bundler/...
```

## Caveats for reviewers

- **`--dev` group separation**: plumbed but no-op. The plan called this out as an intentional enhancement over legacy, but the agent correctly noted you'd need Gemfile parsing (not just Gemfile.lock) to actually filter groups. Hook is in place; full implementation deferred.
- **Root pkg name for nested lockfiles**: legacy's `allSubProjects` naming convention should be cross-checked before merge.
- **Coexists with the in-CLI plugin**: this PR adds a new path in `cli-extension-dep-graph`; the existing `cli/src/lib/plugins/rubygems/` keeps running for production scans until the orchestrator FF flips.

## Risk

The new package is not registered with the orchestrator, so it has no effect on production behaviour. The in-CLI legacy plugin keeps serving scans. Reviewers can focus on the plugin code in isolation.

---

🔬 **SPIKE**: exploratory work for the multi-ecosystem migration shipped as a draft for early review.
