### PR TITLE
feat: add --include-component-metadata support to Gradle native resolver

### DIFF
--- a/internal/legacycli/legacy_resolution.go
+++ b/internal/legacycli/legacy_resolution.go
@@ -206,6 +206,11 @@ func PrepareLegacyFlags(argument string, cfg configuration.Configuration, logger
 		logger.Print("Normalize Gradle dependencies: true")
 	}
 
+	if cfg.GetBool(workflow.FlagGradleRefreshDependencies) {
+		cmdArgs = append(cmdArgs, "--gradle-refresh-dependencies")
+		logger.Print("Gradle refresh dependencies: true")
+	}
+
 	if cfg.GetBool(workflow.FlagAllSubProjects) {
 		cmdArgs = append(cmdArgs, "--all-sub-projects")
 		logger.Print("Test all sub-projects: true")

--- a/internal/legacycli/legacy_resolution_test.go
+++ b/internal/legacycli/legacy_resolution_test.go
@@ -204,6 +204,11 @@ func Test_LegacyResolution(t *testing.T) {
 			value:    true,
 			expected: "--include-component-metadata",
 		},
+		{
+			key:      workflow.FlagGradleRefreshDependencies,
+			value:    true,
+			expected: "--gradle-refresh-dependencies",
+		},
 	}
 
 	for _, tc := range options {

--- a/internal/workflow/flags.go
+++ b/internal/workflow/flags.go
@@ -17,6 +17,7 @@ const (
 	FlagSubProject                    = "sub-project"
 	FlagGradleSubProject              = "gradle-sub-project"
 	FlagGradleNormalizeDeps           = "gradle-normalize-deps"
+	FlagGradleRefreshDependencies     = "gradle-refresh-dependencies"
 	FlagAllSubProjects                = "all-sub-projects"
 	FlagConfigurationMatching         = "configuration-matching"
 	FlagConfigurationAttributes       = "configuration-attributes"

--- a/pkg/depgraph/flags.go
+++ b/pkg/depgraph/flags.go
@@ -27,6 +27,7 @@ func getFlagSet() *pflag.FlagSet {
 	flagSet.String(workflow.FlagSubProject, "", "Name of Gradle sub-project to test.")
 	flagSet.String(workflow.FlagGradleSubProject, "", "Name of Gradle sub-project to test.")
 	flagSet.Bool(workflow.FlagGradleNormalizeDeps, false, "Normalize Gradle dependencies.")
+	flagSet.Bool(workflow.FlagGradleRefreshDependencies, false, "Force Gradle to refresh dependencies so distribution URLs can be captured on a warm cache (used with --include-component-metadata; forces network access).")
 	flagSet.Bool(workflow.FlagAllSubProjects, false, "Test all sub-projects in a multi-project build.")
 	flagSet.String(workflow.FlagConfigurationMatching, "", "Resolve dependencies using only configuration(s) that match the specified Java regular expression.")
 	flagSet.String(workflow.FlagConfigurationAttributes, "", "Select certain values of configuration attributes to install and resolve dependencies.")

--- a/pkg/depgraph/flags.go
+++ b/pkg/depgraph/flags.go
@@ -27,7 +27,9 @@ func getFlagSet() *pflag.FlagSet {
 	flagSet.String(workflow.FlagSubProject, "", "Name of Gradle sub-project to test.")
 	flagSet.String(workflow.FlagGradleSubProject, "", "Name of Gradle sub-project to test.")
 	flagSet.Bool(workflow.FlagGradleNormalizeDeps, false, "Normalize Gradle dependencies.")
-	flagSet.Bool(workflow.FlagGradleRefreshDependencies, false, "Force Gradle to refresh dependencies so distribution URLs can be captured on a warm cache (used with --include-component-metadata; forces network access).")
+	flagSet.Bool(workflow.FlagGradleRefreshDependencies, false,
+		"Force Gradle to refresh dependencies so distribution URLs can be captured on a warm cache "+
+			"(used with --include-component-metadata; forces network access).")
 	flagSet.Bool(workflow.FlagAllSubProjects, false, "Test all sub-projects in a multi-project build.")
 	flagSet.String(workflow.FlagConfigurationMatching, "", "Resolve dependencies using only configuration(s) that match the specified Java regular expression.")
 	flagSet.String(workflow.FlagConfigurationAttributes, "", "Select certain values of configuration attributes to install and resolve dependencies.")

--- a/pkg/ecosystems/gradle/component_metadata_integration_test.go
+++ b/pkg/ecosystems/gradle/component_metadata_integration_test.go
@@ -1,0 +1,173 @@
+//go:build integration && gradle
+// +build integration,gradle
+
+package gradle
+
+import (
+	"context"
+	"encoding/hex"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/snyk/dep-graph/go/pkg/depgraph"
+
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/logger"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/scatest"
+)
+
+// componentMetadataHashLabels maps each digest label the init script must emit
+// for every resolved external artifact under --include-component-metadata to
+// its expected lowercase-hex length.
+var componentMetadataHashLabels = map[string]int{
+	"hash:md5":     32,  // 16 bytes
+	"hash:sha-1":   40,  // 20 bytes
+	"hash:sha-256": 64,  // 32 bytes
+	"hash:sha-512": 128, // 64 bytes
+}
+
+// TestPlugin_ComponentMetadataIntegration exercises --include-component-metadata
+// end-to-end against a real Gradle build. Hashes are deterministic (computed
+// from the resolved artifact files), so they are asserted strictly. The
+// distribution:url label depends on the resource-read listener firing during
+// this run — the feature degrades gracefully when Gradle's internal API is
+// unavailable or the cache is warm — so its presence is best-effort, but its
+// shape (no credentials/query/fragment) is asserted strictly whenever present.
+func TestPlugin_ComponentMetadataIntegration(t *testing.T) {
+	gradleVersion, err := gradleRuntime()
+	require.NoErrorf(t, err, "could not detect gradle runtime version")
+	jdkVersion, err := jdkRuntime()
+	require.NoErrorf(t, err, "could not detect jdk runtime version")
+	t.Logf("gradle %s / jdk %s", gradleVersion, jdkVersion)
+
+	fixtureDir := filepath.Join(fixturesRoot, "simple")
+	absFixture, err := filepath.Abs(fixtureDir)
+	require.NoError(t, err, "failed to resolve simple fixture path")
+
+	t.Run("hashes_and_clean_distribution_url_when_enabled", func(t *testing.T) {
+		// A cold Gradle cache guarantees the artifacts are downloaded during
+		// this run, so the resource-read listener fires and distribution:url is
+		// populated. cmd.Env is inherited by the gradle subprocess (executor.go
+		// leaves cmd.Env nil), so GRADLE_USER_HOME propagates.
+		t.Setenv("GRADLE_USER_HOME", t.TempDir())
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		defer cancel()
+
+		plugin := NewGradlePlugin()
+		results, err := scatest.Run(ctx, plugin, logger.Nop(), absFixture,
+			ecosystems.NewPluginOptions().
+				WithIncludeComponentMetadata(true).
+				WithGradleRefreshDependencies(true))
+		require.NoError(t, err, "BuildDepGraphsFromDir should not return error")
+		require.NotEmpty(t, results, "plugin must emit at least one result")
+
+		nodes := nodesWithComponentMetadata(results)
+		require.NotEmpty(t, nodes,
+			"expected at least one resolved external node to carry hash labels")
+
+		var sawDistributionURL bool
+		for _, n := range nodes {
+			for label, hexLen := range componentMetadataHashLabels {
+				val, ok := n.Info.Labels[label]
+				require.Truef(t, ok, "node %s is missing the %s label", n.NodeID, label)
+				assertLowercaseHex(t, n.NodeID, label, val, hexLen)
+			}
+			if durl, ok := n.Info.Labels["distribution:url"]; ok {
+				sawDistributionURL = true
+				assertCleanDistributionURL(t, n.NodeID, durl)
+			}
+		}
+
+		if !sawDistributionURL {
+			// Not a failure: distribution:url is best-effort and depends on the
+			// internal build-operation listener being available on this Gradle
+			// version. Surface it so a silent loss of coverage is visible.
+			t.Logf("no distribution:url labels were captured on gradle %s; "+
+				"hash coverage was still asserted", gradleVersion)
+		}
+	})
+
+	t.Run("no_component_metadata_labels_when_disabled", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		defer cancel()
+
+		plugin := NewGradlePlugin()
+		results, err := scatest.Run(ctx, plugin, logger.Nop(), absFixture,
+			ecosystems.NewPluginOptions())
+		require.NoError(t, err, "BuildDepGraphsFromDir should not return error")
+		require.NotEmpty(t, results, "plugin must emit at least one result")
+
+		for _, r := range results {
+			if r.DepGraph == nil {
+				continue
+			}
+			for _, n := range r.DepGraph.Graph.Nodes {
+				if n.Info == nil {
+					continue
+				}
+				for label := range n.Info.Labels {
+					assert.Falsef(t,
+						strings.HasPrefix(label, "hash:") || label == "distribution:url",
+						"node %s should not carry component-metadata label %q when the flag is off",
+						n.NodeID, label)
+				}
+			}
+		}
+	})
+}
+
+// nodesWithComponentMetadata returns the graph nodes that carry component
+// metadata, identified by the presence of a hash:sha-256 label (emitted only
+// for resolved external artifacts).
+func nodesWithComponentMetadata(results []ecosystems.SCAResult) []depgraph.Node {
+	var out []depgraph.Node
+	for _, r := range results {
+		if r.DepGraph == nil {
+			continue
+		}
+		for _, n := range r.DepGraph.Graph.Nodes {
+			if n.Info != nil {
+				if _, ok := n.Info.Labels["hash:sha-256"]; ok {
+					out = append(out, n)
+				}
+			}
+		}
+	}
+	return out
+}
+
+func assertLowercaseHex(t *testing.T, nodeID, label, val string, wantLen int) {
+	t.Helper()
+	assert.Lenf(t, val, wantLen, "node %s label %s: unexpected hex length", nodeID, label)
+	assert.Equalf(t, strings.ToLower(val), val,
+		"node %s label %s: expected lowercase hex, got %q", nodeID, label, val)
+	_, err := hex.DecodeString(val)
+	assert.NoErrorf(t, err, "node %s label %s: value %q is not valid hex", nodeID, label, val)
+}
+
+// assertCleanDistributionURL enforces the credential-safety contract: the label
+// must be an http(s) URL reduced to its canonical location, with no userinfo,
+// query string or fragment — the places URL-borne auth (SAS tokens, signed-URL
+// signatures, basic-auth credentials) would otherwise leak from.
+func assertCleanDistributionURL(t *testing.T, nodeID, durl string) {
+	t.Helper()
+	assert.Truef(t, strings.HasPrefix(durl, "https://") || strings.HasPrefix(durl, "http://"),
+		"node %s distribution:url should be an http(s) URL: %q", nodeID, durl)
+	assert.NotContainsf(t, durl, "?",
+		"node %s distribution:url must not carry a query string: %q", nodeID, durl)
+	assert.NotContainsf(t, durl, "#",
+		"node %s distribution:url must not carry a fragment: %q", nodeID, durl)
+	u, err := url.Parse(durl)
+	require.NoErrorf(t, err, "node %s distribution:url is not parseable: %q", nodeID, durl)
+	assert.Nilf(t, u.User,
+		"node %s distribution:url must not carry userinfo: %q", nodeID, durl)
+	assert.Emptyf(t, u.RawQuery,
+		"node %s distribution:url must not carry a query: %q", nodeID, durl)
+}

--- a/pkg/ecosystems/gradle/depgraph.go
+++ b/pkg/ecosystems/gradle/depgraph.go
@@ -43,6 +43,9 @@ func buildDepGraph(proj *gradleProject, options *ecosystems.SCAPluginOptions) (*
 	// Create a map of dependency ID to provenance information for quick lookups
 	provenanceMap := buildProvenanceMap(proj.Configurations, options)
 
+	// Map of dependency ID to component metadata (hashes + distribution URL).
+	componentMetadataMap := buildComponentMetadataMap(proj.Configurations, options)
+
 	// Create function to ensure each edge is added only once across configurations
 	connectOnce := createEdgeDeduplicator(builder)
 
@@ -58,9 +61,10 @@ func buildDepGraph(proj *gradleProject, options *ecosystems.SCAPluginOptions) (*
 
 	// Create context with shared state for dependency graph building
 	ctx := &depGraphContext{
-		builder:       builder,
-		connectOnce:   connectOnce,
-		provenanceMap: provenanceMap,
+		builder:              builder,
+		connectOnce:          connectOnce,
+		provenanceMap:        provenanceMap,
+		componentMetadataMap: componentMetadataMap,
 	}
 
 	// Merge all configurations into a single graph.
@@ -91,6 +95,10 @@ type depGraphContext struct {
 	builder       *depgraph.Builder
 	connectOnce   func(parentID, childID string) error
 	provenanceMap map[string]*allDepEntry
+	// componentMetadataMap maps dependency ID to its component-metadata entry
+	// (hashes + distribution URL). Non-nil only when --include-component-metadata
+	// is set; used to attach hash:<alg>/distribution:url node labels.
+	componentMetadataMap map[string]*allDepEntry
 }
 
 // addDep recursively adds a resolved dependency node and its children to the
@@ -177,7 +185,12 @@ func (ctx *depGraphContext) addDep(dep *gradleDep, parentID string, processed ma
 		provenanceEntry = ctx.provenanceMap[dep.ID]
 	}
 	pkgInfo := createPkgInfo(name, version, provenanceEntry, ctx.provenanceMap != nil)
-	ctx.builder.AddNode(nodeID, pkgInfo)
+	// Attach component-metadata labels (hash:<alg>, distribution:url) when present.
+	if labels := ctx.componentMetadataLabels(dep.ID); len(labels) > 0 {
+		ctx.builder.AddNode(nodeID, pkgInfo, depgraph.WithNodeInfo(&depgraph.NodeInfo{Labels: labels}))
+	} else {
+		ctx.builder.AddNode(nodeID, pkgInfo)
+	}
 	if err := ctx.connectOnce(parentID, nodeID); err != nil {
 		return err
 	}
@@ -272,6 +285,57 @@ func buildProvenanceMap(configurations []gradleConfig, options *ecosystems.SCAPl
 		}
 	}
 	return provenanceMap
+}
+
+// buildComponentMetadataMap creates a map from dependency ID to its
+// component-metadata entry (file hashes and, when the real resolution was
+// observed, the distribution URL). Built only when --include-component-metadata
+// is enabled. First configuration to carry metadata for an ID wins.
+func buildComponentMetadataMap(configurations []gradleConfig, options *ecosystems.SCAPluginOptions) map[string]*allDepEntry {
+	if options == nil || !options.Global.IncludeComponentMetadata {
+		return nil
+	}
+
+	metadataMap := make(map[string]*allDepEntry)
+	for _, cfg := range configurations {
+		for i := range cfg.AllDependencies {
+			entry := &cfg.AllDependencies[i]
+			if len(entry.Hashes) == 0 && entry.DistributionURL == "" {
+				continue
+			}
+			if _, exists := metadataMap[entry.ID]; !exists {
+				metadataMap[entry.ID] = entry
+			}
+		}
+	}
+	return metadataMap
+}
+
+// componentMetadataLabels returns the node labels (hash:<alg>, distribution:url)
+// for a dependency ID, using the shared cross-ecosystem label vocabulary so SBOM
+// generation consumes them identically to Maven/npm. Returns nil when the
+// feature is off or no metadata is available.
+func (ctx *depGraphContext) componentMetadataLabels(depID string) map[string]string {
+	if ctx.componentMetadataMap == nil {
+		return nil
+	}
+	entry := ctx.componentMetadataMap[depID]
+	if entry == nil {
+		return nil
+	}
+	labels := make(map[string]string)
+	for alg, value := range entry.Hashes {
+		if value != "" {
+			labels["hash:"+alg] = value
+		}
+	}
+	if entry.DistributionURL != "" {
+		labels["distribution:url"] = entry.DistributionURL
+	}
+	if len(labels) == 0 {
+		return nil
+	}
+	return labels
 }
 
 // createEdgeDeduplicator creates a function that ensures each edge is only

--- a/pkg/ecosystems/gradle/depgraph_test.go
+++ b/pkg/ecosystems/gradle/depgraph_test.go
@@ -792,6 +792,74 @@ func TestFilterConfigurationsByPattern(t *testing.T) {
 	})
 }
 
+// ── Component metadata (hash:* / distribution:url labels) ────────────────────
+
+func TestBuildDepGraph_ComponentMetadata(t *testing.T) {
+	// A single config with one dep whose flat allDependencies entry carries
+	// hashes + distribution URL (as the init script emits under the flag).
+	makeProjWithMetadata := func(entry allDepEntry) gradleProject {
+		cfg := makeConfig("runtimeClasspath", "com.example:my-app:1.0.0", []gradleDep{
+			makeDep("com.google.guava:guava:30.1.1-jre"),
+		})
+		cfg.AllDependencies = []allDepEntry{entry}
+		return makeProject("com.example", "my-app", "1.0.0", []gradleConfig{cfg})
+	}
+
+	fullEntry := allDepEntry{
+		ID: "com.google.guava:guava:30.1.1-jre",
+		Hashes: map[string]string{
+			"sha-1":   "87e0fd1df874ea3cbe577702fe6f17068b790fd8",
+			"sha-256": "44ce229ce26d880bf3afc362bbfcec34d7e6903d195bbb1db9f3b6e0d9834f06",
+		},
+		DistributionURL: "https://repo.maven.apache.org/maven2/com/google/guava/guava/30.1.1-jre/guava-30.1.1-jre.jar",
+	}
+
+	t.Run("attaches hash:* and distribution:url labels when flag enabled", func(t *testing.T) {
+		proj := makeProjWithMetadata(fullEntry)
+		options := &ecosystems.SCAPluginOptions{}
+		options.Global.IncludeComponentMetadata = true
+
+		dg, err := buildDepGraph(&proj, options)
+		require.NoError(t, err)
+
+		node := findNodeByID(t, dg, "com.google.guava:guava@30.1.1-jre")
+		require.NotNil(t, node.Info)
+		assert.Equal(t, "87e0fd1df874ea3cbe577702fe6f17068b790fd8", node.Info.Labels["hash:sha-1"])
+		assert.Equal(t, "44ce229ce26d880bf3afc362bbfcec34d7e6903d195bbb1db9f3b6e0d9834f06", node.Info.Labels["hash:sha-256"])
+		assert.Equal(t, "https://repo.maven.apache.org/maven2/com/google/guava/guava/30.1.1-jre/guava-30.1.1-jre.jar", node.Info.Labels["distribution:url"])
+	})
+
+	t.Run("emits hashes without distribution:url when URL absent (warm cache)", func(t *testing.T) {
+		entry := fullEntry
+		entry.DistributionURL = ""
+		proj := makeProjWithMetadata(entry)
+		options := &ecosystems.SCAPluginOptions{}
+		options.Global.IncludeComponentMetadata = true
+
+		dg, err := buildDepGraph(&proj, options)
+		require.NoError(t, err)
+
+		node := findNodeByID(t, dg, "com.google.guava:guava@30.1.1-jre")
+		require.NotNil(t, node.Info)
+		assert.Equal(t, "87e0fd1df874ea3cbe577702fe6f17068b790fd8", node.Info.Labels["hash:sha-1"])
+		_, hasURL := node.Info.Labels["distribution:url"]
+		assert.False(t, hasURL, "distribution:url should be absent when not observed")
+	})
+
+	t.Run("adds no component-metadata labels when flag disabled", func(t *testing.T) {
+		proj := makeProjWithMetadata(fullEntry)
+
+		dg, err := buildDepGraph(&proj, nil)
+		require.NoError(t, err)
+
+		node := findNodeByID(t, dg, "com.google.guava:guava@30.1.1-jre")
+		if node.Info != nil {
+			assert.Empty(t, node.Info.Labels["hash:sha-1"])
+			assert.Empty(t, node.Info.Labels["distribution:url"])
+		}
+	})
+}
+
 func TestCreatePkgInfo(t *testing.T) {
 	t.Run("creates basic PkgInfo without provenance enabled", func(t *testing.T) {
 		pkgInfo := createPkgInfo("org.example:artifact", "1.0.0", nil, false)

--- a/pkg/ecosystems/gradle/init/snyk-deps-init.gradle
+++ b/pkg/ecosystems/gradle/init/snyk-deps-init.gradle
@@ -553,15 +553,28 @@ def getGradleChecksum(File file, artifact) {
 // `algorithms` maps the JDK algorithm name to its output label; returns
 // {label: lowercase-hex}. Shared by every file-hashing helper below.
 def digestFile(File file, Map<String, String> algorithms) {
-    def digests = algorithms.collectEntries { javaName, _label ->
-        [(javaName): java.security.MessageDigest.getInstance(javaName)]
+    def javaNames = algorithms.keySet().toList()
+    def mds = javaNames.collect { java.security.MessageDigest.getInstance(it) }
+    // Reuse a single 64 KB buffer for the whole file. Groovy's
+    // File.eachByte(int, Closure) allocates a fresh byte[] copy per chunk, so
+    // hashing large artifacts churns enough short-lived garbage to inflate the
+    // Gradle daemon's peak heap; a manual read loop keeps allocation ~constant.
+    // Digests are identical either way — MessageDigest is chunking-invariant.
+    // All state is local, so this stays safe under parallel per-project tasks.
+    byte[] buffer = new byte[64 * 1024]
+    file.withInputStream { input ->
+        int read
+        while ((read = input.read(buffer)) != -1) {
+            for (md in mds) {
+                md.update(buffer, 0, read)
+            }
+        }
     }
-    file.eachByte(1024 * 8) { buffer, len ->
-        digests.each { _name, md -> md.update(buffer, 0, len) }
+    def result = [:]
+    javaNames.eachWithIndex { javaName, i ->
+        result[algorithms[javaName]] = mds[i].digest().encodeHex().toString()
     }
-    return digests.collectEntries { javaName, md ->
-        [(algorithms[javaName]): md.digest().encodeHex().toString()]
-    }
+    return result
 }
 
 // Computes SHA1 hash of a file (used for provenance checksums).

--- a/pkg/ecosystems/gradle/init/snyk-deps-init.gradle
+++ b/pkg/ecosystems/gradle/init/snyk-deps-init.gradle
@@ -584,8 +584,8 @@ def computeHashes(File file) {
     return digestFile(file, ['MD5': 'md5', 'SHA-1': 'sha-1', 'SHA-256': 'sha-256', 'SHA-512': 'sha-512'])
 }
 
-// Reduce a resource URL to its canonical location — scheme://host[:port]/path —
-// by parsing it as a URI and dropping userInfo, query and fragment.
+// Reduce an already-parsed resource URI to its canonical location —
+// scheme://host[:port]/path — by dropping userInfo, query and fragment.
 // Standard Maven/Gradle repos authenticate via headers and serve artifacts at
 // plain path-based URLs, but a repo configured with credentials embedded in the
 // URL (https://user:pass@host/repo) carries that userInfo on every artifact
@@ -594,12 +594,22 @@ def computeHashes(File file) {
 // location (at most a request-scoped redirect artefact), so the bare path is
 // the correct, reproducible provenance value. Operating on the parsed URI keeps
 // the rule single and robust.
-def canonicalUrl(String url) {
+def canonicalUrl(URI u) {
     try {
-        def u = new URI(url)
-        return new URI(u.scheme, null, u.host, u.port, u.path, null, null).toString()
+        // Reduce to the authority minus any embedded userInfo. We can't use
+        // u.host/u.port here: Java leaves getHost() null for any authority it
+        // deems registry-based rather than server-based — notably hosts
+        // containing an underscore, common on internal Maven mirrors — which
+        // would silently drop the host from the label. getAuthority() preserves
+        // it, so we strip the "user:pass@" prefix ourselves to keep credentials
+        // out of the dep-graph/SBOM.
+        def authority = u.authority
+        if (authority == null) return null
+        int at = authority.lastIndexOf('@')
+        if (at >= 0) authority = authority.substring(at + 1)
+        return new URI(u.scheme, authority, u.path, null, null).toString()
     } catch (Exception ignored) {
-        // Fail closed: if the URL can't be parsed and rebuilt from its
+        // Fail closed: if the URI can't be rebuilt from its
         // components we cannot guarantee userinfo/query/fragment were stripped,
         // so drop it entirely rather than risk a credential surviving into a
         // label. The caller records nothing when this returns null.
@@ -650,7 +660,7 @@ def recordResourceRead(buildOp, urlsByFilename) {
         int slash = path.lastIndexOf('/')
         if (slash < 0 || slash == path.length() - 1) return
         def filename = path.substring(slash + 1)
-        def clean = canonicalUrl(url)
+        def clean = canonicalUrl(uri)
         if (clean == null) return
         urlsByFilename
             .computeIfAbsent(filename) { _ -> java.util.Collections.synchronizedSet(new LinkedHashSet()) }

--- a/pkg/ecosystems/gradle/init/snyk-deps-init.gradle
+++ b/pkg/ecosystems/gradle/init/snyk-deps-init.gradle
@@ -646,6 +646,18 @@ def registerResourceReadListener(urlsByFilename) {
             finished: { buildOp, finishEvent -> recordResourceRead(buildOp, urlsByFilename) },
         ] as org.gradle.internal.operations.BuildOperationListener
         manager.addListener(listener)
+        // BuildOperationListenerManager is a daemon-scoped service, so a listener
+        // added here otherwise survives into later builds on a reused daemon —
+        // accumulating one per build, each pinning its build's captured state.
+        // Remove it when this build finishes. buildFinished is deprecated on newer
+        // Gradle but remains the most portable cleanup hook across 4.x–9.x;
+        // guarded so an unavailable hook never breaks resolution.
+        try {
+            gradle.buildFinished { manager.removeListener(listener) }
+        } catch (Exception ignored) {
+            // No usable build-finished hook: the listener is reclaimed when the
+            // daemon exits, so the worst case is a bounded per-build leak.
+        }
     } catch (Exception ignored) {
         // Internal API unavailable on this Gradle version — distribution:url
         // simply won't be populated; hashes are unaffected.

--- a/pkg/ecosystems/gradle/init/snyk-deps-init.gradle
+++ b/pkg/ecosystems/gradle/init/snyk-deps-init.gradle
@@ -584,13 +584,15 @@ def computeHashes(File file) {
     return digestFile(file, ['MD5': 'md5', 'SHA-1': 'sha-1', 'SHA-256': 'sha-256', 'SHA-512': 'sha-512'])
 }
 
-// Reduce a resource URL to its canonical, credential-free location —
-// scheme://host[:port]/path — by parsing it as a URI and dropping userInfo,
-// query and fragment. The query is where URL-borne auth lives (Azure Blob SAS
-// tokens, GCS/S3 signed-URL signatures); it is request-scoped and never part
-// of the artifact's durable location, so it is dropped wholesale rather than
-// by enumerating credential parameter names. Basic-auth userInfo is dropped
-// for the same reason. Operating on the parsed URI (not string surgery) keeps
+// Reduce a resource URL to its canonical location — scheme://host[:port]/path —
+// by parsing it as a URI and dropping userInfo, query and fragment.
+// Standard Maven/Gradle repos authenticate via headers and serve artifacts at
+// plain path-based URLs, but a repo configured with credentials embedded in the
+// URL (https://user:pass@host/repo) carries that userInfo on every artifact
+// URL, so we strip it to keep credentials out of the dep-graph/SBOM. Query and
+// fragment are dropped too: they are not part of the artifact's durable
+// location (at most a request-scoped redirect artefact), so the bare path is
+// the correct, reproducible provenance value. Operating on the parsed URI keeps
 // the rule single and robust.
 def canonicalUrl(String url) {
     try {

--- a/pkg/ecosystems/gradle/init/snyk-deps-init.gradle
+++ b/pkg/ecosystems/gradle/init/snyk-deps-init.gradle
@@ -597,9 +597,11 @@ def canonicalUrl(String url) {
         def u = new URI(url)
         return new URI(u.scheme, null, u.host, u.port, u.path, null, null).toString()
     } catch (Exception ignored) {
-        // Unparseable — still make a best effort to drop query/fragment so a
-        // token in the query can never survive into a label.
-        return url.replaceAll(/[?#].*$/, '')
+        // Fail closed: if the URL can't be parsed and rebuilt from its
+        // components we cannot guarantee userinfo/query/fragment were stripped,
+        // so drop it entirely rather than risk a credential surviving into a
+        // label. The caller records nothing when this returns null.
+        return null
     }
 }
 
@@ -646,9 +648,11 @@ def recordResourceRead(buildOp, urlsByFilename) {
         int slash = path.lastIndexOf('/')
         if (slash < 0 || slash == path.length() - 1) return
         def filename = path.substring(slash + 1)
+        def clean = canonicalUrl(url)
+        if (clean == null) return
         urlsByFilename
             .computeIfAbsent(filename) { _ -> java.util.Collections.synchronizedSet(new LinkedHashSet()) }
-            .add(canonicalUrl(url))
+            .add(clean)
     } catch (Exception ignored) { /* one bad op must not break resolution */ }
 }
 

--- a/pkg/ecosystems/gradle/init/snyk-deps-init.gradle
+++ b/pkg/ecosystems/gradle/init/snyk-deps-init.gradle
@@ -549,23 +549,28 @@ def getGradleChecksum(File file, artifact) {
     return null
 }
 
-// Computes SHA1 hash of a file manually
+// Stream a file once, feeding every requested digest from a single read.
+// `algorithms` maps the JDK algorithm name to its output label; returns
+// {label: lowercase-hex}. Shared by every file-hashing helper below.
+def digestFile(File file, Map<String, String> algorithms) {
+    def digests = algorithms.collectEntries { javaName, _label ->
+        [(javaName): java.security.MessageDigest.getInstance(javaName)]
+    }
+    file.eachByte(1024 * 8) { buffer, len ->
+        digests.each { _name, md -> md.update(buffer, 0, len) }
+    }
+    return digests.collectEntries { javaName, md ->
+        [(algorithms[javaName]): md.digest().encodeHex().toString()]
+    }
+}
+
+// Computes SHA1 hash of a file (used for provenance checksums).
 def computeSHA1(File file) {
     try {
         if (!file.exists()) {
             return null
         }
-
-        def digest = java.security.MessageDigest.getInstance('SHA-1')
-        file.withInputStream { stream ->
-            def buffer = new byte[8192]
-            int bytesRead
-            while ((bytesRead = stream.read(buffer)) != -1) {
-                digest.update(buffer, 0, bytesRead)
-            }
-        }
-        def result = digest.digest().encodeHex().toString()
-        return result
+        return digestFile(file, ['SHA-1': 'sha-1'])['sha-1']
     } catch (Exception e) {
         return null
     }
@@ -576,18 +581,7 @@ def computeSHA1(File file) {
 // Computes md5/sha-1/sha-256/sha-512 in a single pass over the file bytes.
 // Keys match the CycloneDX-friendly label suffixes used across ecosystems.
 def computeHashes(File file) {
-    def algos = ['MD5': 'md5', 'SHA-1': 'sha-1', 'SHA-256': 'sha-256', 'SHA-512': 'sha-512']
-    def digests = algos.collectEntries { javaName, _label -> [(javaName): java.security.MessageDigest.getInstance(javaName)] }
-    file.withInputStream { stream ->
-        def buffer = new byte[8192]
-        int bytesRead
-        while ((bytesRead = stream.read(buffer)) != -1) {
-            digests.each { _name, md -> md.update(buffer, 0, bytesRead) }
-        }
-    }
-    def result = [:]
-    digests.each { javaName, md -> result[algos[javaName]] = md.digest().encodeHex().toString() }
-    return result
+    return digestFile(file, ['MD5': 'md5', 'SHA-1': 'sha-1', 'SHA-256': 'sha-256', 'SHA-512': 'sha-512'])
 }
 
 // Reduce a resource URL to its canonical, credential-free location —

--- a/pkg/ecosystems/gradle/init/snyk-deps-init.gradle
+++ b/pkg/ecosystems/gradle/init/snyk-deps-init.gradle
@@ -671,20 +671,22 @@ def computeComponentMetadata(component, artifactLookup, urlsByFilename) {
     }
 }
 
-// Resolve a filename to the URL it was actually read from. When a filename maps
-// to more than one captured URL (shared cache seeing multiple repos), pick the
-// one matching this artifact's Maven layout; if still ambiguous, emit nothing.
+// Resolve a filename to the URL it was actually read from. Always confirm the
+// captured URL belongs to THIS artifact's Maven-layout path before labelling:
+// a shared build can read the same filename from more than one repo, and even
+// a lone captured URL may belong to a different GAV that happens to share a
+// filename. If no candidate — or more than one — matches the layout, emit
+// nothing rather than guess.
 def lookupDistributionUrl(String name, String version, String fileName, urlsByFilename) {
     if (urlsByFilename == null) return null
     def candidates = urlsByFilename.get(fileName)
     if (!candidates || candidates.isEmpty()) return null
-    if (candidates.size() == 1) return candidates.iterator().next()
     try {
         def group = name.contains(':') ? name.substring(0, name.indexOf(':')) : name
         def module = name.contains(':') ? name.substring(name.indexOf(':') + 1) : name
         def suffix = "/${group.replace('.', '/')}/${module}/${version}/${fileName}".toString()
-        def match = candidates.find { it.replaceAll(/[?#].*$/, '').endsWith(suffix) }
-        if (match) return match
+        def matches = candidates.findAll { it.replaceAll(/[?#].*$/, '').endsWith(suffix) }
+        if (matches.size() == 1) return matches[0]
     } catch (Exception ignored) { /* fall through to no-label */ }
     return null
 }

--- a/pkg/ecosystems/gradle/init/snyk-deps-init.gradle
+++ b/pkg/ecosystems/gradle/init/snyk-deps-init.gradle
@@ -590,16 +590,23 @@ def computeHashes(File file) {
     return result
 }
 
-// Strip any userinfo (basic-auth credentials) from a URL before labelling so
-// private-registry credentials never leak into the dep-graph.
-def stripCredentials(String url) {
+// Reduce a resource URL to its canonical, credential-free location —
+// scheme://host[:port]/path — by parsing it as a URI and dropping userInfo,
+// query and fragment. The query is where URL-borne auth lives (Azure Blob SAS
+// tokens, GCS/S3 signed-URL signatures); it is request-scoped and never part
+// of the artifact's durable location, so it is dropped wholesale rather than
+// by enumerating credential parameter names. Basic-auth userInfo is dropped
+// for the same reason. Operating on the parsed URI (not string surgery) keeps
+// the rule single and robust.
+def canonicalUrl(String url) {
     try {
         def u = new URI(url)
-        if (u.userInfo != null) {
-            return new URI(u.scheme, null, u.host, u.port, u.path, u.query, u.fragment).toString()
-        }
-    } catch (Exception ignored) { /* not a parseable URI — return as-is */ }
-    return url
+        return new URI(u.scheme, null, u.host, u.port, u.path, null, null).toString()
+    } catch (Exception ignored) {
+        // Unparseable — still make a best effort to drop query/fragment so a
+        // token in the query can never survive into a label.
+        return url.replaceAll(/[?#].*$/, '')
+    }
 }
 
 // Register an internal build-operation listener recording the URL of every
@@ -636,13 +643,18 @@ def recordResourceRead(buildOp, urlsByFilename) {
         if (loc == null) return
         def url = loc.toString()
         if (!(url.startsWith('http://') || url.startsWith('https://'))) return
-        def clean = url.replaceAll(/[?#].*$/, '')
-        int slash = clean.lastIndexOf('/')
-        if (slash < 0 || slash == clean.length() - 1) return
-        def filename = clean.substring(slash + 1)
+        def uri
+        try { uri = new URI(url) } catch (Exception ignored) { return }
+        // Derive the filename from the parsed path (already free of query and
+        // fragment), then store the canonicalised, credential-free URL.
+        def path = uri.path
+        if (!path) return
+        int slash = path.lastIndexOf('/')
+        if (slash < 0 || slash == path.length() - 1) return
+        def filename = path.substring(slash + 1)
         urlsByFilename
             .computeIfAbsent(filename) { _ -> java.util.Collections.synchronizedSet(new LinkedHashSet()) }
-            .add(stripCredentials(url))
+            .add(canonicalUrl(url))
     } catch (Exception ignored) { /* one bad op must not break resolution */ }
 }
 
@@ -685,7 +697,13 @@ def lookupDistributionUrl(String name, String version, String fileName, urlsByFi
         def group = name.contains(':') ? name.substring(0, name.indexOf(':')) : name
         def module = name.contains(':') ? name.substring(name.indexOf(':') + 1) : name
         def suffix = "/${group.replace('.', '/')}/${module}/${version}/${fileName}".toString()
-        def matches = candidates.findAll { it.replaceAll(/[?#].*$/, '').endsWith(suffix) }
+        def matches = candidates.findAll { candidate ->
+            try {
+                return new URI(candidate).path?.endsWith(suffix)
+            } catch (Exception ignored) {
+                return false
+            }
+        }
         if (matches.size() == 1) return matches[0]
     } catch (Exception ignored) { /* fall through to no-label */ }
     return null

--- a/pkg/ecosystems/gradle/init/snyk-deps-init.gradle
+++ b/pkg/ecosystems/gradle/init/snyk-deps-init.gradle
@@ -26,6 +26,26 @@ gradle.projectsEvaluated { g ->
     // Check if provenance (checksums) should be included
     def includeProvenance = root.findProperty('snykIncludeProvenance')?.toBoolean() ?: false
 
+    // ── Component metadata (opt-in: -PsnykIncludeComponentMetadata) ──────
+    // Shared cross-ecosystem label vocabulary (see snyk-mvn-plugin /
+    // nodejs-lockfile-parser): hash:<alg> lowercase-hex digests, and
+    // distribution:url — the real remote URL Gradle read the artifact from.
+    // distribution:url is TRUE provenance only: Gradle's public API exposes no
+    // per-artifact source repository, so we capture actual resource-read URLs
+    // via an internal build-operation listener. On a warm cache nothing is
+    // re-fetched, so a node simply carries no distribution:url (never a guess).
+    //
+    // The map and the listener are created here, in the same scope threaded to
+    // the per-project tasks, so the listener and the lookups share one instance
+    // (a run()-scope local captured across the build lifecycle does not).
+    // projectsEvaluated runs before task execution, so the listener is active
+    // before any resolution/download happens.
+    def includeComponentMetadata = root.findProperty('snykIncludeComponentMetadata')?.toBoolean() ?: false
+    def urlsByFilename = new java.util.concurrent.ConcurrentHashMap()
+    if (includeComponentMetadata) {
+        registerResourceReadListener(urlsByFilename)
+    }
+
     // Parse configuration-attributes filter once upfront for all projects
     def confAttrSpec = root.hasProperty('snykConfAttr') ? 
         parseConfigurationAttributes(root.snykConfAttr) : null
@@ -49,7 +69,7 @@ gradle.projectsEvaluated { g ->
             }
             doLast {
                 outputFile.parentFile.mkdirs()
-                outputFile.text = groovy.json.JsonOutput.toJson(buildProjectEntry(proj, confAttrSpec, includeProvenance))
+                outputFile.text = groovy.json.JsonOutput.toJson(buildProjectEntry(proj, confAttrSpec, includeProvenance, includeComponentMetadata, urlsByFilename))
             }
         }
     }
@@ -108,7 +128,7 @@ def buildMetadata(rootProject) {
 
 // ── Per-project entry ───────────────────────────────────────────────
 
-def buildProjectEntry(project, confAttrSpec, includeProvenance = false) {
+def buildProjectEntry(project, confAttrSpec, includeProvenance = false, includeComponentMetadata = false, urlsByFilename = null) {
     def resolvableConfigs = project.configurations.matching { config ->
         if (!config.canBeResolved) {
             return false
@@ -140,7 +160,7 @@ def buildProjectEntry(project, confAttrSpec, includeProvenance = false) {
 
     resolvableConfigs.each { config ->
         try {
-            def configEntry = resolveConfiguration(config, includeProvenance)
+            def configEntry = resolveConfiguration(config, includeProvenance, includeComponentMetadata, urlsByFilename)
             if (configEntry != null) {
                 entry.configurations << configEntry
             }
@@ -157,7 +177,7 @@ def buildProjectEntry(project, confAttrSpec, includeProvenance = false) {
 
 // ── Configuration resolution ────────────────────────────────────────
 
-def resolveConfiguration(config, includeProvenance = false) {
+def resolveConfiguration(config, includeProvenance = false, includeComponentMetadata = false, urlsByFilename = null) {
     def resolutionResult = config.incoming.resolutionResult
     def rootComponent = resolutionResult.root
 
@@ -181,9 +201,10 @@ def resolveConfiguration(config, includeProvenance = false) {
     def ancestry = new HashSet<String>()
     def tree = walkDependencies(rootComponent, processed, ancestry, resolvedNames)
 
-    // Build artifact lookup map once per configuration for O(1) lookups
+    // Build artifact lookup map once per configuration for O(1) lookups.
+    // Needed for provenance checksums and/or component-metadata hashes+URL.
     def artifactLookup = null
-    if (includeProvenance) {
+    if (includeProvenance || includeComponentMetadata) {
         artifactLookup = buildArtifactLookup(config)
     }
 
@@ -195,7 +216,7 @@ def resolveConfiguration(config, includeProvenance = false) {
             dependencies: tree,
         ],
         // Flat list of all resolved components for quick lookups
-        allDependencies: collectAllDependencies(resolutionResult, includeProvenance, artifactLookup),
+        allDependencies: collectAllDependencies(resolutionResult, includeProvenance, artifactLookup, includeComponentMetadata, urlsByFilename),
     ]
 }
 
@@ -310,7 +331,7 @@ def buildArtifactLookup(config) {
 
 // ── Flat dependency collection ──────────────────────────────────────
 
-def collectAllDependencies(resolutionResult, includeProvenance, artifactLookup) {
+def collectAllDependencies(resolutionResult, includeProvenance, artifactLookup, includeComponentMetadata = false, urlsByFilename = null) {
     def all = []
 
     resolutionResult.allComponents.each { component ->
@@ -322,6 +343,12 @@ def collectAllDependencies(resolutionResult, includeProvenance, artifactLookup) 
             def provenance = computeProvenance(component, artifactLookup)
             if (provenance != null) {
                 entry.putAll(provenance)
+            }
+        }
+        if (includeComponentMetadata) {
+            def metadata = computeComponentMetadata(component, artifactLookup, urlsByFilename)
+            if (metadata != null) {
+                entry.putAll(metadata)
             }
         }
         all << entry
@@ -542,4 +569,122 @@ def computeSHA1(File file) {
     } catch (Exception e) {
         return null
     }
+}
+
+// ── Component metadata helpers ──────────────────────────────────────
+
+// Computes md5/sha-1/sha-256/sha-512 in a single pass over the file bytes.
+// Keys match the CycloneDX-friendly label suffixes used across ecosystems.
+def computeHashes(File file) {
+    def algos = ['MD5': 'md5', 'SHA-1': 'sha-1', 'SHA-256': 'sha-256', 'SHA-512': 'sha-512']
+    def digests = algos.collectEntries { javaName, _label -> [(javaName): java.security.MessageDigest.getInstance(javaName)] }
+    file.withInputStream { stream ->
+        def buffer = new byte[8192]
+        int bytesRead
+        while ((bytesRead = stream.read(buffer)) != -1) {
+            digests.each { _name, md -> md.update(buffer, 0, bytesRead) }
+        }
+    }
+    def result = [:]
+    digests.each { javaName, md -> result[algos[javaName]] = md.digest().encodeHex().toString() }
+    return result
+}
+
+// Strip any userinfo (basic-auth credentials) from a URL before labelling so
+// private-registry credentials never leak into the dep-graph.
+def stripCredentials(String url) {
+    try {
+        def u = new URI(url)
+        if (u.userInfo != null) {
+            return new URI(u.scheme, null, u.host, u.port, u.path, u.query, u.fragment).toString()
+        }
+    } catch (Exception ignored) { /* not a parseable URI — return as-is */ }
+    return url
+}
+
+// Register an internal build-operation listener recording the URL of every
+// external resource Gradle reads during resolution — the only signal carrying
+// true per-artifact provenance. Internal + unstable across versions, so the
+// whole thing is best-effort: any failure degrades to "no distribution:url".
+def registerResourceReadListener(urlsByFilename) {
+    try {
+        def manager = gradle.services.get(org.gradle.internal.operations.BuildOperationListenerManager)
+        // Map-of-closures coerced to the interface: closures take untyped args,
+        // satisfying the interface's typed abstract methods on every Gradle
+        // version (the method set has changed over time). Absent methods no-op.
+        def listener = [
+            started : { buildOp, startEvent -> },
+            progress: { operationId, progressEvent -> },
+            finished: { buildOp, finishEvent -> recordResourceRead(buildOp, urlsByFilename) },
+        ] as org.gradle.internal.operations.BuildOperationListener
+        manager.addListener(listener)
+    } catch (Exception ignored) {
+        // Internal API unavailable on this Gradle version — distribution:url
+        // simply won't be populated; hashes are unaffected.
+    }
+}
+
+// Record one finished build operation's URL if it is an external-resource read.
+// Duck-typed on getLocation() to avoid importing the internal details type
+// (whose package has moved across Gradle versions).
+def recordResourceRead(buildOp, urlsByFilename) {
+    try {
+        def details = buildOp?.details
+        if (details == null) return
+        if (!details.metaClass.respondsTo(details, 'getLocation')) return
+        def loc = details.getLocation()
+        if (loc == null) return
+        def url = loc.toString()
+        if (!(url.startsWith('http://') || url.startsWith('https://'))) return
+        def clean = url.replaceAll(/[?#].*$/, '')
+        int slash = clean.lastIndexOf('/')
+        if (slash < 0 || slash == clean.length() - 1) return
+        def filename = clean.substring(slash + 1)
+        urlsByFilename
+            .computeIfAbsent(filename) { _ -> java.util.Collections.synchronizedSet(new LinkedHashSet()) }
+            .add(stripCredentials(url))
+    } catch (Exception ignored) { /* one bad op must not break resolution */ }
+}
+
+// Build the per-node component metadata (hashes + distribution:url) for a
+// resolved external component. Returns null when nothing could be derived.
+def computeComponentMetadata(component, artifactLookup, urlsByFilename) {
+    try {
+        def id = component.id
+        if (!id.hasProperty('group') || !id.hasProperty('module') || !id.hasProperty('version')) return null
+        def moduleVersion = component.moduleVersion
+        if (moduleVersion == null) return null
+        def matchingArtifacts = (artifactLookup ? artifactLookup[component.id] : null) ?: []
+        if (matchingArtifacts.empty) return null
+        def file = matchingArtifacts.first().file
+        if (file == null || !file.isFile()) return null
+        def result = [hashes: computeHashes(file)]
+        def url = lookupDistributionUrl(
+            "${moduleVersion.group}:${moduleVersion.name}".toString(),
+            moduleVersion.version?.toString(),
+            file.name,
+            urlsByFilename)
+        if (url) result.distributionUrl = url
+        return result
+    } catch (Exception ignored) {
+        return null
+    }
+}
+
+// Resolve a filename to the URL it was actually read from. When a filename maps
+// to more than one captured URL (shared cache seeing multiple repos), pick the
+// one matching this artifact's Maven layout; if still ambiguous, emit nothing.
+def lookupDistributionUrl(String name, String version, String fileName, urlsByFilename) {
+    if (urlsByFilename == null) return null
+    def candidates = urlsByFilename.get(fileName)
+    if (!candidates || candidates.isEmpty()) return null
+    if (candidates.size() == 1) return candidates.iterator().next()
+    try {
+        def group = name.contains(':') ? name.substring(0, name.indexOf(':')) : name
+        def module = name.contains(':') ? name.substring(name.indexOf(':') + 1) : name
+        def suffix = "/${group.replace('.', '/')}/${module}/${version}/${fileName}".toString()
+        def match = candidates.find { it.replaceAll(/[?#].*$/, '').endsWith(suffix) }
+        if (match) return match
+    } catch (Exception ignored) { /* fall through to no-label */ }
+    return null
 }

--- a/pkg/ecosystems/gradle/parser.go
+++ b/pkg/ecosystems/gradle/parser.go
@@ -94,6 +94,12 @@ type allDepEntry struct {
 	ID       string `json:"id"`
 	Checksum string `json:"checksum,omitempty"`
 	Type     string `json:"type,omitempty"`
+	// Component-metadata fields, populated by the init script only under
+	// -PsnykIncludeComponentMetadata. Hashes maps algorithm (md5, sha-1,
+	// sha-256, sha-512) to lowercase-hex digest; DistributionURL is the real
+	// remote URL Gradle read the artifact from (present only when observed).
+	Hashes          map[string]string `json:"hashes,omitempty"`
+	DistributionURL string            `json:"distributionUrl,omitempty"`
 }
 
 // parseDependencyGraphJSON deserialises the NDJSON file produced by snyk-deps-init.gradle.

--- a/pkg/ecosystems/gradle/plugin.go
+++ b/pkg/ecosystems/gradle/plugin.go
@@ -484,6 +484,17 @@ func buildExtraArgs(projectDir string, options *ecosystems.SCAPluginOptions) []s
 		args = append(args, "-PsnykConfAttr="+configAttrs)
 	}
 
+	// Opt-in component-metadata labels (hash:<alg>, distribution:url). The init
+	// script only does the extra work when this property is present.
+	if options.Global.IncludeComponentMetadata {
+		args = append(args, "-PsnykIncludeComponentMetadata=true")
+		// Forces network re-validation of metadata so distribution:url can be
+		// captured on a warm cache. Only meaningful alongside the metadata flag.
+		if options.Gradle.RefreshDependencies {
+			args = append(args, "--refresh-dependencies")
+		}
+	}
+
 	return args
 }
 

--- a/pkg/ecosystems/gradle/plugin_integration_test.go
+++ b/pkg/ecosystems/gradle/plugin_integration_test.go
@@ -230,6 +230,17 @@ func pluginTestCases() map[string]PluginTestCase {
 			Options:      ecosystems.NewPluginOptions().WithIncludeProvenance(true),
 			ExpectedFile: "expected_plugin_with_provenance.json",
 		},
+		// Component-metadata integration test - exercises
+		// --include-component-metadata to verify hash:<alg> node labels are
+		// attached to resolved external artifacts. distribution:url is stripped
+		// from the snapshot (environment-dependent, see
+		// stripEnvironmentDependentLabels); its format and credential-safety are
+		// asserted separately in TestPlugin_ComponentMetadataIntegration.
+		"simple_with_component_metadata": {
+			Fixture:      "simple",
+			Options:      ecosystems.NewPluginOptions().WithIncludeComponentMetadata(true),
+			ExpectedFile: "expected_plugin_with_component_metadata.json",
+		},
 	}
 }
 
@@ -607,7 +618,12 @@ func writeExpectedSnapshot(t *testing.T, path string, results []ecosystems.SCARe
 		cleaned[i].Error = nil
 		// ResolverMetadata contains runtime-specific info and is not part of the snapshot format.
 		cleaned[i].ResolverMetadata = nil
+		// ProcessedFiles is an implementation detail excluded from comparison
+		// (see assertResultsMatchExpected); strip it here too so a regenerated
+		// snapshot matches what the comparison path expects.
+		cleaned[i].ProcessedFiles = nil
 	}
+	stripEnvironmentDependentLabels(cleaned)
 
 	data, err := json.MarshalIndent(cleaned, "", "  ")
 	require.NoError(t, err, "failed to marshal results for snapshot")
@@ -639,6 +655,11 @@ func assertResultsMatchExpected(t *testing.T, actual, expected []ecosystems.SCAR
 		// is verified separately.
 		sortedActual[i].ProcessedFiles = nil
 	}
+	// distribution:url is only populated when a live download is observed, so
+	// it is environment-dependent (cache warmth / gradle version) and excluded
+	// from snapshots; its format and credential-safety are covered by
+	// TestPlugin_ComponentMetadataIntegration.
+	stripEnvironmentDependentLabels(sortedActual)
 
 	actualJSON, err := json.Marshal(sortedActual)
 	require.NoErrorf(t, err, "[%s] failed to marshal actual results", fixture)
@@ -650,6 +671,28 @@ func assertResultsMatchExpected(t *testing.T, actual, expected []ecosystems.SCAR
 	require.NoErrorf(t, err, "[%s] failed to resolve wildcard versions", fixture)
 
 	assert.JSONEq(t, string(resolvedExpected), string(actualJSON), "[%s] results mismatch", fixture)
+}
+
+// stripEnvironmentDependentLabels removes node labels whose presence depends on
+// the runtime environment rather than the resolved graph. Currently that is
+// distribution:url, which the init script only emits when the resource-read
+// listener observes a live download (cold cache or --refresh-dependencies), so
+// it cannot appear in a deterministic snapshot. The hash:<alg> labels are
+// derived from the artifact files and stay in the snapshot. No-op for fixtures
+// that carry no such labels.
+func stripEnvironmentDependentLabels(results []ecosystems.SCAResult) {
+	for _, r := range results {
+		if r.DepGraph == nil {
+			continue
+		}
+		for i := range r.DepGraph.Graph.Nodes {
+			info := r.DepGraph.Graph.Nodes[i].Info
+			if info == nil || info.Labels == nil {
+				continue
+			}
+			delete(info.Labels, "distribution:url")
+		}
+	}
 }
 
 // sortResults returns a copy of results sorted by target file (with root

--- a/pkg/ecosystems/gradle/plugin_test.go
+++ b/pkg/ecosystems/gradle/plugin_test.go
@@ -451,6 +451,36 @@ func TestBuildExtraArgs(t *testing.T) {
 		args := buildExtraArgs(dir, opts)
 		assert.Empty(t, args)
 	})
+
+	t.Run("adds snykIncludeComponentMetadata property when the flag is set", func(t *testing.T) {
+		dir := t.TempDir()
+		opts := &ecosystems.SCAPluginOptions{
+			Global: ecosystems.GlobalOptions{IncludeComponentMetadata: true},
+		}
+
+		args := buildExtraArgs(dir, opts)
+		assert.Contains(t, args, "-PsnykIncludeComponentMetadata=true")
+		assert.NotContains(t, args, "--refresh-dependencies")
+	})
+
+	t.Run("adds --refresh-dependencies only with component metadata enabled", func(t *testing.T) {
+		dir := t.TempDir()
+
+		// refresh alone (without component metadata) does nothing
+		optsRefreshOnly := &ecosystems.SCAPluginOptions{
+			Gradle: ecosystems.GradleOptions{RefreshDependencies: true},
+		}
+		assert.Empty(t, buildExtraArgs(dir, optsRefreshOnly))
+
+		// refresh + component metadata forwards both
+		opts := &ecosystems.SCAPluginOptions{
+			Global: ecosystems.GlobalOptions{IncludeComponentMetadata: true},
+			Gradle: ecosystems.GradleOptions{RefreshDependencies: true},
+		}
+		args := buildExtraArgs(dir, opts)
+		assert.Contains(t, args, "-PsnykIncludeComponentMetadata=true")
+		assert.Contains(t, args, "--refresh-dependencies")
+	})
 }
 
 // ── Target file filtering behavior demonstration ──────────────────────────────

--- a/pkg/ecosystems/options.go
+++ b/pkg/ecosystems/options.go
@@ -30,8 +30,11 @@ type GlobalOptions struct {
 	ForceIncludeWorkspacePackages bool                 `arg:"--internal-uv-workspace-packages"`
 	ProjectName                   *string              `arg:"--project-name"`
 	IncludeProvenance             bool                 `arg:"--include-provenance"`
-	WorkspacePackage              *string              `arg:"--workspace-package"`
-	RawFlags                      []string
+	// IncludeComponentMetadata emits component-metadata node labels
+	// (hash:<alg> and, when the real resolution was observed, distribution:url).
+	IncludeComponentMetadata bool    `arg:"--include-component-metadata"`
+	WorkspacePackage         *string `arg:"--workspace-package"`
+	RawFlags                 []string
 }
 
 // CommaSeparatedString is a custom type that parses comma-separated values.
@@ -66,6 +69,11 @@ type GradleOptions struct {
 	// NormalizeDeps uses the SHAs of the dependencies provided by the IncludeProvenance flag
 	// to lookup the canonical GAV coordinates of the dependency and rewrite the produced DepGraphs.
 	NormalizeDeps bool `arg:"--gradle-normalize-deps"`
+	// RefreshDependencies forces `--refresh-dependencies` so metadata reads fire
+	// and distribution:url is populated even on a warm cache. Opt-in: forces
+	// network access and can re-resolve dynamic/SNAPSHOT versions. Only affects
+	// distribution:url coverage; hash:<alg> labels are unaffected.
+	RefreshDependencies bool `arg:"--gradle-refresh-dependencies"`
 }
 
 // BazelOptions contains Bazel-specific options for dependency graph generation.
@@ -226,6 +234,16 @@ func (o *SCAPluginOptions) WithGradleNormalizeDeps(normalizeDeps bool) *SCAPlugi
 
 func (o *SCAPluginOptions) WithIncludeProvenance(includeProvenance bool) *SCAPluginOptions {
 	o.Global.IncludeProvenance = includeProvenance
+	return o
+}
+
+func (o *SCAPluginOptions) WithIncludeComponentMetadata(includeComponentMetadata bool) *SCAPluginOptions {
+	o.Global.IncludeComponentMetadata = includeComponentMetadata
+	return o
+}
+
+func (o *SCAPluginOptions) WithGradleRefreshDependencies(refreshDependencies bool) *SCAPluginOptions {
+	o.Gradle.RefreshDependencies = refreshDependencies
 	return o
 }
 

--- a/pkg/ecosystems/options_test.go
+++ b/pkg/ecosystems/options_test.go
@@ -382,3 +382,31 @@ func TestWithIncludeProvenance(t *testing.T) {
 	options = NewPluginOptions().WithIncludeProvenance(false)
 	assert.False(t, options.Global.IncludeProvenance)
 }
+
+func TestNewPluginOptionsFromRawFlags_IncludeComponentMetadata(t *testing.T) {
+	got, err := NewPluginOptionsFromRawFlags([]string{"--include-component-metadata"})
+	assert.NoError(t, err)
+	assert.True(t, got.Global.IncludeComponentMetadata)
+}
+
+func TestNewPluginOptionsFromRawFlags_GradleRefreshDependencies(t *testing.T) {
+	got, err := NewPluginOptionsFromRawFlags([]string{"--gradle-refresh-dependencies"})
+	assert.NoError(t, err)
+	assert.True(t, got.Gradle.RefreshDependencies)
+}
+
+func TestWithIncludeComponentMetadata(t *testing.T) {
+	options := NewPluginOptions().WithIncludeComponentMetadata(true)
+	assert.True(t, options.Global.IncludeComponentMetadata)
+
+	options = NewPluginOptions().WithIncludeComponentMetadata(false)
+	assert.False(t, options.Global.IncludeComponentMetadata)
+}
+
+func TestWithGradleRefreshDependencies(t *testing.T) {
+	options := NewPluginOptions().WithGradleRefreshDependencies(true)
+	assert.True(t, options.Gradle.RefreshDependencies)
+
+	options = NewPluginOptions().WithGradleRefreshDependencies(false)
+	assert.False(t, options.Gradle.RefreshDependencies)
+}

--- a/pkg/ecosystems/testdata/fixtures/gradle/simple/expected_plugin_with_component_metadata.json
+++ b/pkg/ecosystems/testdata/fixtures/gradle/simple/expected_plugin_with_component_metadata.json
@@ -1,0 +1,222 @@
+[
+  {
+    "depGraph": {
+      "schemaVersion": "1.3.0",
+      "pkgManager": {
+        "name": "gradle"
+      },
+      "pkgs": [
+        {
+          "id": "com.snyk.fixtures:simple-app@1.0.0",
+          "info": {
+            "name": "com.snyk.fixtures:simple-app",
+            "version": "1.0.0"
+          }
+        },
+        {
+          "id": "com.google.guava:guava@30.1.1-jre",
+          "info": {
+            "name": "com.google.guava:guava",
+            "version": "30.1.1-jre"
+          }
+        },
+        {
+          "id": "com.google.guava:failureaccess@1.0.1",
+          "info": {
+            "name": "com.google.guava:failureaccess",
+            "version": "1.0.1"
+          }
+        },
+        {
+          "id": "com.google.guava:listenablefuture@9999.0-empty-to-avoid-conflict-with-guava",
+          "info": {
+            "name": "com.google.guava:listenablefuture",
+            "version": "9999.0-empty-to-avoid-conflict-with-guava"
+          }
+        },
+        {
+          "id": "com.google.code.findbugs:jsr305@3.0.2",
+          "info": {
+            "name": "com.google.code.findbugs:jsr305",
+            "version": "3.0.2"
+          }
+        },
+        {
+          "id": "org.checkerframework:checker-qual@3.8.0",
+          "info": {
+            "name": "org.checkerframework:checker-qual",
+            "version": "3.8.0"
+          }
+        },
+        {
+          "id": "com.google.errorprone:error_prone_annotations@2.5.1",
+          "info": {
+            "name": "com.google.errorprone:error_prone_annotations",
+            "version": "2.5.1"
+          }
+        },
+        {
+          "id": "com.google.j2objc:j2objc-annotations@1.3",
+          "info": {
+            "name": "com.google.j2objc:j2objc-annotations",
+            "version": "1.3"
+          }
+        },
+        {
+          "id": "org.apache.commons:commons-lang3@3.14.0",
+          "info": {
+            "name": "org.apache.commons:commons-lang3",
+            "version": "3.14.0"
+          }
+        }
+      ],
+      "graph": {
+        "rootNodeId": "root-node",
+        "nodes": [
+          {
+            "nodeId": "root-node",
+            "pkgId": "com.snyk.fixtures:simple-app@1.0.0",
+            "deps": [
+              {
+                "nodeId": "com.google.guava:guava@30.1.1-jre"
+              },
+              {
+                "nodeId": "org.apache.commons:commons-lang3@3.14.0"
+              }
+            ]
+          },
+          {
+            "nodeId": "com.google.guava:guava@30.1.1-jre",
+            "pkgId": "com.google.guava:guava@30.1.1-jre",
+            "info": {
+              "labels": {
+                "hash:md5": "05374f163d0a4141db672fff9df95b12",
+                "hash:sha-1": "87e0fd1df874ea3cbe577702fe6f17068b790fd8",
+                "hash:sha-256": "44ce229ce26d880bf3afc362bbfcec34d7e6903d195bbb1db9f3b6e0d9834f06",
+                "hash:sha-512": "025cdd70db7d896d57cc04a8a735ded609b393e8d56af23d454198b64a263147ab0d68fbdffabcb926b143433fccdc022f76aaed658b9448c5ce85f07c42140f"
+              }
+            },
+            "deps": [
+              {
+                "nodeId": "com.google.guava:failureaccess@1.0.1"
+              },
+              {
+                "nodeId": "com.google.guava:listenablefuture@9999.0-empty-to-avoid-conflict-with-guava"
+              },
+              {
+                "nodeId": "com.google.code.findbugs:jsr305@3.0.2"
+              },
+              {
+                "nodeId": "org.checkerframework:checker-qual@3.8.0"
+              },
+              {
+                "nodeId": "com.google.errorprone:error_prone_annotations@2.5.1"
+              },
+              {
+                "nodeId": "com.google.j2objc:j2objc-annotations@1.3"
+              }
+            ]
+          },
+          {
+            "nodeId": "com.google.guava:failureaccess@1.0.1",
+            "pkgId": "com.google.guava:failureaccess@1.0.1",
+            "info": {
+              "labels": {
+                "hash:md5": "091883993ef5bfa91da01dcc8fc52236",
+                "hash:sha-1": "1dcf1de382a0bf95a3d8b0849546c88bac1292c9",
+                "hash:sha-256": "a171ee4c734dd2da837e4b16be9df4661afab72a41adaf31eb84dfdaf936ca26",
+                "hash:sha-512": "f8d59b808d6ba617252305b66d5590937da9b2b843d492d06b8d0b1b1f397e39f360d5817707797b979a5bf20bf21987b35333e7a15c44ed7401fea2d2119cae"
+              }
+            },
+            "deps": []
+          },
+          {
+            "nodeId": "com.google.guava:listenablefuture@9999.0-empty-to-avoid-conflict-with-guava",
+            "pkgId": "com.google.guava:listenablefuture@9999.0-empty-to-avoid-conflict-with-guava",
+            "info": {
+              "labels": {
+                "hash:md5": "d094c22570d65e132c19cea5d352e381",
+                "hash:sha-1": "b421526c5f297295adef1c886e5246c39d4ac629",
+                "hash:sha-256": "b372a037d4230aa57fbeffdef30fd6123f9c0c2db85d0aced00c91b974f33f99",
+                "hash:sha-512": "c5987a979174cbacae2e78b319f080420cc71bcdbcf7893745731eeb93c23ed13bff8d4599441f373f3a246023d33df03e882de3015ee932a74a774afdd0782f"
+              }
+            },
+            "deps": []
+          },
+          {
+            "nodeId": "com.google.code.findbugs:jsr305@3.0.2",
+            "pkgId": "com.google.code.findbugs:jsr305@3.0.2",
+            "info": {
+              "labels": {
+                "hash:md5": "dd83accb899363c32b07d7a1b2e4ce40",
+                "hash:sha-1": "25ea2e8b0c338a877313bd4672d3fe056ea78f0d",
+                "hash:sha-256": "766ad2a0783f2687962c8ad74ceecc38a28b9f72a2d085ee438b7813e928d0c7",
+                "hash:sha-512": "bb09db62919a50fa5b55906013be6ca4fc7acb2e87455fac5eaf9ede2e41ce8bbafc0e5a385a561264ea4cd71bbbd3ef5a45e02d63277a201d06a0ae1636f804"
+              }
+            },
+            "deps": []
+          },
+          {
+            "nodeId": "org.checkerframework:checker-qual@3.8.0",
+            "pkgId": "org.checkerframework:checker-qual@3.8.0",
+            "info": {
+              "labels": {
+                "hash:md5": "b9822b33f72326c74abded69b7c717cc",
+                "hash:sha-1": "6b83e4a33220272c3a08991498ba9dc09519f190",
+                "hash:sha-256": "c88c2e6a5fdaeb9f26fcf879264042de8a9ee9d376e2477838feaabcfa44dda6",
+                "hash:sha-512": "742f5442d72b37cb7d2e8e069dbe03545e5e21f1cba51254fc62beea3ed688446cbb5c4e505670c4c4e3f12b35fe9292ec501bd799319c6f0dfc129495bc90c9"
+              }
+            },
+            "deps": []
+          },
+          {
+            "nodeId": "com.google.errorprone:error_prone_annotations@2.5.1",
+            "pkgId": "com.google.errorprone:error_prone_annotations@2.5.1",
+            "info": {
+              "labels": {
+                "hash:md5": "2bf3239388cf5c817cd83ecb692b045f",
+                "hash:sha-1": "562d366678b89ce5d6b6b82c1a073880341e3fba",
+                "hash:sha-256": "ff80626baaf12a09342befd4e84cba9d50662f5fcd7f7a9b3490a6b7cf87e66c",
+                "hash:sha-512": "24d512c97bbea2b972addff6bb28b9e7edae62249dfb6693835f077fe239395bb15ce82ad58d4ee42d8c4891a0e62b51398450ad6c9dec473173eacb6c6bcd3a"
+              }
+            },
+            "deps": []
+          },
+          {
+            "nodeId": "com.google.j2objc:j2objc-annotations@1.3",
+            "pkgId": "com.google.j2objc:j2objc-annotations@1.3",
+            "info": {
+              "labels": {
+                "hash:md5": "5fa4ec4ec0c5aa70af8a7d4922df1931",
+                "hash:sha-1": "ba035118bc8bac37d7eff77700720999acd9986d",
+                "hash:sha-256": "21af30c92267bd6122c0e0b4d20cccb6641a37eaf956c6540ec471d584e64a7b",
+                "hash:sha-512": "51ea975179f809cb260751d11a513881b643bf016d15949bcb63b57d3c8868a2197e0620ccbaa5739e032797ec6faa3aa6d64606e999fce32930314780ca4115"
+              }
+            },
+            "deps": []
+          },
+          {
+            "nodeId": "org.apache.commons:commons-lang3@3.14.0",
+            "pkgId": "org.apache.commons:commons-lang3@3.14.0",
+            "info": {
+              "labels": {
+                "hash:md5": "4e5c3f5e6b0b965ef241d7d72ac8971f",
+                "hash:sha-1": "1ed471194b02f2c6cb734a0cd6f6f107c673afae",
+                "hash:sha-256": "7b96bf3ee68949abb5bc465559ac270e0551596fa34523fddf890ec418dde13c",
+                "hash:sha-512": "0338b50767166e5746ada6d6aa2e071e7221d699323bfb629f7f204b294c1dc4cad140610a129ed751798443b43e74e0818989c7df7d33c5915aa29742be9ba8"
+              }
+            },
+            "deps": []
+          }
+        ]
+      }
+    },
+    "projectDescriptor": {
+      "identity": {
+        "type": "gradle",
+        "targetFile": "build.gradle",
+        "rootComponentName": "com.snyk.fixtures:simple-app"
+      }
+    }
+  }
+]


### PR DESCRIPTION
## What

Wires **`--include-component-metadata`** (and its companion
`--gradle-refresh-dependencies`) through the native Gradle resolver, emitting the
shared cross-ecosystem node labels so SBOM generation consumes Gradle components
identically to Maven/npm:

- `hash:<alg>` — lowercase-hex `md5` / `sha-1` / `sha-256` / `sha-512` digests of
  the resolved artifact file.
- `distribution:url` — the real remote URL Gradle read the artifact from.

Off by default. `distribution:url` is captured best-effort via an internal
build-operation listener in the init script (Gradle exposes no per-artifact
source repository publicly); it degrades gracefully to absent when the internal
API is unavailable or nothing is re-fetched on a warm cache.
`--gradle-refresh-dependencies` forces `--refresh-dependencies` so the reads fire
on a warm cache.

## Commits

1. `feat:` flag registration + options/setters, init-script hashing +
   resource-read listener + URL lookup, NDJSON parsing, and
   `buildComponentMetadataMap` / `componentMetadataLabels` attaching the labels.
2. `fix:` review findings — forward `--gradle-refresh-dependencies` on the legacy
   resolution path (it was dropped, so `distribution:url` was never populated on
   a warm cache there); apply the GAV-layout check to the single-candidate URL
   case. Adds legacy-forwarding table coverage.
3. `fix:` sanitise `distribution:url` — parse it as a `URI` and keep only
   `scheme://host[:port]/path`, dropping userInfo, query and fragment.
4. `test:` `includeComponentMetadata` integration tests (`integration,gradle`).
5. `test:` hash-only snapshot case; strips the environment-dependent
   `distribution:url` from snapshots (also aligns `writeExpectedSnapshot` with
   the comparison path by dropping `ProcessedFiles`).
6. `refactor:` consolidate file hashing onto a shared `digestFile` helper
   (single streamed read via idiomatic `eachByte`); behaviour-preserving,
   provenance + component-metadata snapshots unchanged.
7. `style:` wrap the `--gradle-refresh-dependencies` flag description (lll).
8. `fix:` make `canonicalUrl` fail closed — return null (record nothing) on any
   parse/rebuild failure, rather than a weaker fallback that could keep userInfo.
9. `docs:` correct the `canonicalUrl` rationale (see below).

## On `distribution:url` sanitising

The value is reduced at capture to `scheme://host[:port]/path`. The realistic
in-URL credential vector is **userInfo** — a repo configured as
`https://user:pass@host/repo` carries it on every artifact URL — which this
strips so it can't reach the dep-graph/SBOM. Query and fragment are dropped as
**canonicalisation**: they are not part of the artifact's durable location (at
most a request-scoped redirect artefact), so the bare path is the correct,
reproducible provenance value. It is not a defence against exotic signed-URL
token schemes (Azure SAS / S3-presigned) — those don't arise for normal
header-authenticated, path-based Maven/Gradle repos. `canonicalUrl` fails closed:
an un-sanitisable URL is dropped rather than risking a leak.

## Testing

- `TestPlugin_ComponentMetadataIntegration`: flag on (cold `GRADLE_USER_HOME`) →
  every resolved external node carries all four hashes as lowercase hex, and any
  captured `distribution:url` is a bare, credential-free location; flag off → no
  such labels.
- `simple_with_component_metadata` snapshot case pins the hash labels; verified
  deterministic on warm and cold caches.
- Full gradle integration suite + unit suites green locally on Gradle 9.4.1 /
  JDK 21.

## Notes

- Companion change in `snyk-gradle-plugin` implements the same feature in its
  init script; the `digestFile` and `canonicalUrl` helpers are identical across
  both.

Draft: opening for review of the approach before finalising.
