### PR TITLE
chore: update CODEOWNERS to remove unify

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,2 @@
-* @snyk/open-source_unify @snyk/open-source_open-source-leadership @snyk/open-source_composition-analysis
+* @snyk/open-source_open-source-leadership @snyk/open-source_composition-analysis @snyk/open-source_analysis-platform @snyk/open-source_fix-analysis
 
-/pkg/ecosystems/ @snyk/open-source_composition-analysis
-/pkg/ecosystems/python/uv/ @snyk/open-source_unify @snyk/open-source_open-source-leadership @snyk/open-source_composition-analysis
-/pkg/depgraph @snyk/open-source_unify @snyk/open-source_open-source-leadership
-/pkg/sca_plugin @snyk/open-source_unify @snyk/open-source_open-source-leadership


### PR DESCRIPTION
Updates CODEOWNERS to remove unify. Includes all (former) teams currently under sca_scanners -- pending new github teams
