### PR TITLE
feat: [CMPA-604] Adds support for passing `--include-component-metadata` flag to legacy cli

### DIFF
--- a/internal/legacycli/legacy_resolution.go
+++ b/internal/legacycli/legacy_resolution.go
@@ -274,6 +274,11 @@ func PrepareLegacyFlags(argument string, cfg configuration.Configuration, logger
 		logger.Print("Include provenance: true")
 	}
 
+	if cfg.GetBool(workflow.FlagIncludeComponentMetadata) {
+		cmdArgs = append(cmdArgs, "--include-component-metadata")
+		logger.Print("Include component metadata: true")
+	}
+
 	if cfg.IsSet(workflow.FlagDotnetRuntimeResolution) {
 		dotnetRuntimeResolution := cfg.GetBool(workflow.FlagDotnetRuntimeResolution)
 		cmdArgs = append(cmdArgs, fmt.Sprintf("--dotnet-runtime-resolution=%t", dotnetRuntimeResolution))

--- a/internal/legacycli/legacy_resolution_test.go
+++ b/internal/legacycli/legacy_resolution_test.go
@@ -199,6 +199,11 @@ func Test_LegacyResolution(t *testing.T) {
 			value:    "net9.3",
 			expected: "--dotnet-target-framework=net9.3",
 		},
+		{
+			key:      workflow.FlagIncludeComponentMetadata,
+			value:    true,
+			expected: "--include-component-metadata",
+		},
 	}
 
 	for _, tc := range options {

--- a/internal/workflow/flags.go
+++ b/internal/workflow/flags.go
@@ -30,6 +30,7 @@ const (
 	FlagNugetPkgsFolder               = "packages-folder"
 	FlagUnmanagedMaxDepth             = "max-depth"
 	FlagIncludeProvenance             = "include-provenance"
+	FlagIncludeComponentMetadata      = "include-component-metadata"
 	FlagUseSBOMResolution             = "use-sbom-resolution"
 	FlagPrintEffectiveGraph           = "effective-graph"
 	FlagPrintEffectiveGraphWithErrors = "effective-graph-with-errors"

--- a/pkg/depgraph/flags.go
+++ b/pkg/depgraph/flags.go
@@ -41,6 +41,7 @@ func getFlagSet() *pflag.FlagSet {
 	flagSet.String(workflow.FlagNugetPkgsFolder, "", "Specify a custom path to the packages folder when using NuGet.")
 	flagSet.Int(workflow.FlagUnmanagedMaxDepth, 0, "Specify the maximum level of archive extraction for unmanaged scanning.")
 	flagSet.Bool(workflow.FlagIncludeProvenance, false, "Include checksums in purl to support package provenance.")
+	flagSet.Bool(workflow.FlagIncludeComponentMetadata, false, "Include component metadata (e.g. hashes, distribution URLs) as node labels.")
 	flagSet.String(workflow.FlagExcludePaths, "", "Comma-separated paths to exclude from scanning.")
 	flagSet.Bool(workflow.FlagUseSBOMResolution, false, "Use SBOM resolution instead of legacy CLI.")
 	flagSet.Bool(workflow.FlagPrintEffectiveGraph, false, "Return the pruned dependency graph.")


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [ ] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

This adds support for a new legacy CLI command flag `--include-component-metadata`, which will be passed down from `cli-extension-sbom`.

The flag causes the downstream dependency graph output to include hash and distribution url information as labels on the DepGraph, which can then be used to populate components[].hashes[] entries and provide a distribution entry for externalUrls in the CycloneDX format SBOM.

This is currently going to be implemented for the legacy mvn and npm plugin paths.
