### PR TITLE
feat: wrap orchestrator as SCAPlugin for SBOM flow

### DIFF
--- a/pkg/depgraph/sbom_resolution.go
+++ b/pkg/depgraph/sbom_resolution.go
@@ -20,8 +20,8 @@ import (
 	"github.com/snyk/cli-extension-dep-graph/v2/internal/snykclient"
 	"github.com/snyk/cli-extension-dep-graph/v2/internal/workflow"
 	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems"
-	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/legacy"
 	ecosystemslogger "github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/logger"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/orchestrator"
 	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/python/uv"
 )
 
@@ -51,7 +51,7 @@ func handleSBOMResolution(
 		logger,
 		[]ecosystems.SCAPlugin{
 			uv.NewPlugin(uv.NewClient(), converter, remoteRepoURL),
-			legacy.NewPlugin(ctx),
+			orchestrator.NewPlugin(ctx),
 		},
 	)
 }

--- a/pkg/ecosystems/orchestrator/plugin.go
+++ b/pkg/ecosystems/orchestrator/plugin.go
@@ -1,0 +1,128 @@
+package orchestrator
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/snyk/go-application-framework/pkg/configuration"
+	"github.com/snyk/go-application-framework/pkg/workflow"
+
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/logger"
+)
+
+const PluginName = "orchestrator"
+
+// depgraphResolver is the subset of PluginRegistry the adapter depends on, so the
+// channel->callback bridge can be unit-tested with a fake resolver instead of the
+// real sub-plugins.
+type depgraphResolver interface {
+	ResolveDepgraphs(dir string, opts *ecosystems.SCAPluginOptions) <-chan ecosystems.SCAResult
+}
+
+// Plugin adapts the channel-based PluginRegistry to the callback-based
+// SCAPlugin interface, so the orchestrator (bazel, bun, pnpm, gradle, cargo and
+// the legacy CLI) can be dropped into a []SCAPlugin alongside other resolvers.
+type Plugin struct {
+	ictx workflow.InvocationContext
+	// Overridable in tests; defaults to NewDefaultPluginRegistry.
+	newRegistry func(workflow.InvocationContext) (depgraphResolver, error)
+}
+
+var _ ecosystems.SCAPlugin = (*Plugin)(nil)
+
+// NewPlugin returns an orchestrator-wrapping SCAPlugin. It is a drop-in for
+// legacy.NewPlugin(ictx): with every resolver feature flag off the orchestrator
+// runs only the legacy plugin, so behavior is preserved.
+func NewPlugin(ictx workflow.InvocationContext) *Plugin {
+	return &Plugin{
+		ictx: ictx,
+		newRegistry: func(ictx workflow.InvocationContext) (depgraphResolver, error) {
+			return NewDefaultPluginRegistry(ictx)
+		},
+	}
+}
+
+func (p *Plugin) GetName() string {
+	return PluginName
+}
+
+// BuildDepGraphsFromDir builds the registry, drains its results channel and
+// forwards each SCAResult to onGraph.
+//
+// The log argument is ignored: the orchestrator and its sub-plugins log via
+// ictx.GetEnhancedLogger() internally.
+//
+// Contract: a non-nil onGraph return aborts the run. ResolveDepgraphs runs its
+// work in a goroutine whose sends are guarded by a select on ctx.Done() over an
+// unbuffered channel, so canceling the context is what unblocks it. We derive a
+// cancellable child from the ctx argument (the authoritative cancellation signal)
+// and feed it to the registry via cancelableICtx; the deferred cancel fires on
+// both abort and normal completion, guaranteeing the goroutine unwinds without a
+// manual drain loop.
+func (p *Plugin) BuildDepGraphsFromDir(
+	ctx context.Context,
+	_ logger.Logger,
+	dir string,
+	opts *ecosystems.SCAPluginOptions,
+	onGraph ecosystems.OnGraphFunc,
+) error {
+	if opts == nil {
+		return fmt.Errorf("cannot resolve dependencies without options")
+	}
+
+	childCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	orchOpts, err := p.buildOrchestratorOptions(opts)
+	if err != nil {
+		return err
+	}
+
+	registry, err := p.newRegistry(cancelableICtx{InvocationContext: p.ictx, ctx: childCtx})
+	if err != nil {
+		return fmt.Errorf("failed to create plugin registry: %w", err)
+	}
+
+	for result := range registry.ResolveDepgraphs(dir, orchOpts) {
+		if err := onGraph(result); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// buildOrchestratorOptions builds the options the orchestrator's sub-plugins
+// expect, mirroring how cli-extension-os-flows constructs them: from the raw CLI
+// args, which populate the ecosystem-specific sub-options (Bazel, Python, Gradle)
+// and Global.RawFlags. The shared buildPluginOptions in the SBOM flow does not
+// set those.
+//
+// The batch-critical fields are carried over from the incoming options so the
+// SBOM flow's cross-plugin propagation still works: ExcludePaths carries the
+// files earlier plugins (e.g. uv) already processed, and AllProjects drives
+// fan-out.
+func (p *Plugin) buildOrchestratorOptions(in *ecosystems.SCAPluginOptions) (*ecosystems.SCAPluginOptions, error) {
+	cfg := p.ictx.GetConfiguration()
+	out, err := ecosystems.NewPluginOptionsFromRawFlags(cfg.GetStringSlice(configuration.RAW_CMD_ARGS))
+	if err != nil {
+		return nil, fmt.Errorf("failed to build orchestrator options: %w", err)
+	}
+
+	out.Global.ExcludePaths = in.Global.ExcludePaths
+	out.Global.AllProjects = in.Global.AllProjects
+
+	return out, nil
+}
+
+// cancelableICtx wraps an InvocationContext so Context() returns a caller-supplied
+// (cancellable) context. All other methods delegate to the embedded interface.
+// This lets the adapter hand the registry a context it can cancel without
+// changing ResolveDepgraphs's public signature.
+type cancelableICtx struct {
+	workflow.InvocationContext
+	//nolint:containedctx // intentional: this wrapper exists solely to override Context() with a cancellable child.
+	ctx context.Context
+}
+
+func (c cancelableICtx) Context() context.Context { return c.ctx }

--- a/pkg/ecosystems/orchestrator/plugin_test.go
+++ b/pkg/ecosystems/orchestrator/plugin_test.go
@@ -1,0 +1,153 @@
+package orchestrator
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/snyk/go-application-framework/pkg/workflow"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems"
+)
+
+// fakeResolver mimics PluginRegistry.ResolveDepgraphs: it emits results on an
+// unbuffered channel from a goroutine whose sends are guarded by ctx.Done(), so
+// canceling the context is what unblocks a parked send. It records the context
+// the adapter handed it, letting tests assert cancellation propagated.
+type fakeResolver struct {
+	results []ecosystems.SCAResult
+	//nolint:containedctx // intentional: captures the context the adapter passes via the registry, to assert cancellation.
+	ctx  context.Context
+	done chan struct{}
+}
+
+func (f *fakeResolver) ResolveDepgraphs(_ string, _ *ecosystems.SCAPluginOptions) <-chan ecosystems.SCAResult {
+	ch := make(chan ecosystems.SCAResult)
+	go func() {
+		defer close(ch)
+		defer close(f.done)
+		for _, r := range f.results {
+			select {
+			case ch <- r:
+			case <-f.ctx.Done():
+				return
+			}
+		}
+	}()
+	return ch
+}
+
+func newTestPlugin(t *testing.T, resolver depgraphResolver, registryErr error) *Plugin {
+	t.Helper()
+	return &Plugin{
+		ictx: setupMockInvocationContext(t),
+		newRegistry: func(ictx workflow.InvocationContext) (depgraphResolver, error) {
+			if registryErr != nil {
+				return nil, registryErr
+			}
+			if fr, ok := resolver.(*fakeResolver); ok {
+				fr.ctx = ictx.Context()
+			}
+			return resolver, nil
+		},
+	}
+}
+
+func result(targetFile string) ecosystems.SCAResult {
+	return ecosystems.SCAResult{
+		ResolverMetadata: &ecosystems.ResolverMetadata{NormalisedTargetFile: targetFile},
+	}
+}
+
+func TestPlugin_GetName(t *testing.T) {
+	assert.Equal(t, "orchestrator", NewPlugin(nil).GetName())
+}
+
+func TestPlugin_BuildDepGraphsFromDir_ForwardsAllResults(t *testing.T) {
+	fake := &fakeResolver{
+		results: []ecosystems.SCAResult{result("a"), result("b"), result("c")},
+		done:    make(chan struct{}),
+	}
+	p := newTestPlugin(t, fake, nil)
+
+	var got []string
+	err := p.BuildDepGraphsFromDir(context.Background(), nil, "/dir", ecosystems.NewPluginOptions(), func(r ecosystems.SCAResult) error {
+		got = append(got, r.ResolverMetadata.NormalisedTargetFile)
+		return nil
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"a", "b", "c"}, got)
+}
+
+// TestPlugin_BuildDepGraphsFromDir_AbortCancelsResolver proves the SCAPlugin
+// contract: a non-nil onGraph return aborts the run AND the resolver's context is
+// canceled so its goroutine unwinds (no leak), without a manual drain loop.
+func TestPlugin_BuildDepGraphsFromDir_AbortCancelsResolver(t *testing.T) {
+	fake := &fakeResolver{
+		results: []ecosystems.SCAResult{result("a"), result("b"), result("c")},
+		done:    make(chan struct{}),
+	}
+	p := newTestPlugin(t, fake, nil)
+
+	abortErr := errors.New("stop now")
+	calls := 0
+	err := p.BuildDepGraphsFromDir(context.Background(), nil, "/dir", ecosystems.NewPluginOptions(), func(_ ecosystems.SCAResult) error {
+		calls++
+		return abortErr
+	})
+
+	require.ErrorIs(t, err, abortErr)
+	assert.Equal(t, 1, calls, "onGraph should not be called again after it aborts")
+
+	select {
+	case <-fake.done:
+		// resolver goroutine unwound via ctx cancellation — no leak.
+	case <-time.After(2 * time.Second):
+		t.Fatal("resolver goroutine leaked: not canceled after onGraph aborted")
+	}
+}
+
+func TestPlugin_BuildDepGraphsFromDir_RegistryError(t *testing.T) {
+	p := newTestPlugin(t, nil, errors.New("boom"))
+
+	err := p.BuildDepGraphsFromDir(context.Background(), nil, "/dir", ecosystems.NewPluginOptions(), func(ecosystems.SCAResult) error {
+		t.Fatal("onGraph must not be called when registry construction fails")
+		return nil
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create plugin registry")
+	assert.Contains(t, err.Error(), "boom")
+}
+
+func TestPlugin_BuildDepGraphsFromDir_NilOptions(t *testing.T) {
+	p := newTestPlugin(t, &fakeResolver{done: make(chan struct{})}, nil)
+
+	err := p.BuildDepGraphsFromDir(context.Background(), nil, "/dir", nil, func(ecosystems.SCAResult) error {
+		return nil
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "without options")
+}
+
+// TestPlugin_buildOrchestratorOptions_CarriesBatchFields locks in that the batch
+// fields the SBOM flow relies on (ExcludePaths from earlier plugins, AllProjects)
+// survive onto the os-flows-style options built from raw flags.
+func TestPlugin_buildOrchestratorOptions_CarriesBatchFields(t *testing.T) {
+	p := &Plugin{ictx: setupMockInvocationContext(t)}
+
+	in := ecosystems.NewPluginOptions()
+	in.Global.AllProjects = true
+	in.Global.ExcludePaths = ecosystems.CommaSeparatedString{"uv/uv.lock", "uv/sub/uv.lock"}
+
+	out, err := p.buildOrchestratorOptions(in)
+
+	require.NoError(t, err)
+	assert.True(t, out.Global.AllProjects)
+	assert.Equal(t, ecosystems.CommaSeparatedString{"uv/uv.lock", "uv/sub/uv.lock"}, out.Global.ExcludePaths)
+}


### PR DESCRIPTION
## Overview

Adds an orchestrator-wrapping `SCAPlugin` (`pkg/ecosystems/orchestrator/plugin.go`) and drops it into the SBOM resolution flow in place of `legacy.NewPlugin(ctx)`. The adapter wraps the existing `PluginRegistry`, bridging its channel-based `ResolveDepgraphs` to the callback-based `SCAPlugin.BuildDepGraphsFromDir` interface, so the full set of ecosystem resolvers (bazel, bun, pnpm, gradle, cargo) plus the legacy CLI now run from the SBOM flow alongside the existing `uv` plugin.

## Why a stop-gap

This is deliberately a stop-gap. The end state is for `uv` to migrate fully into the ecosystems orchestrator, after which the SBOM flow runs a single orchestrator entry. Until then, `uv` stays as its own plugin and the orchestrator runs after it:

```go
[]ecosystems.SCAPlugin{
    uv.NewPlugin(uv.NewClient(), converter, remoteRepoURL),
    orchestrator.NewPlugin(ctx),
}
```

This lets the new ecosystems land in the SBOM flow now, without blocking on the uv migration.

## How it reuses the os-flows orchestration

The adapter instantiates the registry exactly like `cli-extension-os-flows` does (`resolveViaOrchestrator` → `NewDefaultPluginRegistry`), and mirrors its option construction: orchestrator options are built from the raw CLI args via `ecosystems.NewPluginOptionsFromRawFlags(RAW_CMD_ARGS)`, so the underlying resolvers receive the same flags (including ecosystem-specific options like Bazel/Python/Gradle) they get under os-flows. The batch-critical fields (`ExcludePaths`, `AllProjects`) are carried over from the incoming SBOM options so cross-plugin exclusion (e.g. files already processed by `uv`) still propagates.

Each underlying ecosystem stays gated behind its existing feature flag (`FlagBazelResolver`, `FlagBunResolver`, `FlagPnpmResolver`, `FlagNewGradleResolver`, `FlagCargoResolver`). With all flags off the orchestrator runs only the legacy plugin, so this is behaviour-preserving by default; ecosystems are toggled on individually.

## Notes

- The channel→callback bridge honours the `SCAPlugin` contract: a non-nil `onGraph` return aborts the run by cancelling a child context, unwinding the orchestrator goroutine with no leak (covered by a `-race` test).
- Build, `-race` tests, and lint are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
