### PR TITLE
feat: [DGP-1824] set a targetFile fallback when TargetFileFromPlugin is empty

### DIFF
--- a/pkg/ecosystems/legacy/plugin.go
+++ b/pkg/ecosystems/legacy/plugin.go
@@ -156,6 +156,13 @@ func depGraphOutputToSCAResult(ctx context.Context, log logger.Logger, output *p
 		if rootPkg := dg.GetRootPkg(); rootPkg != nil {
 			result.ProjectDescriptor.Identity.RootComponentName = rootPkg.Info.Name
 		}
+
+		// The Python plugin omits targetFileFromPlugin for pip projects; normalisedTargetFile
+		// (e.g. requirements.txt) is the correct manifest to use as the fallback in that case.
+		if dg.PkgManager.Name == "pip" && result.ProjectDescriptor.Identity.TargetFile == nil && output.NormalisedTargetFile != "" {
+			tf := output.NormalisedTargetFile
+			result.ProjectDescriptor.Identity.TargetFile = &tf
+		}
 	}
 
 	return result

--- a/pkg/ecosystems/legacy/plugin_test.go
+++ b/pkg/ecosystems/legacy/plugin_test.go
@@ -51,9 +51,10 @@ func TestPlugin_MapsTargetFramework(t *testing.T) {
 
 // TestPlugin_TargetFileForwarding verifies the plugin forwards the legacy CLI's
 // `targetFileFromPlugin` field verbatim onto Identity.TargetFile, and its
-// `normalisedTargetFile` onto ResolverMetadata.NormalisedTargetFile. Downstream
-// emission of MetaKeyTargetFileFromPlugin depends on Identity.TargetFile's nilness
-// exactly matching the CLI's own.
+// `normalisedTargetFile` onto ResolverMetadata.NormalisedTargetFile. For pip projects
+// the Python plugin omits `targetFileFromPlugin`; the plugin falls back to
+// `normalisedTargetFile` (e.g. requirements.txt). For other ecosystems (e.g. npm)
+// `targetFileFromPlugin` is omitted intentionally; Identity.TargetFile stays nil.
 func TestPlugin_TargetFileForwarding(t *testing.T) {
 	cases := map[string]struct {
 		body                 string
@@ -70,15 +71,20 @@ func TestPlugin_TargetFileForwarding(t *testing.T) {
 			wantNormalisedTarget: "build.gradle.kts",
 			wantPluginTargetFile: stringPtr("something-else.kts"),
 		},
-		"CLI omits targetFileFromPlugin → forwarded as nil": {
+		"CLI omits targetFileFromPlugin for npm → forwarded as nil (lockfile, not manifest)": {
 			body:                 `{"depGraph":{"pkgManager":{"name":"npm"}},"normalisedTargetFile":"package-lock.json"}`,
 			wantNormalisedTarget: "package-lock.json",
 			wantPluginTargetFile: nil,
 		},
-		"CLI omits targetFileFromPlugin even when workspace is set": {
+		"CLI omits targetFileFromPlugin for npm even when workspace is set → forwarded as nil": {
 			body:                 `{"depGraph":{"pkgManager":{"name":"npm"}},"normalisedTargetFile":"package-lock.json","workspace":{"type":"npm"}}`,
 			wantNormalisedTarget: "package-lock.json",
 			wantPluginTargetFile: nil,
+		},
+		"CLI omits targetFileFromPlugin for pip → falls back to normalisedTargetFile": {
+			body:                 `{"depGraph":{"pkgManager":{"name":"pip"}},"normalisedTargetFile":"requirements.txt"}`,
+			wantNormalisedTarget: "requirements.txt",
+			wantPluginTargetFile: stringPtr("requirements.txt"),
 		},
 	}
 


### PR DESCRIPTION
Set a targetFile fallback for pip when TargetFileFromPlugin is empty

  - fall back to normalisedTargetFile when targetFileFromPlugin is absent

- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [N/A] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

For SCA Monitor we receive an empty target_file for a few environments:

- npm/yarn/pnpm -- snyk-nodejs-lockfile-parser -- plugin metadata has no targetFile
- python (requirements.txt / pip) -- snyk-python-plugin -- returnedTargetFile() returns undefined for the default case
- Gradle (build.gradle) -- snyk-gradle-plugin -- explicitly returns undefined for non-.kts (BST-529 workaround)

This changes sets pip to use the normalizedTargetFile (requirements.txt).  The other ecosystems have defined reasons for not doing so.