### PR TITLE
feat: add --gradle-refresh-dependencies flag to the depgraph workflow [CMPA-649]

### DIFF
--- a/internal/legacycli/legacy_resolution.go
+++ b/internal/legacycli/legacy_resolution.go
@@ -206,6 +206,11 @@ func PrepareLegacyFlags(argument string, cfg configuration.Configuration, logger
 		logger.Print("Normalize Gradle dependencies: true")
 	}
 
+	if cfg.GetBool(workflow.FlagGradleRefreshDependencies) {
+		cmdArgs = append(cmdArgs, "--gradle-refresh-dependencies")
+		logger.Print("Gradle refresh dependencies: true")
+	}
+
 	if cfg.GetBool(workflow.FlagAllSubProjects) {
 		cmdArgs = append(cmdArgs, "--all-sub-projects")
 		logger.Print("Test all sub-projects: true")

--- a/internal/legacycli/legacy_resolution_test.go
+++ b/internal/legacycli/legacy_resolution_test.go
@@ -204,6 +204,11 @@ func Test_LegacyResolution(t *testing.T) {
 			value:    true,
 			expected: "--include-component-metadata",
 		},
+		{
+			key:      workflow.FlagGradleRefreshDependencies,
+			value:    true,
+			expected: "--gradle-refresh-dependencies",
+		},
 	}
 
 	for _, tc := range options {

--- a/internal/workflow/flags.go
+++ b/internal/workflow/flags.go
@@ -17,6 +17,7 @@ const (
 	FlagSubProject                    = "sub-project"
 	FlagGradleSubProject              = "gradle-sub-project"
 	FlagGradleNormalizeDeps           = "gradle-normalize-deps"
+	FlagGradleRefreshDependencies     = "gradle-refresh-dependencies"
 	FlagAllSubProjects                = "all-sub-projects"
 	FlagConfigurationMatching         = "configuration-matching"
 	FlagConfigurationAttributes       = "configuration-attributes"

--- a/pkg/depgraph/flags.go
+++ b/pkg/depgraph/flags.go
@@ -27,6 +27,9 @@ func getFlagSet() *pflag.FlagSet {
 	flagSet.String(workflow.FlagSubProject, "", "Name of Gradle sub-project to test.")
 	flagSet.String(workflow.FlagGradleSubProject, "", "Name of Gradle sub-project to test.")
 	flagSet.Bool(workflow.FlagGradleNormalizeDeps, false, "Normalize Gradle dependencies.")
+	flagSet.Bool(workflow.FlagGradleRefreshDependencies, false,
+		"Force Gradle to refresh dependencies so distribution URLs can be captured on a warm cache "+
+			"(used with --include-component-metadata; forces network access).")
 	flagSet.Bool(workflow.FlagAllSubProjects, false, "Test all sub-projects in a multi-project build.")
 	flagSet.String(workflow.FlagConfigurationMatching, "", "Resolve dependencies using only configuration(s) that match the specified Java regular expression.")
 	flagSet.String(workflow.FlagConfigurationAttributes, "", "Select certain values of configuration attributes to install and resolve dependencies.")


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Adds the `--gradle-refresh-dependencies` flag to the depgraph workflow: registered on the flagset and forwarded to the legacy CLI resolution path.

Passing it forces Gradle to run with `--refresh-dependencies`, which re-reads artifact metadata so distribution URLs can be captured even on a warm cache — at the cost of network access and possible re-resolution of dynamic/SNAPSHOT versions.

Split out from the Gradle component-metadata work so this small, self-contained flag can land independently of the native (new-resolver) changes.

[CMPA-649](https://snyk.atlassian.net/browse/CMPA-649)

[CMPA-649]: https://snyksec.atlassian.net/browse/CMPA-649?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ