### PR TITLE
feat(pnpm): register Rush/pnpm resolver in orchestrator behind FlagPnpmResolver

### DIFF
--- a/pkg/ecosystems/orchestrator/flags.go
+++ b/pkg/ecosystems/orchestrator/flags.go
@@ -30,12 +30,18 @@ var FlagCargoResolver = flag{
 	Value: "internal-cargo-resolver",
 }
 
+var FlagPnpmResolver = flag{
+	Key:   "internal-pnpm-resolver",
+	Value: "internal-pnpm-resolver",
+}
+
 var allFlags = []flag{
 	FlagUnifiedTestAPIOsCLI,
 	FlagNewGradleResolver,
 	FlagBazelResolver,
 	FlagBunResolver,
 	FlagCargoResolver,
+	FlagPnpmResolver,
 }
 
 // GetAllFlags returns all feature flags as a map of key to flag name.

--- a/pkg/ecosystems/orchestrator/registry.go
+++ b/pkg/ecosystems/orchestrator/registry.go
@@ -12,6 +12,7 @@ import (
 	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/bazel"
 	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/gradle"
 	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/javascript/bun"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/javascript/pnpm"
 	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/legacy"
 	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/logger"
 	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/rust/cargo"
@@ -48,6 +49,9 @@ func NewDefaultPluginRegistry(ictx workflow.InvocationContext) (*PluginRegistry,
 	// javascript
 	if err := r.register(bun.Plugin{}, withFeatureFlagCheck(FlagBunResolver), withPluginDependencies(bazelPluginName)); err != nil {
 		return nil, fmt.Errorf("failed to register bun plugin: %w", err)
+	}
+	if err := r.register(pnpm.Plugin{}, withFeatureFlagCheck(FlagPnpmResolver), withPluginDependencies(bazelPluginName)); err != nil {
+		return nil, fmt.Errorf("failed to register pnpm plugin: %w", err)
 	}
 	// gradle (opt-in via feature flag)
 	cfg := ictx.GetConfiguration()

--- a/pkg/ecosystems/orchestrator/registry_test.go
+++ b/pkg/ecosystems/orchestrator/registry_test.go
@@ -119,14 +119,15 @@ func TestPluginRegistry_DefaultRegistryOrder_WithFeatureFlags(t *testing.T) {
 	ictx := setupMockInvocationContextWithConfig(t, func(cfg configuration.Configuration) {
 		cfg.Set(FlagBazelResolver.Key, true)
 		cfg.Set(FlagBunResolver.Key, true)
+		cfg.Set(FlagPnpmResolver.Key, true)
 		cfg.Set(FlagNewGradleResolver.Key, true)
 		cfg.Set(FlagCargoResolver.Key, true)
 	})
 	r, err := NewDefaultPluginRegistry(ictx)
 	require.NoError(t, err)
 
-	require.Len(t, r.plugins, 4)
-	expectedOrder := []string{"bazel", "bun", "gradle", "cargo"}
+	require.Len(t, r.plugins, 5)
+	expectedOrder := []string{"bazel", "bun", "pnpm", "gradle", "cargo"}
 	for i, plugin := range r.plugins {
 		assert.Equal(t, expectedOrder[i], plugin.GetName())
 	}
@@ -146,6 +147,7 @@ func TestPluginRegistry_DefaultRegistryHasNoCircularDependencies_WithFeatureFlag
 	ictx := setupMockInvocationContextWithConfig(t, func(cfg configuration.Configuration) {
 		cfg.Set(FlagBazelResolver.Key, true)
 		cfg.Set(FlagBunResolver.Key, true)
+		cfg.Set(FlagPnpmResolver.Key, true)
 		cfg.Set(FlagNewGradleResolver.Key, true)
 		cfg.Set(FlagCargoResolver.Key, true)
 	})
@@ -153,7 +155,7 @@ func TestPluginRegistry_DefaultRegistryHasNoCircularDependencies_WithFeatureFlag
 	require.NoError(t, err, "NewDefaultPluginRegistry should not return error for valid dependency graph")
 	assert.NotNil(t, r)
 	assert.NotNil(t, r.plugins, "plugins should be successfully sorted without circular dependencies")
-	assert.Len(t, r.plugins, 4, "all 4 plugins should be registered")
+	assert.Len(t, r.plugins, 5, "all 5 plugins should be registered")
 }
 
 func TestPluginRegistry_CircularDependencyReturnsError(t *testing.T) {


### PR DESCRIPTION
Replaces #215 (auto-closed by GitHub during the #213 base-branch deletion; branch/commit intact, already approved there).

Registers `pnpm.Plugin{}` in `NewDefaultPluginRegistry` behind `FlagPnpmResolver` (`internal-pnpm-resolver`), ordered `bazel → bun → pnpm → gradle → cargo` with a bazel dependency. Dormant until the orchestrator is wired into `handleSBOMResolution` (currently a hand-built `[uv, legacy]` slice with no orchestrator caller).

Verified: build clean, orchestrator + pnpm tests pass, `golangci-lint run --build-tags integration` = 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)