### PR TITLE
feat(pnpm): lockfile-only resolver + Rush adapter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,4 +49,7 @@ test-gradle-integration:
 update-gradle-fixtures:
 	UPDATE_FIXTURES=1 $(GOTEST) -v -tags="integration,gradle" -timeout=15m ./pkg/ecosystems/gradle/
 
-.PHONY: install-req fmt test test-bazel-jvm-integration test-bazel-go-integration test-python-integration test-gradle-integration update-gradle-fixtures lint tidy imports install-golangci-lint
+test-pnpm-integration:
+	$(GOTEST) -v -tags="integration,pnpm" -timeout=10m ./pkg/ecosystems/javascript/pnpm/ -coverprofile cp.out
+
+.PHONY: install-req fmt test test-bazel-jvm-integration test-bazel-go-integration test-python-integration test-gradle-integration test-pnpm-integration update-gradle-fixtures lint tidy imports install-golangci-lint

--- a/pkg/ecosystems/javascript/bun/executor.go
+++ b/pkg/ecosystems/javascript/bun/executor.go
@@ -45,7 +45,7 @@ var _ bunWhyRunner = (*bunCmdExecutor)(nil)
 // The caller must close the returned ReadCloser when done (or on error) to
 // ensure the background goroutine and subprocess are released promptly.
 func (e *bunCmdExecutor) Run(ctx context.Context, dir string) (io.ReadCloser, error) {
-	resolved, err := exec.LookPath("bun") //nolint:goconst // executable name
+	resolved, err := exec.LookPath(pkgManager)
 	if err != nil {
 		return nil, errBunNotFound //nolint:wrapcheck // sentinel error, intentionally returned unwrapped
 	}

--- a/pkg/ecosystems/javascript/pnpm/depgraph.go
+++ b/pkg/ecosystems/javascript/pnpm/depgraph.go
@@ -127,10 +127,17 @@ func addDep(
 	visited, edgesSeen map[string]bool,
 ) error {
 	version := d.Version
+	// A workspace cross-dependency is identified by pnpm's authoritative `link:`
+	// version prefix — NOT by name. Keying on name alone would mis-flag a real
+	// registry package that happens to share a name with a workspace project,
+	// stop-set'ing it and silently dropping its subtree. Once a link is
+	// confirmed, consult wsVersions only to render the sibling's real version
+	// instead of the bare `link:<path>`.
 	isWorkspace := strings.HasPrefix(version, "link:")
-	if v, ok := wsVersions[name]; ok {
-		isWorkspace = true
-		version = v // render the sibling project's real version, not "link:.."
+	if isWorkspace {
+		if v, ok := wsVersions[name]; ok {
+			version = v
+		}
 	}
 	if version == "" {
 		version = defaultVersion

--- a/pkg/ecosystems/javascript/pnpm/depgraph.go
+++ b/pkg/ecosystems/javascript/pnpm/depgraph.go
@@ -1,0 +1,166 @@
+package pnpm
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	godepgraph "github.com/snyk/dep-graph/go/pkg/depgraph"
+)
+
+const pkgManager = "pnpm"
+
+// depGraphResult pairs a built dep graph with the path to the package.json that
+// describes it, relative to the scan root.
+type depGraphResult struct {
+	graph          *godepgraph.DepGraph
+	pkgJSONRelPath string
+}
+
+// buildDepGraphs produces one dep graph per importer project from `pnpm list`
+// output. Other workspace members appear as stop-set leaves in every graph
+// (their subtrees are walked only in their own graph), preventing duplicated
+// reporting across workspaces. The importer whose directory is skipDir (the
+// Rush "rush-common" aggregate at the staged common/temp) is omitted; pass ""
+// to skip nothing.
+func buildDepGraphs(scanDir string, projects []listProject, skipDir string) ([]depGraphResult, error) {
+	// Workspace members keyed by name → resolved version, so `link:` deps can be
+	// rendered as the sibling project's real coordinates.
+	wsVersions := make(map[string]string, len(projects))
+	for _, p := range projects {
+		if p.Name != "" {
+			wsVersions[p.Name] = p.Version
+		}
+	}
+
+	// Resolve symlinks so relative-path math is stable when the scan root and
+	// pnpm's reported project paths disagree on symlinked prefixes (e.g. macOS
+	// /var → /private/var for tmp staging dirs).
+	scanBase := resolveSymlinks(scanDir)
+	var skipResolved string
+	if skipDir != "" {
+		skipResolved = resolveSymlinks(skipDir)
+	}
+
+	var results []depGraphResult
+	for i := range projects {
+		p := projects[i]
+		if p.Name == "" {
+			continue
+		}
+		// Skip the synthetic aggregate importer by path (not by name, so a real
+		// project that happens to be named "rush-common" is not dropped).
+		if skipResolved != "" && resolveSymlinks(p.Path) == skipResolved {
+			continue
+		}
+
+		g, err := buildSingleDepGraph(p, wsVersions)
+		if err != nil {
+			return nil, fmt.Errorf("building dep graph for %s: %w", p.Name, err)
+		}
+
+		relDir := "."
+		if rel, err := filepath.Rel(scanBase, resolveSymlinks(p.Path)); err == nil && !strings.HasPrefix(rel, "..") {
+			relDir = rel
+		}
+		results = append(results, depGraphResult{
+			graph:          g,
+			pkgJSONRelPath: filepath.Join(relDir, packageJSONFile),
+		})
+	}
+
+	return results, nil
+}
+
+// resolveSymlinks returns the symlink-resolved path, or the input unchanged if
+// resolution fails (e.g. path doesn't exist).
+func resolveSymlinks(path string) string {
+	if resolved, err := filepath.EvalSymlinks(path); err == nil {
+		return resolved
+	}
+	return path
+}
+
+func buildSingleDepGraph(p listProject, wsVersions map[string]string) (*godepgraph.DepGraph, error) {
+	rootVersion := p.Version
+	if rootVersion == "" {
+		rootVersion = defaultVersion
+	}
+
+	builder, err := godepgraph.NewBuilder(
+		&godepgraph.PkgManager{Name: pkgManager},
+		&godepgraph.PkgInfo{Name: p.Name, Version: rootVersion},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("creating dep graph builder: %w", err)
+	}
+
+	rootNodeID := builder.GetRootNode().NodeID
+	visited := make(map[string]bool)   // nodes already added (dedup + cycle guard)
+	edgesSeen := make(map[string]bool) // parent→child edges already connected
+
+	// pnpm list --json reports the resolved tree under dependencies,
+	// devDependencies, and optionalDependencies — it emits no separate
+	// peerDependencies key. Satisfied peers already appear within the resolved
+	// tree; a package's own declared peers are the consumer's responsibility.
+	// So there is nothing further to read for peer deps (a deliberate
+	// consequence of delegating resolution to pnpm, matching the npm resolver).
+	for _, deps := range []map[string]listDep{p.Dependencies, p.DevDependencies, p.OptionalDependencies} {
+		for name, d := range deps {
+			if err := addDep(builder, rootNodeID, name, d, wsVersions, visited, edgesSeen); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	return builder.Build(), nil
+}
+
+// addDep adds the dependency (name, d) to the graph and connects it to parentID.
+// A workspace member (resolved via `link:` or present in wsVersions) is added as
+// a leaf — its subtree belongs to its own graph and is not walked here.
+func addDep(
+	builder *godepgraph.Builder,
+	parentID, name string,
+	d listDep,
+	wsVersions map[string]string,
+	visited, edgesSeen map[string]bool,
+) error {
+	version := d.Version
+	isWorkspace := strings.HasPrefix(version, "link:")
+	if v, ok := wsVersions[name]; ok {
+		isWorkspace = true
+		version = v // render the sibling project's real version, not "link:.."
+	}
+	if version == "" {
+		version = defaultVersion
+	}
+
+	id := name + "@" + version
+
+	if !visited[id] {
+		visited[id] = true
+		builder.AddNode(id, &godepgraph.PkgInfo{Name: name, Version: version})
+
+		if !isWorkspace {
+			for childName, child := range d.Dependencies {
+				if err := addDep(builder, id, childName, child, wsVersions, visited, edgesSeen); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	// Connect once per (parent, child) edge. visited dedups nodes, not edges; a
+	// package present under both dependencies and devDependencies would
+	// otherwise yield a duplicate edge from the same parent.
+	edgeKey := parentID + "\x00" + id
+	if !edgesSeen[edgeKey] {
+		edgesSeen[edgeKey] = true
+		if err := builder.ConnectNodes(parentID, id); err != nil {
+			return fmt.Errorf("connecting %s → %s: %w", parentID, id, err)
+		}
+	}
+
+	return nil
+}

--- a/pkg/ecosystems/javascript/pnpm/depgraph_test.go
+++ b/pkg/ecosystems/javascript/pnpm/depgraph_test.go
@@ -1,0 +1,92 @@
+package pnpm
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// Regression for the workspace name-collision: a transitive registry package
+// ("shared@2.0.0") shares a name with a workspace project ("shared@1.0.0").
+// The transitive one has a real version (not link:), so it must NOT be treated
+// as the workspace member — its subtree ("deep") must be walked, not stop-set.
+func TestBuildDepGraphs_NameCollisionIsNotStopSet(t *testing.T) {
+	projects := []listProject{
+		{
+			Name:    "app",
+			Version: "1.0.0",
+			Dependencies: map[string]listDep{
+				"lodash": {Version: "4.17.4", Dependencies: map[string]listDep{
+					"shared": {Version: "2.0.0", Dependencies: map[string]listDep{
+						"deep": {Version: "9.9.9"},
+					}},
+				}},
+			},
+		},
+		{Name: "shared", Version: "1.0.0"}, // workspace project sharing the name
+	}
+
+	results, err := buildDepGraphs("", projects, "")
+	if err != nil {
+		t.Fatalf("buildDepGraphs: %v", err)
+	}
+
+	var appGraph string
+	for _, r := range results {
+		if r.graph.GetRootPkg().Info.Name == "app" {
+			b, mErr := json.Marshal(r.graph)
+			if mErr != nil {
+				t.Fatalf("marshal graph: %v", mErr)
+			}
+			appGraph = string(b)
+		}
+	}
+	if appGraph == "" {
+		t.Fatal("no graph produced for app")
+	}
+
+	if !strings.Contains(appGraph, "shared@2.0.0") {
+		t.Errorf("registry shared@2.0.0 should keep its real version, not the workspace 1.0.0;\n%s", appGraph)
+	}
+	if !strings.Contains(appGraph, "deep@9.9.9") {
+		t.Errorf("subtree under the name-colliding package was dropped (the silent-skip bug);\n%s", appGraph)
+	}
+}
+
+// A genuine workspace link (version "link:..") IS a stop-set leaf and renders
+// as the sibling's real version from wsVersions.
+func TestBuildDepGraphs_WorkspaceLinkResolvesSiblingVersion(t *testing.T) {
+	projects := []listProject{
+		{
+			Name:    "app",
+			Version: "1.0.0",
+			Dependencies: map[string]listDep{
+				"lib": {Version: "link:../lib", Dependencies: map[string]listDep{
+					"should-not-appear": {Version: "1.2.3"},
+				}},
+			},
+		},
+		{Name: "lib", Version: "3.4.5"},
+	}
+
+	results, err := buildDepGraphs("", projects, "")
+	if err != nil {
+		t.Fatalf("buildDepGraphs: %v", err)
+	}
+	var appGraph string
+	for _, r := range results {
+		if r.graph.GetRootPkg().Info.Name == "app" {
+			b, mErr := json.Marshal(r.graph)
+			if mErr != nil {
+				t.Fatalf("marshal graph: %v", mErr)
+			}
+			appGraph = string(b)
+		}
+	}
+	if !strings.Contains(appGraph, "lib@3.4.5") {
+		t.Errorf("workspace link should render the sibling's real version lib@3.4.5;\n%s", appGraph)
+	}
+	if strings.Contains(appGraph, "should-not-appear") {
+		t.Errorf("workspace member subtree must not be walked in the parent graph;\n%s", appGraph)
+	}
+}

--- a/pkg/ecosystems/javascript/pnpm/executor.go
+++ b/pkg/ecosystems/javascript/pnpm/executor.go
@@ -1,0 +1,110 @@
+package pnpm
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os/exec"
+	"regexp"
+	"strings"
+
+	"golang.org/x/mod/semver"
+)
+
+// errPnpmNotFound is returned when the pnpm binary is not in PATH.
+var errPnpmNotFound = errors.New("pnpm binary not found in PATH")
+
+// errPnpmVersionTooLow is returned when the installed pnpm is below the minimum.
+var errPnpmVersionTooLow = errors.New("pnpm version below minimum required " + minPnpmVersion)
+
+// minPnpmVersion is the minimum pnpm that supports
+// `pnpm list --lockfile-only`. The scanner's own pnpm is used (not the repo's
+// declared pnpmVersion); modern pnpm reads v5/v6/v9 lockfile formats.
+const minPnpmVersion = "v8.0.0"
+
+// pnpmVersionRe extracts MAJOR.MINOR.PATCH from `pnpm --version`, tolerating
+// any pre-release/build suffix that would trip strict semver parsing.
+var pnpmVersionRe = regexp.MustCompile(`(\d+)\.(\d+)\.(\d+)`)
+
+// pnpmListRunner runs `pnpm list` on behalf of the plugin.
+type pnpmListRunner interface {
+	Run(ctx context.Context, dir string) (io.ReadCloser, error)
+}
+
+// pnpmCmdExecutor is the production implementation that shells out to pnpm.
+type pnpmCmdExecutor struct{}
+
+var _ pnpmListRunner = (*pnpmCmdExecutor)(nil)
+
+// Run starts `pnpm -r list --lockfile-only --json --depth Infinity` and returns
+// a streaming reader over its stdout. `--lockfile-only` resolves the graph from
+// the lockfile without touching node_modules (no install). The command runs in
+// a goroutine; a non-zero exit surfaces as a read error when the stream is
+// exhausted. The caller must Close the returned reader.
+func (e *pnpmCmdExecutor) Run(ctx context.Context, dir string) (io.ReadCloser, error) {
+	resolved, err := exec.LookPath("pnpm")
+	if err != nil {
+		return nil, errPnpmNotFound //nolint:wrapcheck // sentinel, intentionally unwrapped
+	}
+
+	if err := checkPnpmVersion(ctx, resolved); err != nil {
+		return nil, err
+	}
+
+	cmd := exec.CommandContext(ctx, resolved, "-r", "list", "--lockfile-only", "--json", "--depth", "Infinity")
+	cmd.Dir = dir
+	cmd.Env = append(cmd.Environ(), "NO_COLOR=1")
+
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	pr, pw := io.Pipe()
+	cmd.Stdout = pw
+
+	if err := cmd.Start(); err != nil {
+		pr.Close()
+		pw.Close()
+		return nil, fmt.Errorf("starting pnpm list: %w", err)
+	}
+
+	go func() {
+		if waitErr := cmd.Wait(); waitErr != nil {
+			pw.CloseWithError(fmt.Errorf("pnpm list failed: %w\nstderr: %s", waitErr, stderr.String()))
+		} else {
+			pw.Close()
+		}
+	}()
+
+	return pr, nil
+}
+
+func checkPnpmVersion(ctx context.Context, binary string) error {
+	out, err := exec.CommandContext(ctx, binary, "--version").Output()
+	if err != nil {
+		return fmt.Errorf("failed to get pnpm version: %w", err)
+	}
+
+	ver, err := parsePnpmVersion(strings.TrimSpace(string(out)))
+	if err != nil {
+		return err
+	}
+
+	if semver.Compare(ver, minPnpmVersion) < 0 {
+		return errPnpmVersionTooLow //nolint:wrapcheck // sentinel, intentionally unwrapped
+	}
+
+	return nil
+}
+
+// parsePnpmVersion extracts MAJOR.MINOR.PATCH from raw `pnpm --version` output
+// and returns it as a canonical Go semver string (e.g. "v8.15.8").
+func parsePnpmVersion(raw string) (string, error) {
+	m := pnpmVersionRe.FindStringSubmatch(raw)
+	if m == nil {
+		return "", fmt.Errorf("could not parse pnpm version from %q", raw)
+	}
+
+	return "v" + m[1] + "." + m[2] + "." + m[3], nil
+}

--- a/pkg/ecosystems/javascript/pnpm/executor_test.go
+++ b/pkg/ecosystems/javascript/pnpm/executor_test.go
@@ -1,0 +1,39 @@
+package pnpm
+
+import "testing"
+
+func TestParsePnpmVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     string
+		want    string
+		wantErr bool
+	}{
+		{name: "bare", raw: "8.15.8", want: "v8.15.8"},
+		{name: "trailing newline", raw: "9.1.0\n", want: "v9.1.0"},
+		{name: "v-prefixed", raw: "v8.6.0", want: "v8.6.0"},
+		{name: "prerelease suffix", raw: "9.0.0-alpha.1", want: "v9.0.0"},
+		{name: "build metadata", raw: "8.15.8+build.7", want: "v8.15.8"},
+		{name: "embedded", raw: "pnpm version 8.15.8 (homebrew)", want: "v8.15.8"},
+		{name: "unparseable", raw: "not-a-version", wantErr: true},
+		{name: "empty", raw: "", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parsePnpmVersion(tt.raw)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("parsePnpmVersion(%q) = %q, want error", tt.raw, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parsePnpmVersion(%q) unexpected error: %v", tt.raw, err)
+			}
+			if got != tt.want {
+				t.Fatalf("parsePnpmVersion(%q) = %q, want %q", tt.raw, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/ecosystems/javascript/pnpm/plugin.go
+++ b/pkg/ecosystems/javascript/pnpm/plugin.go
@@ -78,8 +78,8 @@ func (p Plugin) BuildDepGraphsFromDir(
 	}
 
 	exec := p.getExecutor()
-	for _, t := range targets {
-		results := runAndBuild(ctx, log, exec, t)
+	for i := range targets {
+		results := runAndBuild(ctx, log, exec, &targets[i])
 		if err := emit(ctx, log, onGraph, results); err != nil {
 			return err
 		}
@@ -137,7 +137,7 @@ func pnpmTargets(
 
 // runAndBuild executes pnpm list for one target and produces SCAResults. A
 // pre-baked setupErr short-circuits the run and surfaces as the sole result.
-func runAndBuild(ctx context.Context, log logger.Logger, exec pnpmListRunner, t scanTarget) []ecosystems.SCAResult {
+func runAndBuild(ctx context.Context, log logger.Logger, exec pnpmListRunner, t *scanTarget) []ecosystems.SCAResult {
 	if t.setupErr != nil {
 		return errResult(t.errTargetFile, t.setupErr)
 	}

--- a/pkg/ecosystems/javascript/pnpm/plugin.go
+++ b/pkg/ecosystems/javascript/pnpm/plugin.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems"
 	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/discovery"
@@ -25,8 +24,9 @@ const (
 // Plugin implements ecosystems.SCAPlugin for pnpm projects. It shells out to
 // `pnpm list --lockfile-only --json` to resolve the dependency graph from the
 // lockfile without installing node_modules. Rush monorepos (rush.json) are
-// supported by synthesizing the workspace context Rush generates at install
-// time (see rush.go).
+// handled by an adapter in rush.go that synthesizes the workspace context Rush
+// generates at install time; both adapters produce the same scanTarget shape
+// so the runner is uniform.
 type Plugin struct {
 	executor pnpmListRunner
 }
@@ -35,6 +35,22 @@ var _ ecosystems.SCAPlugin = (*Plugin)(nil)
 
 func (p Plugin) GetName() string {
 	return PluginName
+}
+
+// scanTarget is a single prepared pnpm-list invocation. Every adapter
+// (bare-pnpm discovery, Rush staging) collapses its asymmetry into this struct
+// so runAndBuild can treat them uniformly.
+type scanTarget struct {
+	cmdDir          string   // where `pnpm list` runs
+	manifestBaseDir string   // base for package.json relative paths
+	excludeDir      string   // importer dir to drop (e.g. Rush "rush-common"); "" = none
+	processedFiles  []string // files this scan was derived from
+	errTargetFile   string   // target file used for an error SCAResult
+	cleanup         func()   // tmp-tree teardown; never nil
+	// setupErr, when set, short-circuits runAndBuild and surfaces as the
+	// target's sole SCAResult — used when an adapter cannot fully stage a
+	// target but wants to surface the failure rather than skip silently.
+	setupErr error
 }
 
 func (p Plugin) BuildDepGraphsFromDir(
@@ -48,110 +64,105 @@ func (p Plugin) BuildDepGraphsFromDir(
 		log = logger.Nop()
 	}
 
-	exec := p.getExecutor()
-
-	// Rush adapter: a rush.json root has no scannable pnpm-lock.yaml at the
-	// root, so handle it before standard discovery.
-	if isRushRoot(dir) {
-		return emit(ctx, log, onGraph, p.buildRushResults(ctx, log, dir, exec))
-	}
-
-	files, err := p.discoverLockFiles(ctx, dir, options)
+	targets, err := collectTargets(ctx, log, dir, options)
 	if err != nil {
 		return err
 	}
-	if len(files) == 0 {
-		log.Debug(ctx, "No pnpm-lock.yaml found", logger.Attr(logFieldDir, dir))
+	defer func() {
+		for _, t := range targets {
+			t.cleanup()
+		}
+	}()
+	if len(targets) == 0 {
 		return nil
 	}
-	log.Debug(ctx, "Discovered pnpm-lock.yaml files", logger.Attr("count", len(files)))
 
-	for _, file := range files {
-		lockDir := filepath.Dir(file.Path)
-		errTarget := filepath.Join(filepath.Dir(file.RelPath), packageJSONFile)
-		results := p.runAndBuild(ctx, log, exec, &runSpec{
-			runDir:        lockDir,
-			scanDir:       lockDir,
-			baseProcessed: []string{file.RelPath},
-			errTargetFile: errTarget,
-		})
+	exec := p.getExecutor()
+	for _, t := range targets {
+		results := runAndBuild(ctx, log, exec, t)
 		if err := emit(ctx, log, onGraph, results); err != nil {
 			return err
 		}
 	}
-
 	return nil
 }
 
-// buildRushResults stages the Rush workspace then resolves it. npm/yarn-backed
-// or subspaces Rush repos are skipped (logged, no results) per the pnpm-only
-// scope; setup failures surface as an error result.
-func (p Plugin) buildRushResults(ctx context.Context, log logger.Logger, rushDir string, exec pnpmListRunner) []ecosystems.SCAResult {
-	log.Info(ctx, "Building Rush + pnpm dependency graphs", logger.Attr(logFieldDir, rushDir))
-
-	folders, err := rushProjectFolders(rushDir)
-	if err != nil {
-		if errors.Is(err, errRushNotPnpm) || errors.Is(err, errRushSubspaces) {
-			log.Info(ctx, "Skipping Rush workspace", logger.Attr("reason", err.Error()))
-			return nil
-		}
-		return errResult(rushJSONFile, fmt.Errorf("reading rush.json: %w", err))
+// collectTargets dispatches to one adapter per scan root. Rush is checked first
+// because a Rush root has no scannable pnpm-lock.yaml at the top.
+func collectTargets(
+	ctx context.Context,
+	log logger.Logger,
+	dir string,
+	options *ecosystems.SCAPluginOptions,
+) ([]scanTarget, error) {
+	if isRushRoot(dir) {
+		return rushTargets(ctx, log, dir)
 	}
-
-	runDir, scanRoot, skipped, cleanup, err := stageRushWorkspace(rushDir, folders)
-	if err != nil {
-		return errResult(rushJSONFile, err)
-	}
-	defer cleanup()
-
-	if len(skipped) > 0 {
-		// User-visible surfacing of skips is part of the deferred FF+wiring work
-		// (#3); for now log so a stale/renamed project folder doesn't silently
-		// vanish from a scan that otherwise succeeds.
-		log.Info(ctx, "Skipping Rush projects with no readable package.json",
-			logger.Attr("projects", strings.Join(skipped, ", ")))
-	}
-
-	return p.runAndBuild(ctx, log, exec, &runSpec{
-		runDir:        runDir,
-		scanDir:       scanRoot,
-		skipDir:       runDir, // the synthetic "rush-common" aggregate lives here
-		baseProcessed: []string{rushJSONFile, filepath.FromSlash(rushLockfilePath)},
-		errTargetFile: rushJSONFile,
-	})
+	return pnpmTargets(ctx, log, dir, options)
 }
 
-// runSpec parameterises a single pnpm-list run.
-type runSpec struct {
-	runDir        string   // where pnpm runs
-	scanDir       string   // base for package.json relative paths
-	skipDir       string   // importer dir to omit (e.g. the rush-common aggregate); "" skips nothing
-	baseProcessed []string // files every result was derived from
-	errTargetFile string   // target file for an error result
+// pnpmTargets discovers pnpm-lock.yaml files per the scan options and produces
+// one scan target per lockfile. Bare pnpm needs no staging — cmdDir and
+// manifestBaseDir both point at the lockfile's directory.
+func pnpmTargets(
+	ctx context.Context,
+	log logger.Logger,
+	dir string,
+	options *ecosystems.SCAPluginOptions,
+) ([]scanTarget, error) {
+	files, err := discoverLockFiles(ctx, dir, options)
+	if err != nil {
+		return nil, err
+	}
+	if len(files) == 0 {
+		log.Debug(ctx, "No pnpm-lock.yaml found", logger.Attr(logFieldDir, dir))
+		return nil, nil
+	}
+	log.Debug(ctx, "Discovered pnpm-lock.yaml files", logger.Attr("count", len(files)))
+
+	targets := make([]scanTarget, 0, len(files))
+	for _, file := range files {
+		lockDir := filepath.Dir(file.Path)
+		errTargetFile := filepath.Join(filepath.Dir(file.RelPath), packageJSONFile)
+		targets = append(targets, scanTarget{
+			cmdDir:          lockDir,
+			manifestBaseDir: lockDir,
+			processedFiles:  []string{file.RelPath},
+			errTargetFile:   errTargetFile,
+			cleanup:         noopCleanup,
+		})
+	}
+	return targets, nil
 }
 
-func (p Plugin) runAndBuild(ctx context.Context, log logger.Logger, exec pnpmListRunner, spec *runSpec) []ecosystems.SCAResult {
-	log.Info(ctx, "Building pnpm dependency graph", logger.Attr(logFieldDir, spec.runDir))
+// runAndBuild executes pnpm list for one target and produces SCAResults. A
+// pre-baked setupErr short-circuits the run and surfaces as the sole result.
+func runAndBuild(ctx context.Context, log logger.Logger, exec pnpmListRunner, t scanTarget) []ecosystems.SCAResult {
+	if t.setupErr != nil {
+		return errResult(t.errTargetFile, t.setupErr)
+	}
 
-	output, err := exec.Run(ctx, spec.runDir)
+	log.Info(ctx, "Building pnpm dependency graph", logger.Attr(logFieldDir, t.cmdDir))
+
+	output, err := exec.Run(ctx, t.cmdDir)
 	if err != nil {
-		return errResult(spec.errTargetFile, p.wrapRunError(err))
+		return errResult(t.errTargetFile, wrapRunError(err))
 	}
 	defer output.Close()
 
 	data, err := io.ReadAll(output)
 	if err != nil {
-		return errResult(spec.errTargetFile, fmt.Errorf("reading pnpm list output: %w", err))
+		return errResult(t.errTargetFile, fmt.Errorf("reading pnpm list output: %w", err))
 	}
 
 	var projects []listProject
 	if err = json.Unmarshal(data, &projects); err != nil {
-		return errResult(spec.errTargetFile, fmt.Errorf("parsing pnpm list output: %w", err))
+		return errResult(t.errTargetFile, fmt.Errorf("parsing pnpm list output: %w", err))
 	}
 
-	graphResults, err := buildDepGraphs(spec.scanDir, projects, spec.skipDir)
+	graphResults, err := buildDepGraphs(t.manifestBaseDir, projects, t.excludeDir)
 	if err != nil {
-		return errResult(spec.errTargetFile, err)
+		return errResult(t.errTargetFile, err)
 	}
 
 	log.Info(ctx, "Successfully built pnpm dependency graphs", logger.Attr("graphs", len(graphResults)))
@@ -159,7 +170,7 @@ func (p Plugin) runAndBuild(ctx context.Context, log logger.Logger, exec pnpmLis
 	results := make([]ecosystems.SCAResult, len(graphResults))
 	for i, gr := range graphResults {
 		tf := gr.pkgJSONRelPath
-		processed := append(append([]string{}, spec.baseProcessed...), tf)
+		processed := append(append([]string{}, t.processedFiles...), tf)
 		results[i] = ecosystems.SCAResult{
 			DepGraph: gr.graph,
 			ProjectDescriptor: identity.ProjectDescriptor{
@@ -198,6 +209,17 @@ func errResult(targetFile string, err error) []ecosystems.SCAResult {
 	}}
 }
 
+// errTarget builds a scanTarget that carries a setup error in place of a real
+// run. runAndBuild short-circuits and turns this into the only SCAResult, so
+// setup failures surface as one error result instead of aborting the scan.
+func errTarget(targetFile string, err error) scanTarget {
+	return scanTarget{
+		errTargetFile: targetFile,
+		setupErr:      err,
+		cleanup:       noopCleanup,
+	}
+}
+
 func emit(ctx context.Context, log logger.Logger, onGraph ecosystems.OnGraphFunc, results []ecosystems.SCAResult) error {
 	for i := range results {
 		r := &results[i]
@@ -214,7 +236,7 @@ func emit(ctx context.Context, log logger.Logger, onGraph ecosystems.OnGraphFunc
 	return nil
 }
 
-func (p Plugin) wrapRunError(err error) error {
+func wrapRunError(err error) error {
 	if errors.Is(err, errPnpmNotFound) {
 		return fmt.Errorf("pnpm is not installed or not in PATH; install pnpm >= %s to scan this project: %w", minPnpmVersion, err)
 	}
@@ -224,7 +246,7 @@ func (p Plugin) wrapRunError(err error) error {
 	return fmt.Errorf("running pnpm list: %w", err)
 }
 
-func (p Plugin) discoverLockFiles(
+func discoverLockFiles(
 	ctx context.Context,
 	dir string,
 	options *ecosystems.SCAPluginOptions,
@@ -274,6 +296,8 @@ func fileExists(path string) bool {
 	info, err := os.Stat(path)
 	return err == nil && !info.IsDir()
 }
+
+func noopCleanup() {}
 
 // getExecutor returns the configured executor or the production pnpmCmdExecutor.
 // The zero-value Plugin{} is valid and uses the production executor.

--- a/pkg/ecosystems/javascript/pnpm/plugin.go
+++ b/pkg/ecosystems/javascript/pnpm/plugin.go
@@ -1,0 +1,285 @@
+package pnpm
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/discovery"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/logger"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/identity"
+)
+
+const (
+	PluginName       = "pnpm"
+	logFieldLockFile = "lockFile"
+	logFieldDir      = "dir"
+)
+
+// Plugin implements ecosystems.SCAPlugin for pnpm projects. It shells out to
+// `pnpm list --lockfile-only --json` to resolve the dependency graph from the
+// lockfile without installing node_modules. Rush monorepos (rush.json) are
+// supported by synthesizing the workspace context Rush generates at install
+// time (see rush.go).
+type Plugin struct {
+	executor pnpmListRunner
+}
+
+var _ ecosystems.SCAPlugin = (*Plugin)(nil)
+
+func (p Plugin) GetName() string {
+	return PluginName
+}
+
+func (p Plugin) BuildDepGraphsFromDir(
+	ctx context.Context,
+	log logger.Logger,
+	dir string,
+	options *ecosystems.SCAPluginOptions,
+	onGraph ecosystems.OnGraphFunc,
+) error {
+	if log == nil {
+		log = logger.Nop()
+	}
+
+	exec := p.getExecutor()
+
+	// Rush adapter: a rush.json root has no scannable pnpm-lock.yaml at the
+	// root, so handle it before standard discovery.
+	if isRushRoot(dir) {
+		return emit(ctx, log, onGraph, p.buildRushResults(ctx, log, dir, exec))
+	}
+
+	files, err := p.discoverLockFiles(ctx, dir, options)
+	if err != nil {
+		return err
+	}
+	if len(files) == 0 {
+		log.Debug(ctx, "No pnpm-lock.yaml found", logger.Attr(logFieldDir, dir))
+		return nil
+	}
+	log.Debug(ctx, "Discovered pnpm-lock.yaml files", logger.Attr("count", len(files)))
+
+	for _, file := range files {
+		lockDir := filepath.Dir(file.Path)
+		errTarget := filepath.Join(filepath.Dir(file.RelPath), packageJSONFile)
+		results := p.runAndBuild(ctx, log, exec, &runSpec{
+			runDir:        lockDir,
+			scanDir:       lockDir,
+			baseProcessed: []string{file.RelPath},
+			errTargetFile: errTarget,
+		})
+		if err := emit(ctx, log, onGraph, results); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// buildRushResults stages the Rush workspace then resolves it. npm/yarn-backed
+// or subspaces Rush repos are skipped (logged, no results) per the pnpm-only
+// scope; setup failures surface as an error result.
+func (p Plugin) buildRushResults(ctx context.Context, log logger.Logger, rushDir string, exec pnpmListRunner) []ecosystems.SCAResult {
+	log.Info(ctx, "Building Rush + pnpm dependency graphs", logger.Attr(logFieldDir, rushDir))
+
+	folders, err := rushProjectFolders(rushDir)
+	if err != nil {
+		if errors.Is(err, errRushNotPnpm) || errors.Is(err, errRushSubspaces) {
+			log.Info(ctx, "Skipping Rush workspace", logger.Attr("reason", err.Error()))
+			return nil
+		}
+		return errResult(rushJSONFile, fmt.Errorf("reading rush.json: %w", err))
+	}
+
+	runDir, scanRoot, skipped, cleanup, err := stageRushWorkspace(rushDir, folders)
+	if err != nil {
+		return errResult(rushJSONFile, err)
+	}
+	defer cleanup()
+
+	if len(skipped) > 0 {
+		// User-visible surfacing of skips is part of the deferred FF+wiring work
+		// (#3); for now log so a stale/renamed project folder doesn't silently
+		// vanish from a scan that otherwise succeeds.
+		log.Info(ctx, "Skipping Rush projects with no readable package.json",
+			logger.Attr("projects", strings.Join(skipped, ", ")))
+	}
+
+	return p.runAndBuild(ctx, log, exec, &runSpec{
+		runDir:        runDir,
+		scanDir:       scanRoot,
+		skipDir:       runDir, // the synthetic "rush-common" aggregate lives here
+		baseProcessed: []string{rushJSONFile, filepath.FromSlash(rushLockfilePath)},
+		errTargetFile: rushJSONFile,
+	})
+}
+
+// runSpec parameterises a single pnpm-list run.
+type runSpec struct {
+	runDir        string   // where pnpm runs
+	scanDir       string   // base for package.json relative paths
+	skipDir       string   // importer dir to omit (e.g. the rush-common aggregate); "" skips nothing
+	baseProcessed []string // files every result was derived from
+	errTargetFile string   // target file for an error result
+}
+
+func (p Plugin) runAndBuild(ctx context.Context, log logger.Logger, exec pnpmListRunner, spec *runSpec) []ecosystems.SCAResult {
+	log.Info(ctx, "Building pnpm dependency graph", logger.Attr(logFieldDir, spec.runDir))
+
+	output, err := exec.Run(ctx, spec.runDir)
+	if err != nil {
+		return errResult(spec.errTargetFile, p.wrapRunError(err))
+	}
+	defer output.Close()
+
+	data, err := io.ReadAll(output)
+	if err != nil {
+		return errResult(spec.errTargetFile, fmt.Errorf("reading pnpm list output: %w", err))
+	}
+
+	var projects []listProject
+	if err = json.Unmarshal(data, &projects); err != nil {
+		return errResult(spec.errTargetFile, fmt.Errorf("parsing pnpm list output: %w", err))
+	}
+
+	graphResults, err := buildDepGraphs(spec.scanDir, projects, spec.skipDir)
+	if err != nil {
+		return errResult(spec.errTargetFile, err)
+	}
+
+	log.Info(ctx, "Successfully built pnpm dependency graphs", logger.Attr("graphs", len(graphResults)))
+
+	results := make([]ecosystems.SCAResult, len(graphResults))
+	for i, gr := range graphResults {
+		tf := gr.pkgJSONRelPath
+		processed := append(append([]string{}, spec.baseProcessed...), tf)
+		results[i] = ecosystems.SCAResult{
+			DepGraph: gr.graph,
+			ProjectDescriptor: identity.ProjectDescriptor{
+				Identity: identity.ProjectIdentity{
+					ProjectType:       pkgManager,
+					TargetFile:        &tf,
+					RootComponentName: gr.graph.GetRootPkg().Info.Name,
+				},
+			},
+			ResolverMetadata: &ecosystems.ResolverMetadata{
+				PluginName:           PluginName,
+				VersionBuildInfo:     map[string]string{},
+				NormalisedTargetFile: tf,
+			},
+			ProcessedFiles: processed,
+		}
+	}
+	return results
+}
+
+func errResult(targetFile string, err error) []ecosystems.SCAResult {
+	tf := targetFile
+	return []ecosystems.SCAResult{{
+		ProjectDescriptor: identity.ProjectDescriptor{
+			Identity: identity.ProjectIdentity{
+				ProjectType: pkgManager,
+				TargetFile:  &tf,
+			},
+		},
+		ResolverMetadata: &ecosystems.ResolverMetadata{
+			PluginName:           PluginName,
+			NormalisedTargetFile: tf,
+		},
+		ProcessedFiles: []string{targetFile},
+		Error:          err,
+	}}
+}
+
+func emit(ctx context.Context, log logger.Logger, onGraph ecosystems.OnGraphFunc, results []ecosystems.SCAResult) error {
+	for i := range results {
+		r := &results[i]
+		if r.Error != nil {
+			log.Error(ctx, "Failed to build pnpm dependency graph",
+				logger.Attr(logFieldLockFile, r.ProjectDescriptor.GetTargetFile()),
+				logger.Err(r.Error),
+			)
+		}
+		if err := onGraph(*r); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (p Plugin) wrapRunError(err error) error {
+	if errors.Is(err, errPnpmNotFound) {
+		return fmt.Errorf("pnpm is not installed or not in PATH; install pnpm >= %s to scan this project: %w", minPnpmVersion, err)
+	}
+	if errors.Is(err, errPnpmVersionTooLow) {
+		return fmt.Errorf("pnpm >= %s is required for dependency graph resolution: %w", minPnpmVersion, err)
+	}
+	return fmt.Errorf("running pnpm list: %w", err)
+}
+
+func (p Plugin) discoverLockFiles(
+	ctx context.Context,
+	dir string,
+	options *ecosystems.SCAPluginOptions,
+) ([]discovery.FindResult, error) {
+	if options == nil {
+		options = ecosystems.NewPluginOptions()
+	}
+
+	switch {
+	case options.Global.TargetFile != nil:
+		if filepath.Base(*options.Global.TargetFile) != pnpmLockFile {
+			return nil, nil
+		}
+		files, err := discovery.FindFiles(ctx, dir, discovery.WithTargetFile(*options.Global.TargetFile))
+		if err != nil {
+			return nil, fmt.Errorf("discovering pnpm-lock.yaml files: %w", err)
+		}
+		return files, nil
+
+	case options.Global.AllProjects:
+		findOpts := []discovery.FindOption{
+			discovery.WithInclude(pnpmLockFile),
+			discovery.WithCommonExcludes(),
+		}
+		if len(options.Global.Exclude) > 0 {
+			findOpts = append(findOpts, discovery.WithExcludes(options.Global.Exclude...))
+		}
+		if len(options.Global.ExcludePaths) > 0 {
+			findOpts = append(findOpts, discovery.WithExcludes(options.Global.ExcludePaths...))
+		}
+		files, err := discovery.FindFiles(ctx, dir, findOpts...)
+		if err != nil {
+			return nil, fmt.Errorf("discovering pnpm-lock.yaml files: %w", err)
+		}
+		return files, nil
+
+	default:
+		rootLock := filepath.Join(dir, pnpmLockFile)
+		if !fileExists(rootLock) {
+			return nil, nil
+		}
+		return []discovery.FindResult{{Path: rootLock, RelPath: pnpmLockFile}}, nil
+	}
+}
+
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
+}
+
+// getExecutor returns the configured executor or the production pnpmCmdExecutor.
+// The zero-value Plugin{} is valid and uses the production executor.
+func (p Plugin) getExecutor() pnpmListRunner {
+	if p.executor != nil {
+		return p.executor
+	}
+	return &pnpmCmdExecutor{}
+}

--- a/pkg/ecosystems/javascript/pnpm/plugin_integration_test.go
+++ b/pkg/ecosystems/javascript/pnpm/plugin_integration_test.go
@@ -1,0 +1,111 @@
+//go:build integration && pnpm
+// +build integration,pnpm
+
+package pnpm_test
+
+import (
+	"context"
+	"encoding/json"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/javascript/pnpm"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/logger"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/scatest"
+)
+
+// requirePnpm skips the test when pnpm is not installed. Run via:
+//
+//	make test-pnpm-integration   (go test -tags="integration,pnpm" ...)
+func requirePnpm(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("pnpm"); err != nil {
+		t.Skip("pnpm not in PATH")
+	}
+}
+
+func run(t *testing.T, dir string) []ecosystems.SCAResult {
+	t.Helper()
+	results, err := scatest.Run(context.Background(), pnpm.Plugin{}, logger.Nop(), dir, ecosystems.NewPluginOptions())
+	require.NoError(t, err)
+	return results
+}
+
+func TestRushPnpm_SimpleVulnerableWorkspace(t *testing.T) {
+	requirePnpm(t)
+	results := run(t, filepath.Join("testdata", "simple-vulnerable-workspace"))
+
+	// Two real projects; the synthetic "rush-common" importer is filtered out.
+	require.Len(t, results, 2)
+
+	byName := map[string]ecosystems.SCAResult{}
+	for _, r := range results {
+		require.NoError(t, r.Error)
+		byName[r.ProjectDescriptor.Identity.RootComponentName] = r
+	}
+	require.Contains(t, byName, "@rush-fix/app-a")
+	require.Contains(t, byName, "@rush-fix/lib-b")
+
+	assert.Contains(t, graphJSON(t, byName["@rush-fix/app-a"]), "lodash@4.17.4")
+	assert.Contains(t, graphJSON(t, byName["@rush-fix/lib-b"]), "minimatch@3.0.0")
+
+	// targetFile points at the project's package.json, relative to the Rush root.
+	assert.Equal(t, filepath.Join("apps", "app-a", "package.json"),
+		byName["@rush-fix/app-a"].ProjectDescriptor.GetTargetFile())
+}
+
+// Standard (non-Rush) pnpm: a single-package project resolves directly via the
+// pnpm-lock.yaml discovery path, no staging.
+func TestStandalonePnpm(t *testing.T) {
+	requirePnpm(t)
+	results := run(t, filepath.Join("testdata", "standalone-pnpm"))
+
+	require.Len(t, results, 1)
+	require.NoError(t, results[0].Error)
+	assert.Equal(t, "standalone-pnpm-fixture", results[0].ProjectDescriptor.Identity.RootComponentName)
+	assert.Equal(t, "package.json", results[0].ProjectDescriptor.GetTargetFile())
+	assert.Contains(t, graphJSON(t, results[0]), "lodash@4.17.4")
+}
+
+// A project folder listed in rush.json but missing on disk (stale/renamed)
+// must be skipped, not abort the whole monorepo scan.
+func TestRushPnpm_MissingProjectIsSkippedNotFatal(t *testing.T) {
+	requirePnpm(t)
+	results := run(t, filepath.Join("testdata", "rush-missing-project"))
+
+	// app-a + lib-b still resolved; the missing "ghost" project is skipped.
+	require.Len(t, results, 2)
+	for _, r := range results {
+		require.NoError(t, r.Error)
+	}
+	names := map[string]bool{}
+	for _, r := range results {
+		names[r.ProjectDescriptor.Identity.RootComponentName] = true
+	}
+	assert.True(t, names["@rush-fix/app-a"] && names["@rush-fix/lib-b"])
+	assert.False(t, names["@rush-fix/ghost"])
+}
+
+func TestRushPnpm_NonPnpmAndSubspacesAreSkipped(t *testing.T) {
+	requirePnpm(t)
+	for _, scenario := range []string{"rush-npm", "rush-yarn", "subspaces"} {
+		t.Run(scenario, func(t *testing.T) {
+			results := run(t, filepath.Join("testdata", scenario))
+			assert.Empty(t, results, "%s should be skipped, not scanned", scenario)
+		})
+	}
+}
+
+func graphJSON(t *testing.T, r ecosystems.SCAResult) string {
+	t.Helper()
+	require.NotNil(t, r.DepGraph)
+	b, err := json.Marshal(r.DepGraph)
+	require.NoError(t, err)
+	return strings.ToLower(string(b))
+}

--- a/pkg/ecosystems/javascript/pnpm/rush.go
+++ b/pkg/ecosystems/javascript/pnpm/rush.go
@@ -1,11 +1,15 @@
 package pnpm
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
+
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/logger"
 )
 
 // Rush keeps its shared pnpm lockfile at common/config/rush/pnpm-lock.yaml and
@@ -44,6 +48,48 @@ var (
 	rushBlockCommentRe = regexp.MustCompile(`(?s)/\*.*?\*/`)
 	rushLineCommentRe  = regexp.MustCompile(`(?m)^\s*//.*$`)
 )
+
+// rushTargets is the Rush adapter: detects a pnpm-backed Rush monorepo, stages
+// the common/temp workspace context Rush generates at install time, and returns
+// a single scan target whose cleanup tears the tmp tree down.
+//
+// Out-of-scope Rush repos (npm/yarn-backed, subspaces) return (nil, nil) so the
+// scan ends quietly with a skip log. Unexpected setup failures return one
+// errTarget so they surface as an SCAResult rather than aborting the scan.
+func rushTargets(ctx context.Context, log logger.Logger, rushDir string) ([]scanTarget, error) {
+	log.Info(ctx, "Building Rush + pnpm dependency graphs", logger.Attr(logFieldDir, rushDir))
+
+	folders, err := rushProjectFolders(rushDir)
+	if err != nil {
+		if errors.Is(err, errRushNotPnpm) || errors.Is(err, errRushSubspaces) {
+			log.Info(ctx, "Skipping Rush workspace", logger.Attr("reason", err.Error()))
+			return nil, nil
+		}
+		return []scanTarget{errTarget(rushJSONFile, fmt.Errorf("reading rush.json: %w", err))}, nil
+	}
+
+	runDir, scanRoot, skipped, cleanup, err := stageRushWorkspace(rushDir, folders)
+	if err != nil {
+		return []scanTarget{errTarget(rushJSONFile, err)}, nil
+	}
+
+	if len(skipped) > 0 {
+		// User-visible surfacing of skips is part of the deferred FF+wiring
+		// work; for now log so a stale/renamed project folder doesn't silently
+		// vanish from a scan that otherwise succeeds.
+		log.Info(ctx, "Skipping Rush projects with no readable package.json",
+			logger.Attr("projects", strings.Join(skipped, ", ")))
+	}
+
+	return []scanTarget{{
+		cmdDir:          runDir,
+		manifestBaseDir: scanRoot,
+		excludeDir:      runDir, // the synthetic "rush-common" aggregate lives here
+		processedFiles:  []string{rushJSONFile, filepath.FromSlash(rushLockfilePath)},
+		errTargetFile:   rushJSONFile,
+		cleanup:         cleanup,
+	}}, nil
+}
 
 // stripJSONComments removes JSONC block and full-line comments from rush.json.
 func stripJSONComments(data []byte) []byte {

--- a/pkg/ecosystems/javascript/pnpm/rush.go
+++ b/pkg/ecosystems/javascript/pnpm/rush.go
@@ -1,0 +1,160 @@
+package pnpm
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+)
+
+// Rush keeps its shared pnpm lockfile at common/config/rush/pnpm-lock.yaml and
+// does NOT commit a pnpm-workspace.yaml (it generates one under common/temp at
+// `rush install`). To resolve the lockfile on a clean checkout without
+// installing, we recreate that generated layout in a throwaway tmp tree (so the
+// scanned repo is never mutated): a common/temp/ holding the lockfile copy + a
+// synthesized pnpm-workspace.yaml whose `packages:` are ../../<projectFolder>,
+// plus each project's package.json copied to ../../<projectFolder>/package.json
+// so those relative paths resolve within the tmp tree.
+
+const (
+	rushSubspacesConfig = "common/config/rush/subspaces.json"
+	rushLockfilePath    = "common/config/rush/pnpm-lock.yaml"
+	rushImporterBase    = "common/temp"
+)
+
+// errRushNotPnpm is returned for an npm/yarn-backed Rush repo (pnpm-only scope).
+var errRushNotPnpm = errors.New("not a pnpm-backed Rush monorepo; only Rush + pnpm is supported")
+
+// errRushSubspaces is returned when subspaces are enabled (out of scope): the
+// monorepo-level lockfile is forbidden, so scanning it would yield wrong
+// results. Skip rather than scan an incomplete lockfile.
+var errRushSubspaces = errors.New("rush subspaces are not yet supported (common/config/rush/subspaces.json present)")
+
+// rush.json is JSONC (comments + trailing commas); test for fields rather than
+// JSON-parsing.
+var (
+	rushPnpmVersionRe   = regexp.MustCompile(`"pnpmVersion"\s*:`)
+	rushProjectFolderRe = regexp.MustCompile(`"projectFolder"\s*:\s*"([^"]+)"`)
+
+	// JSONC comment strippers so a commented-out block (e.g. an old
+	// `/* "pnpmVersion": "7" */`) can't false-trigger the pnpm gate or inject a
+	// phantom project folder. Line stripping only removes whole-line `//`
+	// comments to avoid clobbering `//` inside string values (e.g. the $schema URL).
+	rushBlockCommentRe = regexp.MustCompile(`(?s)/\*.*?\*/`)
+	rushLineCommentRe  = regexp.MustCompile(`(?m)^\s*//.*$`)
+)
+
+// stripJSONComments removes JSONC block and full-line comments from rush.json.
+func stripJSONComments(data []byte) []byte {
+	data = rushBlockCommentRe.ReplaceAll(data, nil)
+	return rushLineCommentRe.ReplaceAll(data, nil)
+}
+
+// isRushRoot reports whether dir contains a rush.json.
+func isRushRoot(dir string) bool {
+	return fileExists(filepath.Join(dir, rushJSONFile))
+}
+
+// rushProjectFolders parses the project folders out of rush.json, and validates
+// the repo is pnpm-backed and not using subspaces.
+func rushProjectFolders(rushDir string) ([]string, error) {
+	data, err := os.ReadFile(filepath.Join(rushDir, rushJSONFile))
+	if err != nil {
+		return nil, fmt.Errorf("reading rush.json: %w", err)
+	}
+	data = stripJSONComments(data)
+	if !rushPnpmVersionRe.Match(data) {
+		return nil, errRushNotPnpm //nolint:wrapcheck // sentinel matched with errors.Is by the caller
+	}
+	if fileExists(filepath.Join(rushDir, filepath.FromSlash(rushSubspacesConfig))) {
+		return nil, errRushSubspaces //nolint:wrapcheck // sentinel matched with errors.Is by the caller
+	}
+
+	var folders []string
+	for _, m := range rushProjectFolderRe.FindAllSubmatch(data, -1) {
+		folders = append(folders, string(m[1]))
+	}
+	return folders, nil
+}
+
+// stageRushWorkspace recreates, in a throwaway tmp tree, the common/temp/
+// workspace context Rush generates at install time, so `pnpm list
+// --lockfile-only` can resolve the shared lockfile without mutating the scanned
+// repo. Returns runDir (where pnpm runs, = <tmp>/common/temp), scanRoot (the
+// tmp root, used as the base for package.json relative paths — structurally
+// identical to the real repo root), the project folders that were skipped
+// because they had no readable package.json, and a cleanup func.
+//
+// A project folder listed in rush.json but missing its package.json on disk
+// (stale/renamed/decoupled) is skipped, not fatal — pnpm tolerates a member
+// present in the lockfile but absent from pnpm-workspace.yaml. Only a workspace
+// with zero readable projects is an error.
+func stageRushWorkspace(rushDir string, projectFolders []string) (runDir, scanRoot string, skipped []string, cleanup func(), err error) {
+	lockBytes, err := os.ReadFile(filepath.Join(rushDir, filepath.FromSlash(rushLockfilePath)))
+	if err != nil {
+		return "", "", nil, nil, fmt.Errorf("reading Rush lockfile: %w", err)
+	}
+
+	tmpRoot, err := os.MkdirTemp("", "snyk-rush-pnpm-*")
+	if err != nil {
+		return "", "", nil, nil, fmt.Errorf("creating staging dir: %w", err)
+	}
+	cleanup = func() { _ = os.RemoveAll(tmpRoot) }
+
+	// Copy each project's package.json into the mirrored tree so the ../../
+	// importer paths resolve. Only package.json is needed — pnpm list
+	// --lockfile-only reads manifests + the lockfile, never node_modules.
+	var stagedFolders []string
+	for _, pf := range projectFolders {
+		src := filepath.Join(rushDir, filepath.FromSlash(pf), packageJSONFile)
+		data, readErr := os.ReadFile(src)
+		if readErr != nil {
+			skipped = append(skipped, pf)
+			continue
+		}
+		dstDir := filepath.Join(tmpRoot, filepath.FromSlash(pf))
+		if mkErr := os.MkdirAll(dstDir, 0o750); mkErr != nil {
+			cleanup()
+			return "", "", nil, nil, fmt.Errorf("staging %s: %w", pf, mkErr)
+		}
+		if wErr := os.WriteFile(filepath.Join(dstDir, packageJSONFile), data, 0o600); wErr != nil {
+			cleanup()
+			return "", "", nil, nil, fmt.Errorf("staging %s/package.json: %w", pf, wErr)
+		}
+		stagedFolders = append(stagedFolders, pf)
+	}
+	if len(stagedFolders) == 0 {
+		cleanup()
+		return "", "", nil, nil, fmt.Errorf("no Rush projects with a readable package.json found under %s", rushDir)
+	}
+
+	staged := filepath.Join(tmpRoot, filepath.FromSlash(rushImporterBase))
+	if mkErr := os.MkdirAll(staged, 0o750); mkErr != nil {
+		cleanup()
+		return "", "", nil, nil, fmt.Errorf("creating common/temp: %w", mkErr)
+	}
+
+	files := map[string][]byte{
+		pnpmLockFile:          lockBytes,
+		"pnpm-workspace.yaml": workspaceYAML(stagedFolders),
+		// The generated "." importer aggregate, filtered from results by path.
+		packageJSONFile: []byte(`{"name":"rush-common","version":"0.0.0","private":true,"dependencies":{}}`),
+	}
+	for name, data := range files {
+		if wErr := os.WriteFile(filepath.Join(staged, name), data, 0o600); wErr != nil {
+			cleanup()
+			return "", "", nil, nil, fmt.Errorf("staging %s: %w", name, wErr)
+		}
+	}
+
+	return staged, tmpRoot, skipped, cleanup, nil
+}
+
+func workspaceYAML(projectFolders []string) []byte {
+	ws := "packages:\n"
+	for _, pf := range projectFolders {
+		ws += "  - ../../" + pf + "\n"
+	}
+	return []byte(ws)
+}

--- a/pkg/ecosystems/javascript/pnpm/rush_test.go
+++ b/pkg/ecosystems/javascript/pnpm/rush_test.go
@@ -1,0 +1,54 @@
+package pnpm
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestStripJSONComments(t *testing.T) {
+	tests := []struct {
+		name           string
+		in             string
+		mustNotContain []string
+		mustContain    []string
+	}{
+		{
+			name:           "block comment removed",
+			in:             `{ /* "pnpmVersion": "7.0.0", */ "npmVersion": "9.0.0" }`,
+			mustNotContain: []string{"pnpmVersion"},
+			mustContain:    []string{"npmVersion"},
+		},
+		{
+			name:           "whole-line comment removed",
+			in:             "{\n  // \"pnpmVersion\": \"7.0.0\",\n  \"npmVersion\": \"9.0.0\"\n}",
+			mustNotContain: []string{"pnpmVersion"},
+			mustContain:    []string{"npmVersion"},
+		},
+		{
+			name:        "inline // inside a string value is preserved",
+			in:          "{\n  \"$schema\": \"https://example.com/v5/rush.schema.json\",\n  \"pnpmVersion\": \"8.15.8\"\n}",
+			mustContain: []string{"https://example.com", "pnpmVersion"},
+		},
+		{
+			name:        "real config untouched",
+			in:          "{\n  \"pnpmVersion\": \"8.15.8\",\n  \"projects\": [{ \"projectFolder\": \"apps/a\" }]\n}",
+			mustContain: []string{"pnpmVersion", "apps/a"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := string(stripJSONComments([]byte(tt.in)))
+			for _, s := range tt.mustNotContain {
+				if strings.Contains(got, s) {
+					t.Errorf("stripped output should not contain %q; got:\n%s", s, got)
+				}
+			}
+			for _, s := range tt.mustContain {
+				if !strings.Contains(got, s) {
+					t.Errorf("stripped output should contain %q; got:\n%s", s, got)
+				}
+			}
+		})
+	}
+}

--- a/pkg/ecosystems/javascript/pnpm/testdata/rush-missing-project/README.md
+++ b/pkg/ecosystems/javascript/pnpm/testdata/rush-missing-project/README.md
@@ -1,0 +1,12 @@
+# simple-vulnerable-workspace — Rush + pnpm baseline (the easy case)
+
+The canonical Rush + pnpm monorepo: two projects sharing one committed lockfile, with known-vulnerable dependencies. This is the easy case to work with.
+
+- **Layout:** `apps/app-a` (depends on `lodash@4.17.4` and on `@rush-fix/lib-b` via `workspace:*`) + `libs/lib-b` (depends on `minimatch@3.0.0`). Shared lockfile committed at `common/config/rush/pnpm-lock.yaml`. No `common/temp/` and no root `pnpm-workspace.yaml` — i.e. a fresh SCM clone, exactly as the PRD describes.
+- **PRD mapping:** PR-1–PR-5 / JTBD "scan an entire Rush + pnpm monorepo".
+- **Expected (post-Rush-support):** `snyk test --all-projects` produces **one dep graph per Rush project** from the shared lockfile (no `rush install` needed) and reports the lodash + minimatch vulnerabilities.
+- **Today (verified, current CLI 1.1304.0):** the gap reproduces exactly —
+  - `snyk test` → `No supported files found (SNYK-CLI-0008)`.
+  - `snyk test --all-projects` → finds `common/config/rush/pnpm-lock.yaml` but errors *"Could not find package.json at common/config/rush/package.json"* (the shared-deep-lockfile / no-sibling-package.json gap), and the per-project `package.json`s scan manifest-only.
+
+To regenerate the lockfile: `rush update` (Rush 5.175.1, pnpm 8.15.8).

--- a/pkg/ecosystems/javascript/pnpm/testdata/rush-missing-project/apps/app-a/package.json
+++ b/pkg/ecosystems/javascript/pnpm/testdata/rush-missing-project/apps/app-a/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@rush-fix/app-a",
+  "version": "1.0.0",
+  "description": "App that depends on lib-b (workspace) and a vulnerable lodash.",
+  "dependencies": {
+    "lodash": "4.17.4",
+    "@rush-fix/lib-b": "workspace:*"
+  }
+}

--- a/pkg/ecosystems/javascript/pnpm/testdata/rush-missing-project/common/config/rush/.npmrc
+++ b/pkg/ecosystems/javascript/pnpm/testdata/rush-missing-project/common/config/rush/.npmrc
@@ -1,0 +1,2 @@
+# Registry config for Rush-managed pnpm install. Public registry for the fixture.
+registry=https://registry.npmjs.org/

--- a/pkg/ecosystems/javascript/pnpm/testdata/rush-missing-project/common/config/rush/pnpm-lock.yaml
+++ b/pkg/ecosystems/javascript/pnpm/testdata/rush-missing-project/common/config/rush/pnpm-lock.yaml
@@ -1,0 +1,52 @@
+lockfileVersion: '6.0'
+
+settings:
+  autoInstallPeers: false
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .: {}
+
+  ../../apps/app-a:
+    dependencies:
+      '@rush-fix/lib-b':
+        specifier: workspace:*
+        version: link:../../libs/lib-b
+      lodash:
+        specifier: 4.17.4
+        version: 4.17.4
+
+  ../../libs/lib-b:
+    dependencies:
+      minimatch:
+        specifier: 3.0.0
+        version: 3.0.0
+
+packages:
+
+  /balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+    dev: false
+
+  /brace-expansion@1.1.15:
+    resolution: {integrity: sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==}
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
+    dev: false
+
+  /concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+    dev: false
+
+  /lodash@4.17.4:
+    resolution: {integrity: sha512-6X37Sq9KCpLSXEh8uM12AKYlviHPNNk4RxiGBn4cmKGJinbXBneWIV7iE/nXkM928O7ytHcHb6+X6Svl0f4hXg==}
+    dev: false
+
+  /minimatch@3.0.0:
+    resolution: {integrity: sha512-ekKdP/98gMbw+JdQaHZlS5/irFw63ktA3FXHaal7TXkvdaUJ9M6BewwNyEujYzRsTirZGmEVDho+Gh8bfcpVxw==}
+    deprecated: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
+    dependencies:
+      brace-expansion: 1.1.15
+    dev: false

--- a/pkg/ecosystems/javascript/pnpm/testdata/rush-missing-project/common/config/rush/repo-state.json
+++ b/pkg/ecosystems/javascript/pnpm/testdata/rush-missing-project/common/config/rush/repo-state.json
@@ -1,0 +1,4 @@
+// DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
+{
+  "preferredVersionsHash": "bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f"
+}

--- a/pkg/ecosystems/javascript/pnpm/testdata/rush-missing-project/libs/lib-b/package.json
+++ b/pkg/ecosystems/javascript/pnpm/testdata/rush-missing-project/libs/lib-b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@rush-fix/lib-b",
+  "version": "1.0.0",
+  "description": "Library with a vulnerable minimatch, linked into app-a via workspace.",
+  "dependencies": {
+    "minimatch": "3.0.0"
+  }
+}

--- a/pkg/ecosystems/javascript/pnpm/testdata/rush-missing-project/rush.json
+++ b/pkg/ecosystems/javascript/pnpm/testdata/rush-missing-project/rush.json
@@ -1,0 +1,12 @@
+{
+  "rushVersion": "5.175.1",
+  "pnpmVersion": "8.15.8",
+  "pnpmOptions": {
+    "useWorkspaces": true
+  },
+  "projects": [
+    { "packageName": "@rush-fix/app-a", "projectFolder": "apps/app-a" },
+    { "packageName": "@rush-fix/lib-b", "projectFolder": "libs/lib-b" },
+    { "packageName": "@rush-fix/ghost", "projectFolder": "apps/ghost" }
+  ]
+}

--- a/pkg/ecosystems/javascript/pnpm/testdata/rush-npm/README.md
+++ b/pkg/ecosystems/javascript/pnpm/testdata/rush-npm/README.md
@@ -1,0 +1,9 @@
+# rush-npm — Rush + npm (out of scope; detect & skip)
+
+A Rush monorepo configured with **`npmVersion`** instead of `pnpmVersion`.
+
+- **PRD mapping:** PR-7 (Rush + npm / yarn — detect and skip). Out of scope per *Out of scope* (pnpm-only).
+- **Expected (post-Rush-support):** Snyk detects `rush.json` with `npmVersion`, recognizes it as a Rush repo, and **skips with a clear, actionable message** — not a silent zero, not a crash.
+- **Today:** no Rush awareness at all (`rush.json` isn't in the detectable-files list).
+
+This fixture exists to prove the skip-message path, not to scan.

--- a/pkg/ecosystems/javascript/pnpm/testdata/rush-npm/apps/app-a/package.json
+++ b/pkg/ecosystems/javascript/pnpm/testdata/rush-npm/apps/app-a/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@rush-npm/app-a",
+  "version": "1.0.0",
+  "description": "Rush + npm project — out of scope; must be detected and skipped with a clear message.",
+  "dependencies": {
+    "lodash": "4.17.4"
+  }
+}

--- a/pkg/ecosystems/javascript/pnpm/testdata/rush-npm/rush.json
+++ b/pkg/ecosystems/javascript/pnpm/testdata/rush-npm/rush.json
@@ -1,0 +1,7 @@
+{
+  "rushVersion": "5.175.1",
+  "npmVersion": "8.19.4",
+  "projects": [
+    { "packageName": "@rush-npm/app-a", "projectFolder": "apps/app-a" }
+  ]
+}

--- a/pkg/ecosystems/javascript/pnpm/testdata/rush-yarn/README.md
+++ b/pkg/ecosystems/javascript/pnpm/testdata/rush-yarn/README.md
@@ -1,0 +1,9 @@
+# rush-yarn — Rush + yarn (out of scope; detect & skip)
+
+A Rush monorepo configured with **`yarnVersion`** instead of `pnpmVersion`.
+
+- **PRD mapping:** PR-7 (Rush + npm / yarn — detect and skip). Out of scope per *Out of scope* (pnpm-only).
+- **Expected (post-Rush-support):** Snyk detects the Rush repo and **skips with a clear message** stating Rush is supported only with pnpm.
+- **Today:** no Rush awareness.
+
+This fixture exists to prove the skip-message path, not to scan.

--- a/pkg/ecosystems/javascript/pnpm/testdata/rush-yarn/apps/app-a/package.json
+++ b/pkg/ecosystems/javascript/pnpm/testdata/rush-yarn/apps/app-a/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@rush-yarn/app-a",
+  "version": "1.0.0",
+  "description": "Rush + yarn project — out of scope; must be detected and skipped with a clear message.",
+  "dependencies": {
+    "lodash": "4.17.4"
+  }
+}

--- a/pkg/ecosystems/javascript/pnpm/testdata/rush-yarn/rush.json
+++ b/pkg/ecosystems/javascript/pnpm/testdata/rush-yarn/rush.json
@@ -1,0 +1,7 @@
+{
+  "rushVersion": "5.175.1",
+  "yarnVersion": "1.22.22",
+  "projects": [
+    { "packageName": "@rush-yarn/app-a", "projectFolder": "apps/app-a" }
+  ]
+}

--- a/pkg/ecosystems/javascript/pnpm/testdata/simple-vulnerable-workspace/README.md
+++ b/pkg/ecosystems/javascript/pnpm/testdata/simple-vulnerable-workspace/README.md
@@ -1,0 +1,12 @@
+# simple-vulnerable-workspace — Rush + pnpm baseline (the easy case)
+
+The canonical Rush + pnpm monorepo: two projects sharing one committed lockfile, with known-vulnerable dependencies. This is the easy case to work with.
+
+- **Layout:** `apps/app-a` (depends on `lodash@4.17.4` and on `@rush-fix/lib-b` via `workspace:*`) + `libs/lib-b` (depends on `minimatch@3.0.0`). Shared lockfile committed at `common/config/rush/pnpm-lock.yaml`. No `common/temp/` and no root `pnpm-workspace.yaml` — i.e. a fresh SCM clone, exactly as the PRD describes.
+- **PRD mapping:** PR-1–PR-5 / JTBD "scan an entire Rush + pnpm monorepo".
+- **Expected (post-Rush-support):** `snyk test --all-projects` produces **one dep graph per Rush project** from the shared lockfile (no `rush install` needed) and reports the lodash + minimatch vulnerabilities.
+- **Today (verified, current CLI 1.1304.0):** the gap reproduces exactly —
+  - `snyk test` → `No supported files found (SNYK-CLI-0008)`.
+  - `snyk test --all-projects` → finds `common/config/rush/pnpm-lock.yaml` but errors *"Could not find package.json at common/config/rush/package.json"* (the shared-deep-lockfile / no-sibling-package.json gap), and the per-project `package.json`s scan manifest-only.
+
+To regenerate the lockfile: `rush update` (Rush 5.175.1, pnpm 8.15.8).

--- a/pkg/ecosystems/javascript/pnpm/testdata/simple-vulnerable-workspace/apps/app-a/package.json
+++ b/pkg/ecosystems/javascript/pnpm/testdata/simple-vulnerable-workspace/apps/app-a/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@rush-fix/app-a",
+  "version": "1.0.0",
+  "description": "App that depends on lib-b (workspace) and a vulnerable lodash.",
+  "dependencies": {
+    "lodash": "4.17.4",
+    "@rush-fix/lib-b": "workspace:*"
+  }
+}

--- a/pkg/ecosystems/javascript/pnpm/testdata/simple-vulnerable-workspace/common/config/rush/.npmrc
+++ b/pkg/ecosystems/javascript/pnpm/testdata/simple-vulnerable-workspace/common/config/rush/.npmrc
@@ -1,0 +1,2 @@
+# Registry config for Rush-managed pnpm install. Public registry for the fixture.
+registry=https://registry.npmjs.org/

--- a/pkg/ecosystems/javascript/pnpm/testdata/simple-vulnerable-workspace/common/config/rush/pnpm-lock.yaml
+++ b/pkg/ecosystems/javascript/pnpm/testdata/simple-vulnerable-workspace/common/config/rush/pnpm-lock.yaml
@@ -1,0 +1,52 @@
+lockfileVersion: '6.0'
+
+settings:
+  autoInstallPeers: false
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .: {}
+
+  ../../apps/app-a:
+    dependencies:
+      '@rush-fix/lib-b':
+        specifier: workspace:*
+        version: link:../../libs/lib-b
+      lodash:
+        specifier: 4.17.4
+        version: 4.17.4
+
+  ../../libs/lib-b:
+    dependencies:
+      minimatch:
+        specifier: 3.0.0
+        version: 3.0.0
+
+packages:
+
+  /balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+    dev: false
+
+  /brace-expansion@1.1.15:
+    resolution: {integrity: sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==}
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
+    dev: false
+
+  /concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+    dev: false
+
+  /lodash@4.17.4:
+    resolution: {integrity: sha512-6X37Sq9KCpLSXEh8uM12AKYlviHPNNk4RxiGBn4cmKGJinbXBneWIV7iE/nXkM928O7ytHcHb6+X6Svl0f4hXg==}
+    dev: false
+
+  /minimatch@3.0.0:
+    resolution: {integrity: sha512-ekKdP/98gMbw+JdQaHZlS5/irFw63ktA3FXHaal7TXkvdaUJ9M6BewwNyEujYzRsTirZGmEVDho+Gh8bfcpVxw==}
+    deprecated: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
+    dependencies:
+      brace-expansion: 1.1.15
+    dev: false

--- a/pkg/ecosystems/javascript/pnpm/testdata/simple-vulnerable-workspace/common/config/rush/repo-state.json
+++ b/pkg/ecosystems/javascript/pnpm/testdata/simple-vulnerable-workspace/common/config/rush/repo-state.json
@@ -1,0 +1,4 @@
+// DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
+{
+  "preferredVersionsHash": "bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f"
+}

--- a/pkg/ecosystems/javascript/pnpm/testdata/simple-vulnerable-workspace/libs/lib-b/package.json
+++ b/pkg/ecosystems/javascript/pnpm/testdata/simple-vulnerable-workspace/libs/lib-b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@rush-fix/lib-b",
+  "version": "1.0.0",
+  "description": "Library with a vulnerable minimatch, linked into app-a via workspace.",
+  "dependencies": {
+    "minimatch": "3.0.0"
+  }
+}

--- a/pkg/ecosystems/javascript/pnpm/testdata/simple-vulnerable-workspace/rush.json
+++ b/pkg/ecosystems/javascript/pnpm/testdata/simple-vulnerable-workspace/rush.json
@@ -1,0 +1,11 @@
+{
+  "rushVersion": "5.175.1",
+  "pnpmVersion": "8.15.8",
+  "pnpmOptions": {
+    "useWorkspaces": true
+  },
+  "projects": [
+    { "packageName": "@rush-fix/app-a", "projectFolder": "apps/app-a" },
+    { "packageName": "@rush-fix/lib-b", "projectFolder": "libs/lib-b" }
+  ]
+}

--- a/pkg/ecosystems/javascript/pnpm/testdata/standalone-pnpm/package.json
+++ b/pkg/ecosystems/javascript/pnpm/testdata/standalone-pnpm/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "standalone-pnpm-fixture",
+  "version": "1.0.0",
+  "description": "Single-package (non-workspace) pnpm project with a vulnerable lodash.",
+  "dependencies": {
+    "lodash": "4.17.4"
+  }
+}

--- a/pkg/ecosystems/javascript/pnpm/testdata/standalone-pnpm/pnpm-lock.yaml
+++ b/pkg/ecosystems/javascript/pnpm/testdata/standalone-pnpm/pnpm-lock.yaml
@@ -1,0 +1,22 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      lodash:
+        specifier: 4.17.4
+        version: 4.17.4
+
+packages:
+
+  lodash@4.17.4:
+    resolution: {integrity: sha512-6X37Sq9KCpLSXEh8uM12AKYlviHPNNk4RxiGBn4cmKGJinbXBneWIV7iE/nXkM928O7ytHcHb6+X6Svl0f4hXg==}
+
+snapshots:
+
+  lodash@4.17.4: {}

--- a/pkg/ecosystems/javascript/pnpm/testdata/subspaces/README.md
+++ b/pkg/ecosystems/javascript/pnpm/testdata/subspaces/README.md
@@ -1,0 +1,11 @@
+# subspaces — Rush + pnpm subspaces (detect & warn; full scan out of scope)
+
+A Rush monorepo with **subspaces enabled**. Per-subspace lockfiles live at
+`common/config/subspaces/<name>/pnpm-lock.yaml`, and a monorepo-level
+`common/config/rush/pnpm-lock.yaml` is **forbidden** when subspaces are on.
+
+- **PRD mapping:** PR-6 (subspaces detection + warning). Full subspaces scanning is **out of scope** in v1.
+- **Expected (post-Rush-support):** Snyk detects `common/config/rush/subspaces.json` (`subspacesEnabled: true`) and **warns clearly** that subspaces aren't fully scanned yet — it must **never silently return zero**.
+- **Today:** silent zero — the v1 hardcoded `common/config/rush/` path finds no lockfile and scans nothing.
+
+Note: the lockfile here is a representative pnpm v6 file showing the subspaces layout; it is not produced by `rush install` in this fixture. The detection/warn path keys off `subspaces.json`, not lockfile contents.

--- a/pkg/ecosystems/javascript/pnpm/testdata/subspaces/apps/app-a/package.json
+++ b/pkg/ecosystems/javascript/pnpm/testdata/subspaces/apps/app-a/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@rush-sub/app-a",
+  "version": "1.0.0",
+  "description": "Project in a Rush subspace. Lockfile lives at common/config/subspaces/default/pnpm-lock.yaml.",
+  "dependencies": {
+    "lodash": "4.17.4"
+  }
+}

--- a/pkg/ecosystems/javascript/pnpm/testdata/subspaces/common/config/rush/subspaces.json
+++ b/pkg/ecosystems/javascript/pnpm/testdata/subspaces/common/config/rush/subspaces.json
@@ -1,0 +1,4 @@
+{
+  "subspacesEnabled": true,
+  "subspaceNames": ["default"]
+}

--- a/pkg/ecosystems/javascript/pnpm/testdata/subspaces/common/config/subspaces/default/pnpm-lock.yaml
+++ b/pkg/ecosystems/javascript/pnpm/testdata/subspaces/common/config/subspaces/default/pnpm-lock.yaml
@@ -1,0 +1,52 @@
+lockfileVersion: '6.0'
+
+settings:
+  autoInstallPeers: false
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .: {}
+
+  ../../apps/app-a:
+    dependencies:
+      '@rush-fix/lib-b':
+        specifier: workspace:*
+        version: link:../../libs/lib-b
+      lodash:
+        specifier: 4.17.4
+        version: 4.17.4
+
+  ../../libs/lib-b:
+    dependencies:
+      minimatch:
+        specifier: 3.0.0
+        version: 3.0.0
+
+packages:
+
+  /balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+    dev: false
+
+  /brace-expansion@1.1.15:
+    resolution: {integrity: sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==}
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
+    dev: false
+
+  /concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+    dev: false
+
+  /lodash@4.17.4:
+    resolution: {integrity: sha512-6X37Sq9KCpLSXEh8uM12AKYlviHPNNk4RxiGBn4cmKGJinbXBneWIV7iE/nXkM928O7ytHcHb6+X6Svl0f4hXg==}
+    dev: false
+
+  /minimatch@3.0.0:
+    resolution: {integrity: sha512-ekKdP/98gMbw+JdQaHZlS5/irFw63ktA3FXHaal7TXkvdaUJ9M6BewwNyEujYzRsTirZGmEVDho+Gh8bfcpVxw==}
+    deprecated: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
+    dependencies:
+      brace-expansion: 1.1.15
+    dev: false

--- a/pkg/ecosystems/javascript/pnpm/testdata/subspaces/rush.json
+++ b/pkg/ecosystems/javascript/pnpm/testdata/subspaces/rush.json
@@ -1,0 +1,10 @@
+{
+  "rushVersion": "5.175.1",
+  "pnpmVersion": "8.15.8",
+  "pnpmOptions": {
+    "useWorkspaces": true
+  },
+  "projects": [
+    { "packageName": "@rush-sub/app-a", "projectFolder": "apps/app-a", "subspaceName": "default" }
+  ]
+}

--- a/pkg/ecosystems/javascript/pnpm/types.go
+++ b/pkg/ecosystems/javascript/pnpm/types.go
@@ -1,0 +1,30 @@
+package pnpm
+
+const (
+	packageJSONFile = "package.json"
+	pnpmLockFile    = "pnpm-lock.yaml"
+	rushJSONFile    = "rush.json"
+	defaultVersion  = "0.0.0"
+)
+
+// listProject is one importer entry from `pnpm list --json` (an array, one
+// element per workspace project). Dependencies are a forward tree: each dep
+// carries its resolved version and its own nested dependencies.
+type listProject struct {
+	Name                 string             `json:"name"`
+	Version              string             `json:"version"`
+	Path                 string             `json:"path"`
+	Dependencies         map[string]listDep `json:"dependencies"`
+	DevDependencies      map[string]listDep `json:"devDependencies"`
+	OptionalDependencies map[string]listDep `json:"optionalDependencies"`
+}
+
+// listDep is a node in pnpm's forward dependency tree. A workspace
+// cross-dependency has a Version of the form "link:<relpath>".
+type listDep struct {
+	From         string             `json:"from"`
+	Version      string             `json:"version"`
+	Path         string             `json:"path"`
+	Resolved     string             `json:"resolved"`
+	Dependencies map[string]listDep `json:"dependencies"`
+}


### PR DESCRIPTION
## What

Adds a pnpm SCA plugin at `pkg/ecosystems/javascript/pnpm/` that resolves pnpm dependency graphs by shelling out to `pnpm list --lockfile-only --json` — no `node_modules`, no install — plus a **Rush.js** adapter. Conforms to the established plugin pattern (bun/npm/yarn): `SCAPlugin` contract, runner interface + version gate, discovery 3-branch switch, one graph per importer with workspace members as stop-set leaves.

## How

- **pnpm** — `executor.go` shells out to `pnpm list --lockfile-only --json --depth Infinity`; `depgraph.go` builds one `godepgraph` per importer from the forward tree (`link:`/workspace deps rendered as sibling coordinates and treated as stop-set leaves; edge-dedup; cycle guard; version fallback).
- **Rush** (`rush.go`) — detects `rush.json`, gates on `pnpmVersion` (skips npm/yarn-backed and subspaces repos), and reconstructs the `common/temp` workspace context Rush generates at `rush install` time — in a **throwaway tmp tree** (lockfile copy + synthesized `pnpm-workspace.yaml` + copied member `package.json`s), never mutating the scanned repo — so pnpm resolves the committed `common/config/rush/pnpm-lock.yaml` on a clean checkout. A project listed in `rush.json` but missing its `package.json` is skipped-and-logged, not fatal.

## Tests

- Unit (default `go test`): `parsePnpmVersion`, `stripJSONComments`.
- Integration (`//go:build integration && pnpm`, `make test-pnpm-integration`) via `scatest` over `testdata/`: Rush workspace, standalone pnpm, missing-project skip, and npm/yarn/subspaces skip.

## Scope — NOT in this PR (deliberate)

- **Orchestrator registration is deferred.** The plugin is self-contained and not wired into `orchestrator/registry.go`. Registration behind a `FlagPnpmResolver` is the follow-up PR.
- Pre-GA follow-ups (from a PM review), to land with wiring:
  - **Dual-FF mutual exclusivity** — when `FlagPnpmResolver` is on, force the legacy `rushPnpmSupport` FF off for the same scan (the orchestrator runs the legacy CLI last with `--exclude-paths`; otherwise risk double-emission / `snyk monitor` identity churn in `--all-projects`).
  - **User-visible skip warnings** for npm/yarn/subspaces (currently logged only).
  - **Out-of-sync lockfile policy** (`--strict-out-of-sync`).
  - **Detection contract** for nested/sidecar pnpm projects under a Rush root.
- pnpm-feature parity (catalogs / aliases / `patch:`) is an independent-builder assumption to verify — this is **not** a reuse of the TS `nodejs-lockfile-parser`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
