### PR TITLE
chore: transfer ownership to @snyk/engines_sca-scanners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
-* @snyk/open-source_open-source-leadership @snyk/engines_sca-scanners @snyk/open-source_analysis-platform @snyk/open-source_fix-analysis
-
+* @snyk/engines_sca-scanners @snyk/open-source_analysis-platform @snyk/open-source_fix-analysis

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-* @snyk/open-source_open-source-leadership @snyk/open-source_composition-analysis @snyk/open-source_analysis-platform @snyk/open-source_fix-analysis
+* @snyk/open-source_open-source-leadership @snyk/engines_sca-scanners @snyk/open-source_analysis-platform @snyk/open-source_fix-analysis
 


### PR DESCRIPTION
### What?

- `.github/CODEOWNERS`: `@snyk/open-source_composition-analysis` moves to `@snyk/engines_sca-scanners`; also dropped `@snyk/open-source_open-source-leadership` as a co-owner per team feedback (other co-owners unchanged).

### Why?

`@snyk/engines_sca-scanners` now owns this repo, so review requests should land with them rather than the previous team.

---

> [!NOTE]
> **Low Risk**
> Metadata-only ownership update; no runtime or behavior changes.