### PR TITLE
fix(pnpm): only skip Rush subspaces when subspacesEnabled is true

### DIFF
--- a/pkg/ecosystems/javascript/pnpm/plugin_integration_test.go
+++ b/pkg/ecosystems/javascript/pnpm/plugin_integration_test.go
@@ -102,6 +102,24 @@ func TestRushPnpm_NonPnpmAndSubspacesAreSkipped(t *testing.T) {
 	}
 }
 
+// A subspaces.json that exists but has subspacesEnabled:false is NOT a
+// subspaces repo — the monorepo-level lockfile is authoritative, so it must be
+// scanned exactly like the baseline workspace. Regression guard for the
+// file-exists-vs-field-value fix in rushSubspacesEnabled.
+func TestRushPnpm_SubspacesDisabledIsScanned(t *testing.T) {
+	requirePnpm(t)
+	results := run(t, filepath.Join("testdata", "rush-subspaces-disabled"))
+
+	require.Len(t, results, 2)
+	names := map[string]bool{}
+	for _, r := range results {
+		require.NoError(t, r.Error)
+		names[r.ProjectDescriptor.Identity.RootComponentName] = true
+	}
+	assert.True(t, names["@rush-fix/app-a"] && names["@rush-fix/lib-b"],
+		"disabled-subspaces repo should resolve both projects, got %v", names)
+}
+
 func graphJSON(t *testing.T, r ecosystems.SCAResult) string {
 	t.Helper()
 	require.NotNil(t, r.DepGraph)

--- a/pkg/ecosystems/javascript/pnpm/rush.go
+++ b/pkg/ecosystems/javascript/pnpm/rush.go
@@ -2,6 +2,7 @@ package pnpm
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -30,10 +31,12 @@ const (
 // errRushNotPnpm is returned for an npm/yarn-backed Rush repo (pnpm-only scope).
 var errRushNotPnpm = errors.New("not a pnpm-backed Rush monorepo; only Rush + pnpm is supported")
 
-// errRushSubspaces is returned when subspaces are enabled (out of scope): the
+// errRushSubspaces is returned when subspaces are enabled (subspacesEnabled:
+// true in common/config/rush/subspaces.json) — out of scope: the
 // monorepo-level lockfile is forbidden, so scanning it would yield wrong
-// results. Skip rather than scan an incomplete lockfile.
-var errRushSubspaces = errors.New("rush subspaces are not yet supported (common/config/rush/subspaces.json present)")
+// results. Skip rather than scan an incomplete lockfile. A subspaces.json that
+// merely exists with the flag off is not subspaces; see rushSubspacesEnabled.
+var errRushSubspaces = errors.New("rush subspaces are not yet supported (subspacesEnabled: true in common/config/rush/subspaces.json)")
 
 // rush.json is JSONC (comments + trailing commas); test for fields rather than
 // JSON-parsing.
@@ -91,6 +94,23 @@ func rushTargets(ctx context.Context, log logger.Logger, rushDir string) ([]scan
 	}}, nil
 }
 
+// rushSubspacesEnabled reports whether the subspaces.json file at path exists
+// and contains "subspacesEnabled": true. If the file is absent, unreadable, or
+// does not contain the field, it returns false (the Rush default).
+func rushSubspacesEnabled(path string) bool {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	var cfg struct {
+		SubspacesEnabled bool `json:"subspacesEnabled"`
+	}
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return false
+	}
+	return cfg.SubspacesEnabled
+}
+
 // stripJSONComments removes JSONC block and full-line comments from rush.json.
 func stripJSONComments(data []byte) []byte {
 	data = rushBlockCommentRe.ReplaceAll(data, nil)
@@ -113,7 +133,7 @@ func rushProjectFolders(rushDir string) ([]string, error) {
 	if !rushPnpmVersionRe.Match(data) {
 		return nil, errRushNotPnpm //nolint:wrapcheck // sentinel matched with errors.Is by the caller
 	}
-	if fileExists(filepath.Join(rushDir, filepath.FromSlash(rushSubspacesConfig))) {
+	if rushSubspacesEnabled(filepath.Join(rushDir, filepath.FromSlash(rushSubspacesConfig))) {
 		return nil, errRushSubspaces //nolint:wrapcheck // sentinel matched with errors.Is by the caller
 	}
 

--- a/pkg/ecosystems/javascript/pnpm/rush_test.go
+++ b/pkg/ecosystems/javascript/pnpm/rush_test.go
@@ -1,8 +1,15 @@
 package pnpm
 
 import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
+
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/logger"
 )
 
 func TestStripJSONComments(t *testing.T) {
@@ -51,4 +58,361 @@ func TestStripJSONComments(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestRushSubspacesEnabled covers the field-aware subspaces detection that
+// replaced the old "file exists" check. Only a literal "subspacesEnabled": true
+// should report enabled; everything else (absent file, false, missing field,
+// malformed JSON) is the Rush default of disabled.
+func TestRushSubspacesEnabled(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string // "" means: do not create the file at all
+		write   bool
+		want    bool
+	}{
+		{name: "file absent", write: false, want: false},
+		{name: "enabled true", write: true, content: `{"subspacesEnabled": true, "subspaceNames": ["default"]}`, want: true},
+		{name: "enabled false", write: true, content: `{"subspacesEnabled": false, "subspaceNames": []}`, want: false},
+		{name: "field missing", write: true, content: `{"subspaceNames": ["default"]}`, want: false},
+		{name: "empty object", write: true, content: `{}`, want: false},
+		{name: "malformed json", write: true, content: `{ this is not json`, want: false},
+		{name: "enabled true among other fields", write: true, content: `{"$schema":"x","subspaceNames":[],"subspacesEnabled":true}`, want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "subspaces.json")
+			if tt.write {
+				if err := os.WriteFile(path, []byte(tt.content), 0o600); err != nil {
+					t.Fatalf("writing fixture: %v", err)
+				}
+			}
+			if got := rushSubspacesEnabled(path); got != tt.want {
+				t.Errorf("rushSubspacesEnabled() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// writeRushRepo stages a minimal Rush repo under a fresh temp dir and returns
+// its root. files maps repo-relative slash paths to contents; parent dirs are
+// created as needed.
+func writeRushRepo(t *testing.T, files map[string]string) string {
+	t.Helper()
+	root := t.TempDir()
+	for rel, content := range files {
+		full := filepath.Join(root, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(full), 0o750); err != nil {
+			t.Fatalf("mkdir for %s: %v", rel, err)
+		}
+		if err := os.WriteFile(full, []byte(content), 0o600); err != nil {
+			t.Fatalf("writing %s: %v", rel, err)
+		}
+	}
+	return root
+}
+
+const rushJSONPnpm = `{
+  "pnpmVersion": "8.15.8",
+  "projects": [
+    { "packageName": "@x/app-a", "projectFolder": "apps/app-a" },
+    { "packageName": "@x/lib-b", "projectFolder": "libs/lib-b" }
+  ]
+}`
+
+func TestRushProjectFolders(t *testing.T) {
+	t.Run("pnpm-backed returns project folders", func(t *testing.T) {
+		root := writeRushRepo(t, map[string]string{rushJSONFile: rushJSONPnpm})
+
+		folders, err := rushProjectFolders(root)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		sort.Strings(folders)
+		want := []string{"apps/app-a", "libs/lib-b"}
+		if len(folders) != len(want) || folders[0] != want[0] || folders[1] != want[1] {
+			t.Errorf("folders = %v, want %v", folders, want)
+		}
+	})
+
+	t.Run("npm-backed is errRushNotPnpm", func(t *testing.T) {
+		root := writeRushRepo(t, map[string]string{
+			rushJSONFile: `{ "npmVersion": "9.0.0", "projects": [{ "projectFolder": "apps/a" }] }`,
+		})
+		_, err := rushProjectFolders(root)
+		if !errors.Is(err, errRushNotPnpm) {
+			t.Errorf("err = %v, want errRushNotPnpm", err)
+		}
+	})
+
+	t.Run("commented-out pnpmVersion does not satisfy the pnpm gate", func(t *testing.T) {
+		root := writeRushRepo(t, map[string]string{
+			rushJSONFile: `{ /* "pnpmVersion": "7.0.0", */ "npmVersion": "9.0.0" }`,
+		})
+		_, err := rushProjectFolders(root)
+		if !errors.Is(err, errRushNotPnpm) {
+			t.Errorf("err = %v, want errRushNotPnpm (commented pnpmVersion must not count)", err)
+		}
+	})
+
+	t.Run("subspaces enabled is errRushSubspaces", func(t *testing.T) {
+		root := writeRushRepo(t, map[string]string{
+			rushJSONFile:        rushJSONPnpm,
+			rushSubspacesConfig: `{"subspacesEnabled": true}`,
+		})
+		_, err := rushProjectFolders(root)
+		if !errors.Is(err, errRushSubspaces) {
+			t.Errorf("err = %v, want errRushSubspaces", err)
+		}
+	})
+
+	// Regression for the customer fix: a subspaces.json that exists but has
+	// subspacesEnabled:false must NOT skip the repo — the monorepo lockfile is
+	// still authoritative, so the projects resolve normally.
+	t.Run("subspaces present but disabled is scanned", func(t *testing.T) {
+		root := writeRushRepo(t, map[string]string{
+			rushJSONFile:        rushJSONPnpm,
+			rushSubspacesConfig: `{"subspacesEnabled": false, "subspaceNames": []}`,
+		})
+		folders, err := rushProjectFolders(root)
+		if err != nil {
+			t.Fatalf("disabled subspaces must not error, got: %v", err)
+		}
+		if len(folders) != 2 {
+			t.Errorf("want 2 project folders, got %v", folders)
+		}
+	})
+
+	t.Run("missing rush.json errors", func(t *testing.T) {
+		_, err := rushProjectFolders(t.TempDir())
+		if err == nil {
+			t.Error("expected an error reading a missing rush.json")
+		}
+		if errors.Is(err, errRushNotPnpm) || errors.Is(err, errRushSubspaces) {
+			t.Errorf("a read failure must not masquerade as a skip sentinel: %v", err)
+		}
+	})
+}
+
+func TestIsRushRoot(t *testing.T) {
+	withRush := writeRushRepo(t, map[string]string{rushJSONFile: `{}`})
+	if !isRushRoot(withRush) {
+		t.Error("dir containing rush.json should be a Rush root")
+	}
+	if isRushRoot(t.TempDir()) {
+		t.Error("dir without rush.json should not be a Rush root")
+	}
+}
+
+func TestWorkspaceYAML(t *testing.T) {
+	got := string(workspaceYAML([]string{"apps/app-a", "libs/lib-b"}))
+	want := "packages:\n  - ../../apps/app-a\n  - ../../libs/lib-b\n"
+	if got != want {
+		t.Errorf("workspaceYAML mismatch:\n got: %q\nwant: %q", got, want)
+	}
+}
+
+// stageRushFiles is the set of files a stageRushWorkspace happy path needs: a
+// monorepo lockfile plus one package.json per project folder.
+func stageRushFiles() map[string]string {
+	return map[string]string{
+		rushJSONFile:                    rushJSONPnpm,
+		rushLockfilePath:                "lockfileVersion: '6.0'\n",
+		"apps/app-a/" + packageJSONFile: `{"name":"@x/app-a","version":"1.0.0"}`,
+		"libs/lib-b/" + packageJSONFile: `{"name":"@x/lib-b","version":"1.0.0"}`,
+	}
+}
+
+func TestStageRushWorkspace_HappyPath(t *testing.T) {
+	root := writeRushRepo(t, stageRushFiles())
+
+	runDir, scanRoot, skipped, cleanup, err := stageRushWorkspace(root, []string{"apps/app-a", "libs/lib-b"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	t.Cleanup(cleanup)
+
+	if len(skipped) != 0 {
+		t.Errorf("no projects should be skipped, got %v", skipped)
+	}
+
+	// runDir is <tmp>/common/temp and holds the lockfile, synthesized
+	// workspace manifest, and the aggregate "." importer package.json.
+	if filepath.Base(filepath.Dir(runDir)) != "common" || filepath.Base(runDir) != "temp" {
+		t.Errorf("runDir should be common/temp, got %q", runDir)
+	}
+	for _, name := range []string{pnpmLockFile, "pnpm-workspace.yaml", packageJSONFile} {
+		if !fileExists(filepath.Join(runDir, name)) {
+			t.Errorf("expected staged file %q under runDir", name)
+		}
+	}
+
+	// Each project's package.json is mirrored under scanRoot at its original
+	// relative path so the ../../ importer paths resolve.
+	for _, pf := range []string{"apps/app-a", "libs/lib-b"} {
+		if !fileExists(filepath.Join(scanRoot, filepath.FromSlash(pf), packageJSONFile)) {
+			t.Errorf("expected mirrored package.json for %q under scanRoot", pf)
+		}
+	}
+
+	// The synthesized workspace manifest lists every staged project.
+	ws, readErr := os.ReadFile(filepath.Join(runDir, "pnpm-workspace.yaml"))
+	if readErr != nil {
+		t.Fatalf("reading staged pnpm-workspace.yaml: %v", readErr)
+	}
+	for _, want := range []string{"../../apps/app-a", "../../libs/lib-b"} {
+		if !strings.Contains(string(ws), want) {
+			t.Errorf("pnpm-workspace.yaml missing %q;\n%s", want, ws)
+		}
+	}
+
+	// cleanup tears the whole tmp tree down.
+	cleanup()
+	if _, statErr := os.Stat(scanRoot); !os.IsNotExist(statErr) {
+		t.Errorf("cleanup should remove the staging tree, stat err = %v", statErr)
+	}
+}
+
+func TestStageRushWorkspace_MissingProjectSkippedNotFatal(t *testing.T) {
+	root := writeRushRepo(t, stageRushFiles())
+
+	_, _, skipped, cleanup, err := stageRushWorkspace(root, []string{"apps/app-a", "libs/lib-b", "apps/ghost"})
+	if err != nil {
+		t.Fatalf("a stale project folder must not be fatal, got: %v", err)
+	}
+	t.Cleanup(cleanup)
+
+	if len(skipped) != 1 || skipped[0] != "apps/ghost" {
+		t.Errorf("skipped = %v, want [apps/ghost]", skipped)
+	}
+}
+
+// stageErr runs stageRushWorkspace for the failure-path tests, which only care
+// about the returned error (a failed stage returns a nil cleanup).
+func stageErr(root string, folders []string) error {
+	_, _, _, _, err := stageRushWorkspace(root, folders) //nolint:dogsled // error-path tests want only err
+	return err
+}
+
+func TestStageRushWorkspace_ZeroReadableProjectsIsError(t *testing.T) {
+	root := writeRushRepo(t, map[string]string{
+		rushJSONFile:     rushJSONPnpm,
+		rushLockfilePath: "lockfileVersion: '6.0'\n",
+	})
+	if err := stageErr(root, []string{"apps/app-a"}); err == nil {
+		t.Error("a workspace with no readable package.json should error")
+	}
+}
+
+func TestStageRushWorkspace_MissingLockfileIsError(t *testing.T) {
+	root := writeRushRepo(t, map[string]string{
+		rushJSONFile:                    rushJSONPnpm,
+		"apps/app-a/" + packageJSONFile: `{"name":"@x/app-a","version":"1.0.0"}`,
+	})
+	if err := stageErr(root, []string{"apps/app-a"}); err == nil {
+		t.Error("a missing Rush lockfile should error")
+	}
+}
+
+func TestRushTargets_HappyPath(t *testing.T) {
+	root := writeRushRepo(t, stageRushFiles())
+
+	targets, err := rushTargets(context.Background(), logger.Nop(), root)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(targets) != 1 {
+		t.Fatalf("want 1 target, got %d", len(targets))
+	}
+	tgt := targets[0]
+	t.Cleanup(tgt.cleanup)
+
+	if tgt.setupErr != nil {
+		t.Errorf("happy path target should carry no setupErr, got %v", tgt.setupErr)
+	}
+	if tgt.cmdDir == "" || tgt.manifestBaseDir == "" {
+		t.Errorf("target should have cmdDir and manifestBaseDir set, got %+v", tgt)
+	}
+	// excludeDir drops the synthetic rush-common aggregate importer.
+	if tgt.excludeDir != tgt.cmdDir {
+		t.Errorf("excludeDir should equal the common/temp runDir, got %q vs %q", tgt.excludeDir, tgt.cmdDir)
+	}
+	if !contains(tgt.processedFiles, rushJSONFile) {
+		t.Errorf("processedFiles should include rush.json, got %v", tgt.processedFiles)
+	}
+}
+
+func TestRushTargets_NonPnpmSkipped(t *testing.T) {
+	root := writeRushRepo(t, map[string]string{
+		rushJSONFile: `{ "npmVersion": "9.0.0", "projects": [] }`,
+	})
+	targets, err := rushTargets(context.Background(), logger.Nop(), root)
+	if err != nil {
+		t.Fatalf("skip should not error, got %v", err)
+	}
+	if targets != nil {
+		t.Errorf("non-pnpm Rush repo should be skipped, got %d targets", len(targets))
+	}
+}
+
+func TestRushTargets_SubspacesEnabledSkipped(t *testing.T) {
+	files := stageRushFiles()
+	files[rushSubspacesConfig] = `{"subspacesEnabled": true}`
+	root := writeRushRepo(t, files)
+
+	targets, err := rushTargets(context.Background(), logger.Nop(), root)
+	if err != nil {
+		t.Fatalf("skip should not error, got %v", err)
+	}
+	if targets != nil {
+		t.Errorf("subspaces-enabled repo should be skipped, got %d targets", len(targets))
+	}
+}
+
+// Regression for the customer fix at the adapter boundary: a disabled
+// subspaces.json must produce a real, runnable target instead of a skip.
+func TestRushTargets_SubspacesDisabledStaged(t *testing.T) {
+	files := stageRushFiles()
+	files[rushSubspacesConfig] = `{"subspacesEnabled": false}`
+	root := writeRushRepo(t, files)
+
+	targets, err := rushTargets(context.Background(), logger.Nop(), root)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(targets) != 1 {
+		t.Fatalf("disabled subspaces must be scanned; want 1 target, got %d", len(targets))
+	}
+	t.Cleanup(targets[0].cleanup)
+	if targets[0].setupErr != nil {
+		t.Errorf("target should be runnable, got setupErr %v", targets[0].setupErr)
+	}
+}
+
+func TestRushTargets_UnreadableRushJSONSurfacesErrTarget(t *testing.T) {
+	// rush.json is a directory, so os.ReadFile fails — neither sentinel
+	// matches, so rushTargets must surface a single error target rather than
+	// silently skipping.
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, rushJSONFile), 0o750); err != nil {
+		t.Fatalf("staging unreadable rush.json: %v", err)
+	}
+	targets, err := rushTargets(context.Background(), logger.Nop(), root)
+	if err != nil {
+		t.Fatalf("rushTargets should return the error as a target, not fail: %v", err)
+	}
+	if len(targets) != 1 || targets[0].setupErr == nil {
+		t.Fatalf("want one target carrying a setupErr, got %+v", targets)
+	}
+	t.Cleanup(targets[0].cleanup)
+}
+
+func contains(xs []string, want string) bool {
+	for _, x := range xs {
+		if x == want {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/ecosystems/javascript/pnpm/testdata/rush-subspaces-disabled/README.md
+++ b/pkg/ecosystems/javascript/pnpm/testdata/rush-subspaces-disabled/README.md
@@ -1,0 +1,22 @@
+# rush-subspaces-disabled — subspaces.json present but turned off
+
+Same layout as `simple-vulnerable-workspace` (two projects sharing one committed
+lockfile at `common/config/rush/pnpm-lock.yaml`), but this repo *also* commits
+`common/config/rush/subspaces.json` with `"subspacesEnabled": false`.
+
+Rush ships a `subspaces.json` whenever the feature has ever been touched in
+config, and only honours it when `subspacesEnabled` is `true`. With the flag
+off, the monorepo-level lockfile is still the single source of truth, so the
+repo is fully scannable.
+
+- **Layout:** `apps/app-a` (`lodash@4.17.4` + `@rush-fix/lib-b` via
+  `workspace:*`) + `libs/lib-b` (`minimatch@3.0.0`).
+- **Expected:** scanned exactly like `simple-vulnerable-workspace` — one dep
+  graph per Rush project (`@rush-fix/app-a`, `@rush-fix/lib-b`) from the shared
+  lockfile.
+- **Regression guard:** the earlier file-exists check skipped this repo (false
+  `errRushSubspaces`). The fix parses `subspacesEnabled` and only skips when it
+  is genuinely `true`, so this fixture must produce results, not an empty scan.
+  Covered by `TestRushPnpm_SubspacesDisabledIsScanned`.
+
+To regenerate the lockfile: `rush update` (Rush 5.175.1, pnpm 8.15.8).

--- a/pkg/ecosystems/javascript/pnpm/testdata/rush-subspaces-disabled/apps/app-a/package.json
+++ b/pkg/ecosystems/javascript/pnpm/testdata/rush-subspaces-disabled/apps/app-a/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@rush-fix/app-a",
+  "version": "1.0.0",
+  "description": "App that depends on lib-b (workspace) and a vulnerable lodash.",
+  "dependencies": {
+    "lodash": "4.17.4",
+    "@rush-fix/lib-b": "workspace:*"
+  }
+}

--- a/pkg/ecosystems/javascript/pnpm/testdata/rush-subspaces-disabled/common/config/rush/.npmrc
+++ b/pkg/ecosystems/javascript/pnpm/testdata/rush-subspaces-disabled/common/config/rush/.npmrc
@@ -1,0 +1,2 @@
+# Registry config for Rush-managed pnpm install. Public registry for the fixture.
+registry=https://registry.npmjs.org/

--- a/pkg/ecosystems/javascript/pnpm/testdata/rush-subspaces-disabled/common/config/rush/pnpm-lock.yaml
+++ b/pkg/ecosystems/javascript/pnpm/testdata/rush-subspaces-disabled/common/config/rush/pnpm-lock.yaml
@@ -1,0 +1,52 @@
+lockfileVersion: '6.0'
+
+settings:
+  autoInstallPeers: false
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .: {}
+
+  ../../apps/app-a:
+    dependencies:
+      '@rush-fix/lib-b':
+        specifier: workspace:*
+        version: link:../../libs/lib-b
+      lodash:
+        specifier: 4.17.4
+        version: 4.17.4
+
+  ../../libs/lib-b:
+    dependencies:
+      minimatch:
+        specifier: 3.0.0
+        version: 3.0.0
+
+packages:
+
+  /balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+    dev: false
+
+  /brace-expansion@1.1.15:
+    resolution: {integrity: sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==}
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
+    dev: false
+
+  /concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+    dev: false
+
+  /lodash@4.17.4:
+    resolution: {integrity: sha512-6X37Sq9KCpLSXEh8uM12AKYlviHPNNk4RxiGBn4cmKGJinbXBneWIV7iE/nXkM928O7ytHcHb6+X6Svl0f4hXg==}
+    dev: false
+
+  /minimatch@3.0.0:
+    resolution: {integrity: sha512-ekKdP/98gMbw+JdQaHZlS5/irFw63ktA3FXHaal7TXkvdaUJ9M6BewwNyEujYzRsTirZGmEVDho+Gh8bfcpVxw==}
+    deprecated: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
+    dependencies:
+      brace-expansion: 1.1.15
+    dev: false

--- a/pkg/ecosystems/javascript/pnpm/testdata/rush-subspaces-disabled/common/config/rush/repo-state.json
+++ b/pkg/ecosystems/javascript/pnpm/testdata/rush-subspaces-disabled/common/config/rush/repo-state.json
@@ -1,0 +1,4 @@
+// DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
+{
+  "preferredVersionsHash": "bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f"
+}

--- a/pkg/ecosystems/javascript/pnpm/testdata/rush-subspaces-disabled/common/config/rush/subspaces.json
+++ b/pkg/ecosystems/javascript/pnpm/testdata/rush-subspaces-disabled/common/config/rush/subspaces.json
@@ -1,0 +1,4 @@
+{
+  "subspacesEnabled": false,
+  "subspaceNames": []
+}

--- a/pkg/ecosystems/javascript/pnpm/testdata/rush-subspaces-disabled/libs/lib-b/package.json
+++ b/pkg/ecosystems/javascript/pnpm/testdata/rush-subspaces-disabled/libs/lib-b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@rush-fix/lib-b",
+  "version": "1.0.0",
+  "description": "Library with a vulnerable minimatch, linked into app-a via workspace.",
+  "dependencies": {
+    "minimatch": "3.0.0"
+  }
+}

--- a/pkg/ecosystems/javascript/pnpm/testdata/rush-subspaces-disabled/rush.json
+++ b/pkg/ecosystems/javascript/pnpm/testdata/rush-subspaces-disabled/rush.json
@@ -1,0 +1,11 @@
+{
+  "rushVersion": "5.175.1",
+  "pnpmVersion": "8.15.8",
+  "pnpmOptions": {
+    "useWorkspaces": true
+  },
+  "projects": [
+    { "packageName": "@rush-fix/app-a", "projectFolder": "apps/app-a" },
+    { "packageName": "@rush-fix/lib-b", "projectFolder": "libs/lib-b" }
+  ]
+}


### PR DESCRIPTION
## What

Rush ships `common/config/rush/subspaces.json` whenever the subspaces feature has ever been touched in config, and only honours it when `"subspacesEnabled": true`. The previous gate skipped any Rush repo where that file *merely existed* — so a monorepo with subspaces turned **off** was silently dropped from scans, even though its monorepo-level `pnpm-lock.yaml` is authoritative and fully scannable.

This is the customer-reported case: a Rush + pnpm monorepo that committed a disabled `subspaces.json` got an empty scan instead of per-project dep graphs.

## Fix

`rushSubspacesEnabled()` now parses the file and skips only when `subspacesEnabled` is genuinely `true`. An absent file, `false`, a missing field, or malformed JSON all resolve to disabled (the Rush default).

## Tests

Brought the `rush.go` unit coverage up to the bar set by the other ecosystem resolvers (bun / cargo / gradle), which it was missing:

- `TestRushSubspacesEnabled` — field-aware detection (absent / true / false / missing field / malformed)
- `TestRushProjectFolders` — pnpm gate, JSONC comment stripping, subspaces gate, **disabled-subspaces regression**, read-failure ≠ skip
- `TestRushTargets_*` — adapter skip / stage / error-target paths, incl. disabled-subspaces staged
- `TestStageRushWorkspace_*` — happy path, stale-project skip, zero-projects + missing-lockfile errors
- `TestIsRushRoot`, `TestWorkspaceYAML`
- `TestRushPnpm_SubspacesDisabledIsScanned` (integration) + new `testdata/rush-subspaces-disabled/` fixture proving the fix end-to-end against real pnpm

All green; `golangci-lint` clean on the package; verified end-to-end with pnpm 10.33.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)