### PR TITLE
chore: exclude testdata from sec scanning

### DIFF
--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -280,6 +280,7 @@ jobs:
       - prodsec/security_scans:
           mode: auto
           iac-scan: disabled
+          open-source-additional-arguments: --exclude=testdata
 
   determine-version:
     <<: *go_image


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

We are security scanning `testdata` and should exclude it (it contains old deps with vulns which are not part of the distributable).
