### PR TITLE
fix: upgrade golang.org/x/crypto to v0.52.0 and Go to 1.26.4

### DIFF
--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -6,7 +6,7 @@ orbs:
 parameters:
   go_version:
     type: string
-    default: "1.26.3"
+    default: "1.26.4"
   android_version:
     type: string
     default: "2026.03"

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-golang 1.26.3
+golang 1.26.4

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/snyk/cli-extension-dep-graph/v2
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/BurntSushi/toml v1.6.0
@@ -96,7 +96,7 @@ require (
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/multierr v1.9.0 // indirect
-	golang.org/x/crypto v0.51.0 // indirect
+	golang.org/x/crypto v0.52.0 // indirect
 	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/oauth2 v0.27.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -239,8 +239,8 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
-golang.org/x/crypto v0.51.0 h1:IBPXwPfKxY7cWQZ38ZCIRPI50YLeevDLlLnyC5wRGTI=
-golang.org/x/crypto v0.51.0/go.mod h1:8AdwkbraGNABw2kOX6YFPs3WM22XqI4EXEd8g+x7Oc8=
+golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
+golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
 golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f h1:W3F4c+6OLc6H2lb//N1q4WpJkhzJCK5J6kUi1NTVXfM=
 golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f/go.mod h1:J1xhfL/vlindoeF/aINzNzt2Bket5bjo9sdOYzOsU80=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=


### PR DESCRIPTION
Addresses [UNIFY-1406](https://snyksec.atlassian.net/browse/UNIFY-1406).

Clears 8 high-severity CVEs reported by Snyk:

- `golang.org/x/crypto` v0.51.0 → v0.52.0
  - CVE-2026-46597, CVE-2026-39835, CVE-2026-39831, CVE-2026-39827 (`ssh`)
  - CVE-2026-46598 (`ssh/agent`)
  - CVE-2026-42508 (`ssh/knownhosts`)
- Go 1.26.3 → 1.26.4 (`go.mod`, `.tool-versions`, `.circleci/continue-config.yml`)
  - CVE-2026-27145 (`crypto/x509`)
  - CVE-2026-42504 (`mime`)

Verified with `snyk test --file=go.mod --severity-threshold=high` — no vulnerable paths found. `go build ./...` and `go test ./...` pass.

[UNIFY-1406]: https://snyksec.atlassian.net/browse/UNIFY-1406?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ